### PR TITLE
Add mono_method_is_inflated and mono_method_is_generic and expose them f...

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2371,15 +2371,3 @@ mono_method_get_index (MonoMethod *method) {
 	}
 	return 0;
 }
-
-gboolean
-mono_method_is_inflated (MonoMethod* method)
-{
-	return method->is_inflated;
-}
-
-gboolean
-mono_method_is_generic (MonoMethod* method)
-{
-	return method->is_generic;
-}

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -87,12 +87,6 @@ mono_stack_walk         (MonoStackWalk func, gpointer user_data);
 void
 mono_stack_walk_no_il   (MonoStackWalk func, gpointer user_data);
 
-gboolean
-mono_method_is_inflated (MonoMethod* method);
-
-gboolean
-mono_method_is_generic (MonoMethod* method);
-
 G_END_DECLS
 
 #endif

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -25,6 +25,8 @@ mono_loader_error_prepare_exception
 unity_mono_install_memory_callbacks
 unity_mono_redirect_output
 unity_mono_close_output
+unity_mono_method_is_inflated
+unity_mono_method_is_generic
 mono_unity_liveness_allocate_struct
 mono_unity_liveness_stop_gc_world
 mono_unity_liveness_finalize
@@ -592,8 +594,6 @@ mono_method_header_get_clauses
 mono_method_header_get_code
 mono_method_header_get_locals
 mono_method_header_get_num_clauses
-mono_method_is_generic
-mono_method_is_inflated
 mono_method_signature
 mono_method_verify
 mono_mlist_alloc

--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -186,3 +186,15 @@ unsigned mono_unity_get_all_classes_with_name_case (MonoImage *image, const char
 		*length_ref = length;
 	return length;
 }
+
+gboolean
+unity_mono_method_is_inflated (MonoMethod* method)
+{
+	return method->is_inflated;
+}
+
+gboolean
+unity_mono_method_is_generic (MonoMethod* method)
+{
+	return method->is_generic;
+}

--- a/unity/unity_utils.h
+++ b/unity/unity_utils.h
@@ -33,4 +33,10 @@ void mono_unity_set_vprintf_func(vprintf_func func);
 
 void unity_mono_install_memory_callbacks(MonoMemoryCallbacks* callbacks);
 
+gboolean
+unity_mono_method_is_inflated (MonoMethod* method);
+
+gboolean
+unity_mono_method_is_generic (MonoMethod* method);
+
 #endif


### PR DESCRIPTION
Expose mono_method_is_generic, mono_method_is_inflated, needed to filter in unity for uninflated generic methods.
