### PR TITLE
intptr_t is an optional C99 type requiring include

### DIFF
--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -1,6 +1,8 @@
 #ifndef _MONO_CLI_OBJECT_H_
 #define _MONO_CLI_OBJECT_H_
 
+#include <stdint.h>
+
 #include <mono/metadata/class.h>
 
 G_BEGIN_DECLS


### PR DESCRIPTION
Without this, it is not possible to compile with gcc 4.9.1 on debian jessie.