### PR TITLE
Windows Registry: fixed a security issue

### DIFF
--- a/mcs/class/corlib/Microsoft.Win32/Registry.cs
+++ b/mcs/class/corlib/Microsoft.Win32/Registry.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Win32
 			}
 
 			for (int i = 1; i < keys.Length; i++){
-				RegistryKey nkey = key.OpenSubKey (keys [i], true);
+				RegistryKey nkey = key.OpenSubKey (keys [i], setting);
 				if (nkey == null){
 					if (!setting)
 						return null;


### PR DESCRIPTION
Windows Registry: fixed the issue when Microsoft.Win32.Registry.GetValue() required write permissions (cases 595950, 602822)
