### PR TITLE
Update X509Certificate.cs

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/X509Certificate.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X509Certificate.cs
@@ -306,6 +306,9 @@ namespace Mono.Security.X509 {
 						case "1.2.840.10040.4.3":	// SHA1-1 with DSA
 							hash = SHA1.Create ();
 							break;
+						case "1.2.840.113549.1.1.11": //SHA 256 Fix for "Unsupported hash for SSL certificate" bug
+							hash = SHA256.Create ();
+							break;
 						default:
 							return null;
 					}
@@ -404,6 +407,7 @@ namespace Mono.Security.X509 {
 					case "1.2.840.113549.1.1.4":	// MD5 with RSA encryption 
 					case "1.2.840.113549.1.1.5":	// SHA-1 with RSA Encryption 
 					case "1.3.14.3.2.29":		// SHA1 with RSA signature
+					case "1.2.840.113549.1.1.11":
 						return (byte[]) signature.Clone ();
 
 					case "1.2.840.10040.4.3":	// SHA-1 with DSA
@@ -510,6 +514,9 @@ namespace Mono.Security.X509 {
 				case "1.2.840.113549.1.1.5":
 				case "1.3.14.3.2.29":
 					v.SetHashAlgorithm ("SHA1");
+					break;
+				case "1.2.840.113549.1.1.11":
+					v.SetHashAlgorithm ("SHA256");
 					break;
 				default:
 					throw new CryptographicException ("Unsupported hash algorithm: " + m_signaturealgo);


### PR DESCRIPTION
SHA 256 Fix for "Unsupported hash for SSL certificate" bug
http://fogbugz.unity3d.com/default.asp?602783_4ddsl9l014uuvquo

No idea if this is the right branch, or even if you accept pull requests.

I haven't tested it, but I assume it works.  It's based off a patch from here https://bugzilla.xamarin.com/show_bug.cgi?id=8788
