### PR TITLE
buildsystem: update build process for 10.8

### DIFF
--- a/build_classlibs_osx.pl
+++ b/build_classlibs_osx.pl
@@ -61,11 +61,9 @@ if (-d $libmono)
 
 if (not $skipbuild)
 {
-	#we need to manually set the compiler to gcc4, because the 10.4 sdk only shipped with the gcc4 headers
-        #their setup is a bit broken as they dont autodetect this, but basically the gist is if you want to copmile
-        #against the 10.4 sdk, you better use gcc4, otherwise things go boink.
-        $ENV{CC} = "gcc-4.0";
-        $ENV{CXX} = "gcc-4.0";
+	$ENV{CFLAGS}  = "$ENV{CFLAGS} -arch i386";
+	$ENV{CXXFLAGS}  = "$ENV{CXXFLAGS} -arch i386";
+	$ENV{LDFLAGS}  = "$ENV{LDFLAGS} -arch i386";
 
 	if ($cleanbuild)
 	{
@@ -86,7 +84,7 @@ if (not $skipbuild)
 		print(">>>Calling autoreconf in mono\n");
 		system("autoreconf -i") eq 0 or die("failed to autoreconf mono");
 		print(">>>Calling configure in mono\n");
-		system("./configure","--prefix=$monoprefix","--with-monotouch=$withMonotouch","-with-unity=$withUnity", "--with-glib=embedded","--with-mcs-docs=no","--with-macversion=10.4", "--disable-nls") eq 0 or die ("failing autogenning mono");
+		system("./configure","--prefix=$monoprefix","--with-monotouch=$withMonotouch","-with-unity=$withUnity", "--with-glib=embedded","--with-mcs-docs=no","--with-macversion=10.5", "--disable-nls") eq 0 or die ("failing autogenning mono");
 		print("calling make clean in mono\n");
 		system("make","clean") eq 0 or die ("failed to make clean");
 	}

--- a/build_runtime_osx.pl
+++ b/build_runtime_osx.pl
@@ -44,8 +44,8 @@ for my $arch (@arches)
 {
 	print "Building for architecture: $arch\n";
 
-	my $macversion = '10.4';
-	my $sdkversion = '10.4u';
+	my $macversion = '10.5';
+	my $sdkversion = '10.5';
 	if ($arch eq 'x86_64') {
 		$macversion = '10.6';
 		$sdkversion = '10.6';
@@ -68,21 +68,6 @@ for my $arch (@arches)
 
 	if (not $skipbuild)
 	{
-		#rmtree($bintarget);
-		#rmtree($libtarget);
-
-		#we need to manually set the compiler to gcc4, because the 10.4 sdk only shipped with the gcc4 headers
-		#their setup is a bit broken as they dont autodetect this, but basically the gist is if you want to copmile
-		#against the 10.4 sdk, you better use gcc4, otherwise things go boink.
-		unless ($ENV{CC})
-		{
-			$ENV{CC} = "gcc-4.0";
-		}
-		unless ($ENV{CXX})
-		{
-			$ENV{CXX} = "gcc-4.0";
-		}
-
 		if ($debug)
 		{
 			$ENV{CFLAGS} = "-arch $arch -g -O0 -D_XOPEN_SOURCE=1 -DMONO_DISABLE_SHM=1 -DDISABLE_SHARED_HANDLES=1";


### PR DESCRIPTION
This includes build script changes needed to make the classlibs and runtime build on 10.8.  I verified via TC that these scripts are backwards-compatible to 10.6.
