### PR TITLE
Fix System.Object method invocation on value types to be constrained

### DIFF
--- a/mcs/mcs/expression.cs
+++ b/mcs/mcs/expression.cs
@@ -5158,8 +5158,17 @@ namespace Mono.CSharp {
 			if (!omit_args && Arguments != null)
 				Arguments.Emit (ec, dup_args, this_arg);
 
+			/* Note from MSDN:
+			 * "When calling methods of System.Object on value types, consider using the constrained prefix 
+			 *  with the callvirt instruction instead of emitting a call instruction. This removes the need 
+			 *  to emit different IL depending on whether or not the value type overrides the method, 
+			 *  avoiding a potential versioning problem."
+			 * Value types can't derive from other value types so System.Object should be the /only/ thing
+			 * we need to check for in this way. */
+			bool isSystemObjectMethod = (decl_type == TypeManager.object_type);
+
 			OpCode call_op;
-			if (is_static || struct_call || is_base || (this_call && !method.IsVirtual)) {
+			if (is_static || struct_call || ((is_base || (this_call && !method.IsVirtual)) && !(TypeManager.IsValueType(instance_expr.Type) && isSystemObjectMethod))) {
 				call_op = OpCodes.Call;
 			} else {
 				call_op = OpCodes.Callvirt;


### PR DESCRIPTION
This fixes the IL generation around System.Object calls via 'this' and 'base' references in value types, which previously fell through the middle (didn't box but didn't constrain either), generating invalid IL and choking IL2CPP. Now both cases are correctly generated as constrained virtual calls, as per MSDN recommendation.
