### PR TITLE
Bug fixes

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -529,6 +529,11 @@ static void thread_cleanup (MonoThread *thread)
 	thread->abort_exc = NULL;
 	thread->current_appcontext = NULL;
 
+	/* if the thread is not in the hash it has been removed already */
+	if (!handle_remove (thread))
+		return;
+
+	EnterCriticalSection (thread->synch_cs);
 	/*
 	 * This is necessary because otherwise we might have
 	 * cross-domain references which will not get cleaned up when
@@ -538,11 +543,12 @@ static void thread_cleanup (MonoThread *thread)
 		int i;
 		for (i = 0; i < NUM_CACHED_CULTURES * 2; ++i)
 			mono_array_set (thread->cached_culture_info, MonoObject*, i, NULL);
+
+		thread->cached_culture_info = NULL;
 	}
 
-	/* if the thread is not in the hash it has been removed already */
-	if (!handle_remove (thread))
-		return;
+	LeaveCriticalSection (thread->synch_cs);
+
 	mono_release_type_locks (thread);
 
 	EnterCriticalSection (thread->synch_cs);
@@ -564,8 +570,6 @@ static void thread_cleanup (MonoThread *thread)
 		g_free (thread->serialized_ui_culture_info);
 
 	g_free (thread->name);
-
-	thread->cached_culture_info = NULL;
 
 	mono_gc_free_fixed (thread->static_data);
 	thread->static_data = NULL;


### PR DESCRIPTION
425166: Refreshing Chrome tab causes WebPlayer plugin crash.
https://fogbugz.unity3d.com/default.asp?425166#1065910357

Mono was in an infinite loop sleeping a thread waiting for shutdown. We unloaded the mono dll but didn't exit the process. Windows then segfaulted since it was executing code in memory that had been unmapped.

390013: Editor crashed after editing and saving script DepthSounderTest.js
https://fogbugz.unity3d.com/default.asp?390013#1065911390

Added locks to synchronize access. Hopefully this fixes the issue.
