### PR TITLE
Ios/fix aot class leak

### DIFF
--- a/mono/mini/ChangeLog
+++ b/mono/mini/ChangeLog
@@ -1,3 +1,7 @@
+2010-04-28  Zoltan Varga  <vargaz@gmail.com>
+
+	* aot-compiler.c (emit_got_info): Double the buffer size to avoid an assert.
+
 2009-11-26  Zoltan Varga  <vargaz@gmail.com>
 
 	* mini.h (MonoDebugOptions): Add 'explicit_null_checks' option.

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -5143,7 +5143,7 @@ emit_got_info (MonoAotCompile *acfg)
 	 */
 
 	/* Encode info required to decode shared GOT entries */
-	buf_size = acfg->got_patches->len * 64;
+	buf_size = acfg->got_patches->len * 128;
 	p = buf = mono_mempool_alloc (acfg->mempool, buf_size);
 	got_info_offsets = mono_mempool_alloc (acfg->mempool, acfg->got_patches->len * sizeof (guint32));
 	acfg->plt_got_info_offsets = mono_mempool_alloc (acfg->mempool, acfg->plt_offset * sizeof (guint32));


### PR DESCRIPTION
Fixes klass instance leak while doing AOT on bigger codebase with lots generics + value types.
Fixes out of buffer space while encoding GOT entries.
