### PR TITLE
fix the arm mono_arch_instrument_epilog_full

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1917,8 +1917,10 @@ mono_arch_instrument_epilog_full (MonoCompile *cfg, void *func, void *p, gboolea
 		save_mode = SAVE_TWO;
 		break;
 	case MONO_TYPE_R4:
+		save_mode = SAVE_ONE;
+		break;
 	case MONO_TYPE_R8:
-		save_mode = SAVE_FP;
+		save_mode = SAVE_TWO;
 		break;
 	case MONO_TYPE_VALUETYPE:
 		save_mode = SAVE_STRUCT;
@@ -1930,23 +1932,16 @@ mono_arch_instrument_epilog_full (MonoCompile *cfg, void *func, void *p, gboolea
 
 	switch (save_mode) {
 	case SAVE_TWO:
-		ARM_STR_IMM (code, ARMREG_R0, cfg->frame_reg, save_offset);
-		ARM_STR_IMM (code, ARMREG_R1, cfg->frame_reg, save_offset + 4);
+		ARM_PUSH (code, ((1 << ARMREG_R0 | (1 << ARMREG_R1))));
 		if (enable_arguments) {
 			ARM_MOV_REG_REG (code, ARMREG_R2, ARMREG_R1);
 			ARM_MOV_REG_REG (code, ARMREG_R1, ARMREG_R0);
 		}
 		break;
 	case SAVE_ONE:
-		ARM_STR_IMM (code, ARMREG_R0, cfg->frame_reg, save_offset);
+		ARM_PUSH (code, (1 << ARMREG_R0));
 		if (enable_arguments) {
 			ARM_MOV_REG_REG (code, ARMREG_R1, ARMREG_R0);
-		}
-		break;
-	case SAVE_FP:
-		/* FIXME: what reg?  */
-		if (enable_arguments) {
-			/* FIXME: what reg?  */
 		}
 		break;
 	case SAVE_STRUCT:
@@ -1966,14 +1961,10 @@ mono_arch_instrument_epilog_full (MonoCompile *cfg, void *func, void *p, gboolea
 
 	switch (save_mode) {
 	case SAVE_TWO:
-		ARM_LDR_IMM (code, ARMREG_R0, cfg->frame_reg, save_offset);
-		ARM_LDR_IMM (code, ARMREG_R1, cfg->frame_reg, save_offset + 4);
+		ARM_POP (code, ((1 << ARMREG_R0 | (1 << ARMREG_R1))));
 		break;
 	case SAVE_ONE:
-		ARM_LDR_IMM (code, ARMREG_R0, cfg->frame_reg, save_offset);
-		break;
-	case SAVE_FP:
-		/* FIXME */
+		ARM_POP (code, (1 << ARMREG_R0 ));
 		break;
 	case SAVE_NONE:
 	default:


### PR DESCRIPTION
when turn on the profiler of MONO_PROFILE_ENTER_LEAVE in arm(android),  mono_arch_instrument_epilog_full will crash.

because the reg r0 and r1 maybe lose.

the jited code from mscorlib : Hashtable.ctor
```
debug113:7625AF10 MOV             R12, SP
debug113:7625AF14 STMFD           SP!, {R6-R8,R11,R12,LR}
debug113:7625AF18 MOV             R11, SP
debug113:7625AF1C MOV             R7, R0
debug113:7625AF20 MOV             R0, #0x764947F8
debug113:7625AF28 MOV             R1, #0
debug113:7625AF2C MOV             R2, #0x741C9988
debug113:7625AF34 BLX             R2 ; mono_profiler_method_enter
debug113:7625AF38 MOV             R6, #0
debug113:7625AF3C B               loc_7625AFA8
debug113:7625AF40 ; ---------------------------------------------------------------------------
debug113:7625AF40
debug113:7625AF40 loc_7625AF40
debug113:7625AF40 MOV             R0, #0x762BEE40
debug113:7625AF48 LDR             R0, [R0,#(dword_762BEE4C - 0x762BEE40)]
debug113:7625AF4C CMP             R0, R6
debug113:7625AF50 BLLS            unk_7625AFE8
debug113:7625AF54 MOV             R0, R6,LSL#2
debug113:7625AF58 MOV             R1, #0x762BEE40
debug113:7625AF60 ADD             R0, R0, R1
debug113:7625AF64 ADD             R0, R0, #0x10
debug113:7625AF68 LDR             R0, [R0]
debug113:7625AF6C CMP             R7, R0
debug113:7625AF70 BGT             loc_7625AFA4
debug113:7625AF74 MOV             R0, #0x762BEE40
debug113:7625AF7C LDR             R0, [R0,#(dword_762BEE4C - 0x762BEE40)]
debug113:7625AF80 CMP             R0, R6
debug113:7625AF84 BLLS            unk_7625AFE8
debug113:7625AF88 MOV             R0, R6,LSL#2
debug113:7625AF8C MOV             R1, #0x762BEE40
debug113:7625AF94 ADD             R0, R0, R1
debug113:7625AF98 ADD             R0, R0, #0x10
debug113:7625AF9C LDR             R0, [R0]
debug113:7625AFA0 B               loc_7625AFC4
debug113:7625AFA4 ; ---------------------------------------------------------------------------
debug113:7625AFA4
debug113:7625AFA4 loc_7625AFA4                            
debug113:7625AFA4 ADD             R6, R6, #1
debug113:7625AFA8
debug113:7625AFA8 loc_7625AFA8                            
debug113:7625AFA8 MOV             R0, #0x762BEE40
debug113:7625AFB0 LDR             R0, [R0,#(dword_762BEE4C - 0x762BEE40)]
debug113:7625AFB4 CMP             R6, R0
debug113:7625AFB8 BLT             loc_7625AF40
debug113:7625AFBC MOV             R0, R7
debug113:7625AFC0 BL              unk_7625AFF8
debug113:7625AFC4
debug113:7625AFC4 loc_7625AFC4                            
debug113:7625AFC4 STR             R0, [R11]		<<<------------------the r6 is losed! look the debug113:7625AF14
debug113:7625AFC8 MOV             R0, #0x764947F8
debug113:7625AFD0 MOV             R12, #0x741C9A10
debug113:7625AFD8 BLX             R12 ; mono_profiler_method_leave
debug113:7625AFDC LDR             R0, [R11]
debug113:7625AFE0 MOV             SP, R11
debug113:7625AFE4 LDMFD           SP, {R6-R8,R11,SP,PC}
debug113:7625AFE4 ; ---------------------------------------------------------------------------
```

so, I used the ARM_PUSH and ARM_POP instead of ARM_STR_IMM.

and 
```
1908	 case MONO_TYPE_VOID:
1909		/* special case string .ctor icall */
1910		if (strcmp (".ctor", method->name) && method->klass == mono_defaults.string_class)
1911			save_mode = SAVE_ONE;
1912		else
1913			save_mode = SAVE_NONE;
1914		break;
```
I'm not sure if it is:
```
1908	 case MONO_TYPE_VOID:
1909		/* special case string .ctor icall */
1910		if (strcmp (".ctor", method->name) == 0 && method->klass == mono_defaults.string_class)
1911			save_mode = SAVE_ONE;
1912		else
1913			save_mode = SAVE_NONE;
1914		break;
```