### PR TITLE
Make sure long paths are used always

### DIFF
--- a/build_unityscript_bareminimum_win.pl
+++ b/build_unityscript_bareminimum_win.pl
@@ -42,7 +42,7 @@ sub AddDotNetFolderToPath() {
 
 AddDotNetFolderToPath();
 
-my $output = NormalizePath(Win32::GetLongPathName("$ENV{TEMP}/output/BareMinimum"));
+my $output = Win32::GetLongPathName("$ENV{TEMP}/output/BareMinimum");
 
 print("\nEnvironment Path: $ENV{PATH}\n");
 


### PR DESCRIPTION
booc has issues is launched from directory with long names and is passed a references to the short named version of assemblies.
