### PR TITLE
for some weird reason calling  GetLongPath() with the full path returns an empty string on build slaves - but works on my machine (tm).

### DIFF
--- a/build_unityscript_bareminimum_win.pl
+++ b/build_unityscript_bareminimum_win.pl
@@ -42,7 +42,7 @@ sub AddDotNetFolderToPath() {
 
 AddDotNetFolderToPath();
 
-my $output = Win32::GetLongPathName("$ENV{TEMP}/output/BareMinimum");
+my $output = Win32::GetLongPathName("$ENV{TEMP}") . "/output/BareMinimum";
 
 print("\nEnvironment Path: $ENV{PATH}\n");
 


### PR DESCRIPTION
maybe some issue with slashes.

Tested on Katana and worked (branch unity-staging).
