### PR TITLE
Managed thread id fix for 5.0

### DIFF
--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -142,8 +142,7 @@ namespace System.Threading {
 		private MulticastDelegate threadstart;
 		//private string thread_name=null;
 
-#if NET_2_0		
-		private static int _managed_id_counter;
+#if NET_2_0
 		private int managed_id;
 #endif		
 		
@@ -971,8 +970,13 @@ namespace System.Threading {
 #endif
 
 #if NET_2_0
+		private static int GetNewManagedId()
+		{
+			return GetNewManagedId_internal();
+		}
+
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern private static int GetNewManagedId();
+		extern private static int GetNewManagedId_internal();
 
 		public Thread (ThreadStart start, int maxStackSize)
 		{

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -853,7 +853,7 @@ ICALL(THREAD_5, "GetCachedCurrentCulture", ves_icall_System_Threading_Thread_Get
 ICALL(THREAD_6, "GetCachedCurrentUICulture", ves_icall_System_Threading_Thread_GetCachedCurrentUICulture)
 ICALL(THREAD_7, "GetDomainID", ves_icall_System_Threading_Thread_GetDomainID)
 ICALL(THREAD_8, "GetName_internal", ves_icall_System_Threading_Thread_GetName_internal)
-ICALL(THREAD_8a, "GetNewManagedId", ves_icall_System_Threading_Thread_GetNewManagedId)
+ICALL(THREAD_8a, "GetNewManagedId_internal", ves_icall_System_Threading_Thread_GetNewManagedId_internal)
 ICALL(THREAD_9, "GetSerializedCurrentCulture", ves_icall_System_Threading_Thread_GetSerializedCurrentCulture)
 ICALL(THREAD_10, "GetSerializedCurrentUICulture", ves_icall_System_Threading_Thread_GetSerializedCurrentUICulture)
 ICALL(THREAD_11, "GetState", ves_icall_System_Threading_Thread_GetState)

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -62,7 +62,7 @@ void ves_icall_System_Threading_Thread_Sleep_internal(int ms) MONO_INTERNAL;
 gboolean ves_icall_System_Threading_Thread_Join_internal(MonoThread *this_obj, int ms, HANDLE thread) MONO_INTERNAL;
 gint32 ves_icall_System_Threading_Thread_GetDomainID (void) MONO_INTERNAL;
 MonoString* ves_icall_System_Threading_Thread_GetName_internal (MonoThread *this_obj) MONO_INTERNAL;
-gint32 ves_icall_System_Threading_Thread_GetNewManagedId (void) MONO_INTERNAL;
+gint32 ves_icall_System_Threading_Thread_GetNewManagedId_internal (void) MONO_INTERNAL;
 void ves_icall_System_Threading_Thread_SetName_internal (MonoThread *this_obj, MonoString *name) MONO_INTERNAL;
 MonoObject* ves_icall_System_Threading_Thread_GetCachedCurrentCulture (MonoThread *this_obj) MONO_INTERNAL;
 MonoArray* ves_icall_System_Threading_Thread_GetSerializedCurrentCulture (MonoThread *this_obj) MONO_INTERNAL;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1258,7 +1258,7 @@ ves_icall_System_Threading_Thread_GetName_internal (MonoThread *this_obj)
 	return str;
 }
 
-gint32 ves_icall_System_Threading_Thread_GetNewManagedId()
+gint32 ves_icall_System_Threading_Thread_GetNewManagedId_internal()
 {
     return InterlockedIncrement(&next_managed_thread_id);
 }

--- a/tuning/TuningInput/Security/mscorlib.audit
+++ b/tuning/TuningInput/Security/mscorlib.audit
@@ -2011,6 +2011,7 @@ System.Void System.Threading.Thread::Interrupt()
 System.AppDomain System.Threading.Thread::GetDomain()
 System.Boolean System.Threading.Thread::Join(System.TimeSpan)
 System.Threading.ExecutionContext System.Threading.Thread::get_ExecutionContext()
+System.Int32 System.Threading.Thread::GetNewManagedId()
 
 System.Boolean System.Threading.ThreadPool::SetMaxThreads(System.Int32,System.Int32)
 System.Boolean System.Threading.ThreadPool::SetMinThreads(System.Int32,System.Int32)


### PR DESCRIPTION
Graft of the 'managed thread ID fix' to unity-staging branch for 5.0. 

ACompleteBuild on Katana is green (#337).
