### PR TITLE
Fix MonoImage refcount leak that causes images to not be released

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1098,6 +1098,7 @@ mono_image_open_from_data_with_name (char *data, guint32 data_len, gboolean need
 	iinfo = g_new0 (MonoCLIImageInfo, 1);
 	image->image_info = iinfo;
 	image->ref_only = refonly;
+	image->ref_count = 1;
 
 	image = do_mono_image_load (image, status, TRUE, TRUE);
 	if (image == NULL)


### PR DESCRIPTION
on domain unload which causes new domains to reuse old assemblies referenced
by a leaky image, causing all kinds of funky behaviour. Callers should
call mono_image_close after calling mono_assembly_load\* to ensure things
don't leak.
