### PR TITLE
Make GetProcessesByName work.

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -894,10 +894,16 @@ namespace System.Diagnostics {
 			
 			for (int i = 0; i < procs.Length; i++) {
 				/* Ignore case */
-				if (String.Compare (processName,
-						    procs [i].ProcessName,
-						    true) == 0) {
-					proclist.Add (procs [i]);
+				try {
+					if (String.Compare (processName,
+							    procs [i].ProcessName,
+							    true) == 0) {
+						proclist.Add (procs [i]);
+					}
+				}
+				catch (Exception) { 
+					//do nothing, if the process is invalid then we probably 
+					//don't want it in the list.
 				}
 			}
 


### PR DESCRIPTION
When an exception is thrown (process already ended, etc) while
iterating through processes, exceptions can be thrown accessing the
process name. In these situations, the user wouldn’t want those invalid
processes anyway, so just catch the exception and move on.
