### PR TITLE
Revert "Sign unityscript assemblies when building from classlibs build s...

### DIFF
--- a/build_classlibs_osx.pl
+++ b/build_classlibs_osx.pl
@@ -209,7 +209,7 @@ sub UnityBooc
 {
 	my $commandLine = shift;
 	
-	system("$monoprefixUnity/booc -debug- -keyfile:$booCheckout/src/boo.snk $commandLine") eq 0 or die("booc failed to execute: $commandLine");
+	system("$monoprefixUnity/booc -debug- $commandLine") eq 0 or die("booc failed to execute: $commandLine");
 }
 
 sub BuildUnityScriptForUnity


### PR DESCRIPTION
...cript."

This reverts commit 7505810b3b3785e2cd5db03ba509489f77345aac.

Fixes breaking changes to JS asset packages due to signing.
