### PR TITLE
change the way MAC address retrieval is performed on OS X

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/MacOsNetworkInterfaceMarshal.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/MacOsNetworkInterfaceMarshal.cs
@@ -55,8 +55,10 @@ namespace System.Net.NetworkInformation {
 			public byte   sdl_alen;
 			public byte   sdl_slen;
 
-			[MarshalAs (UnmanagedType.ByValArray, SizeConst=12)]
-			public byte[] sdl_data;
+			// In the sockaddr_dl definition sdl_data is given as size 12, but this
+			// is the MINIMUM size - it may be longer if it needs to be. We can't
+			// marshal variable-length buffers automatically.
+			// public byte[] sdl_data;
 		}
 
 	}

--- a/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
@@ -480,7 +480,7 @@ namespace System.Net.NetworkInformation {
 							MacOsStructs.sockaddr_dl sockaddrdl = (MacOsStructs.sockaddr_dl) Marshal.PtrToStructure (addr.ifa_addr, typeof (MacOsStructs.sockaddr_dl));
 
 							macAddress = new byte [(int) sockaddrdl.sdl_alen];
-							Array.Copy (sockaddrdl.sdl_data, sockaddrdl.sdl_nlen, macAddress, 0, macAddress.Length);
+							Marshal.Copy(new IntPtr(addr.ifa_addr.ToInt64() + 8 + sockaddrdl.sdl_nlen), macAddress, 0, macAddress.Length);
 							index = sockaddrdl.sdl_index;
 
 							int hwtype = (int) sockaddrdl.sdl_type;


### PR DESCRIPTION
Fix for bug #587067:

The sockaddr_dl structure's tail buffer contains both the interface name and the MAC address. This structure was being marshalled as if the buffer was always 12 bytes long - allowing 6 bytes for the interface name and 6 for the MAC address - but in truth the buffer is variable-length, to allow for interface names longer than 6 bytes. Variable-length buffers can't be directly marshalled so we change the MAC address retrieval to use Marshal.Copy with pointer arithmetic instead.
