### PR TITLE
Don't assert when trying to re-expand a template. See case #542749

### DIFF
--- a/mono/metadata/generic-sharing.c
+++ b/mono/metadata/generic-sharing.c
@@ -399,7 +399,11 @@ rgctx_template_set_other_slot (MonoImage *image, MonoRuntimeGenericContextTempla
 		++i;
 	}
 
-	g_assert (!(*oti)->data);
+	// see fogbugz case #542749
+	if ((*oti)->data)
+		return;
+	//g_assert (!(*oti)->data);
+
 	(*oti)->data = data;
 	(*oti)->info_type = info_type;
 


### PR DESCRIPTION
In some very specific situation where there's classes that inherit
from a generic base class like:

BaseClass<T> : MonoBehaviour where T : BaseClass<T>
AClass : BaseClass<AClass>

the compiler tries to expand the templates twice. _boggle_
