### PR TITLE
[corlib] Fix issue with setting Console.InputEncoding/OutputEncoding throwing an exception on Unity .NET profile.

### DIFF
--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -79,7 +79,7 @@ namespace System
 
 		static Console ()
 		{
-#if !NET2_API || NET_2_1
+#if !NET2_API || NET_2_1 && !UNITY
 			Encoding inputEncoding;
 			Encoding outputEncoding;
 #endif


### PR DESCRIPTION
Added UNITY to #if to match the #if used to guard Console.Input/OutputEncoding properties.
