### PR TITLE
SEH fallback

### DIFF
--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -78,6 +78,7 @@ mono_runtime_cleanup_handlers (void)
  * should be the same as for a signal handler. Returns TRUE if the original handler
  * was called, false otherwise.
  */
+int (*gUnhandledExceptionHandler)(EXCEPTION_POINTERS*);
 gboolean
 SIG_HANDLER_SIGNATURE (mono_chain_signal)
 {
@@ -87,6 +88,12 @@ SIG_HANDLER_SIGNATURE (mono_chain_signal)
 	if (old_win32_toplevel_exception_filter) {
 		win32_chained_exception_filter_didrun = TRUE;
 		win32_chained_exception_filter_result = (*old_win32_toplevel_exception_filter)(info);
+		return TRUE;
+	}
+	if (gUnhandledExceptionHandler)
+	{
+		win32_chained_exception_filter_didrun = TRUE;
+		win32_chained_exception_filter_result = (*gUnhandledExceptionHandler)(info);
 		return TRUE;
 	}
 	return FALSE;

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -32,6 +32,9 @@ mono_unity_socket_security_enabled_set
 mono_set_ignore_version_and_key_when_finding_assemblies_already_loaded
 mono_class_is_generic
 mono_class_is_inflated
+mono_unity_seh_handler
+mono_unity_set_unhandled_exception_handler
+
 ;Exports that should have been here, but I dont understand why they're not.
 mono_security_enable_core_clr
 mono_security_set_mode

--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -62,6 +62,19 @@ FILE* unity_fopen( const char *name, const char *mode )
 	return _wfopen( wideName, wideMode );
 }
 
+LONG CALLBACK seh_handler(EXCEPTION_POINTERS* ep);
+LONG mono_unity_seh_handler(EXCEPTION_POINTERS* ep)
+{
+	return seh_handler(ep);
+}
+
+int (*gUnhandledExceptionHandler)(EXCEPTION_POINTERS*) = NULL;
+
+void mono_unity_set_unhandled_exception_handler(void* handler)
+{
+	gUnhandledExceptionHandler = handler;
+}
+
 #endif //Win32
 
 GString* gEmbeddingHostName = 0;


### PR DESCRIPTION
Explicitly call a handler for unhandled exceptions. Needed when top-level exception handler are not allowed like in certain browsers.
