### PR TITLE
Use constrained virtual method call for value-typed instances instead of boxing

### DIFF
--- a/mcs/mcs/expression.cs
+++ b/mcs/mcs/expression.cs
@@ -5123,12 +5123,22 @@ namespace Mono.CSharp {
 							if (dup_args)
 								t = TypeManager.GetReferenceType (iexpr_type);
 						} else {
-							instance_expr.Emit (ec);
+
+#if GMCS_SOURCE
+							if(instance_expr is IMemoryLocation)
+							{
+								((IMemoryLocation)instance_expr).AddressOf(ec, AddressOp.LoadStore);
+								if(dup_args)
+									t = TypeManager.GetReferenceType(iexpr_type);
+							}
+							else
+#endif
+							{
+								instance_expr.Emit (ec);
 							
-							// FIXME: should use instance_expr is IMemoryLocation + constraint.
-							// to help JIT to produce better code
-							ig.Emit (OpCodes.Box, instance_expr.Type);
-							t = TypeManager.object_type;
+								ig.Emit (OpCodes.Box, instance_expr.Type);
+								t = TypeManager.object_type;
+							}
 						}
 					} else {
 						instance_expr.Emit (ec);
@@ -5155,7 +5165,7 @@ namespace Mono.CSharp {
 				call_op = OpCodes.Callvirt;
 				
 #if GMCS_SOURCE
-				if ((instance_expr != null) && (instance_expr.Type.IsGenericParameter))
+				if ((instance_expr != null) && (instance_expr.Type.IsGenericParameter || (TypeManager.IsValueType(instance_expr.Type) && instance_expr is IMemoryLocation)))
 					ig.Emit (OpCodes.Constrained, instance_expr.Type);
 #endif
 			}


### PR DESCRIPTION
Aimed at fixing bug #594320. The idea is to use a constrained virtual call if possible, instead of a boxed reference - this was new in CLR 2.0 (which is why it was never done in the first place I guess).

Initial testing suggests that this works fine - it gets rid of the 24 byte allocation produced by foreach() loops over collections - but I've not been able to get the MCS test suite running smoothly so I'm not sure that it's entirely safe. It seems like a few more tests fail with the change than without but I can't get stable results switching back and forth. Hopefully your test suite setup is more reliable and you can verify that it doesn't break things…

(looks like I based my commit on unity-trunk and then submitted the request against unity-staging. Sorry about that.)
