### PR TITLE
[QNX] socket accept gets interrupted by real-time signals.  Loop over ac...

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1015,7 +1015,13 @@ transport_handshake (void)
 static int
 transport_accept (int socket_fd)
 {
+#ifdef __QNXNTO__
+	do {
+		conn_fd = accept (socket_fd, NULL, NULL);
+	} while( conn_fd == -1 && errno == EINTR );
+#else
 	conn_fd = accept (socket_fd, NULL, NULL);
+#endif
 	if (conn_fd == -1) {
 		fprintf (stderr, "debugger-agent: Unable to listen on %d\n", socket_fd);
 	} else {


### PR DESCRIPTION
...cept function if failure cause was a signal interrupt
