### PR TITLE
Cherry pick Windows Registry fix (fixes issues with the Editor when run under restricted account)

### DIFF
--- a/mcs/class/corlib/Microsoft.Win32/Registry.cs
+++ b/mcs/class/corlib/Microsoft.Win32/Registry.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Win32
 			}
 
 			for (int i = 1; i < keys.Length; i++){
-				RegistryKey nkey = key.OpenSubKey (keys [i], true);
+				RegistryKey nkey = key.OpenSubKey (keys [i], setting);
 				if (nkey == null){
 					if (!setting)
 						return null;


### PR DESCRIPTION
Windows Registry: fixed the issue when Microsoft.Win32.Registry.GetValue() required write permissions

(cherry picked from commit 70fe346baf38269177067e9035dbfd07e02b89c7)
