### PR TITLE
Workaround the isinst bug again

### DIFF
--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -79,7 +79,7 @@ namespace System
 
 		static Console ()
 		{
-#if !NET2_API || NET_2_1
+#if !NET2_API || NET_2_1 && !UNITY
 			Encoding inputEncoding;
 			Encoding outputEncoding;
 #endif

--- a/mcs/class/corlib/System/Enum.cs
+++ b/mcs/class/corlib/System/Enum.cs
@@ -402,37 +402,37 @@ namespace System
 		//
 		static int FindPosition (object value, Array values)
 		{
-			int[] int_array = values as int[];
-			if (int_array != null)
-				return Array.BinarySearch (int_array, (int)value, MonoEnumInfo.int_comparer);
-
 			uint[] uint_array = values as uint [];
 			if (uint_array != null)
 				return Array.BinarySearch (uint_array, (uint)value);
+
+			int[] int_array = values as int[];
+			if (int_array != null)
+				return Array.BinarySearch (int_array, (int)value, MonoEnumInfo.int_comparer);
 			
+			ushort [] ushort_array = values as ushort [];
+			if (ushort_array != null)
+				return Array.BinarySearch (ushort_array, (ushort)value);
+
 			short [] short_array = values as short [];
 			if (short_array != null)
 				return Array.BinarySearch (short_array, (short)value, MonoEnumInfo.short_comparer);
 
-			ushort [] ushort_array = values as ushort [];
-			if (ushort_array != null)
-				return Array.BinarySearch (ushort_array, (ushort)value);
-					
-			sbyte [] sbyte_array = values as sbyte [];
-			if (sbyte_array != null)
-				return Array.BinarySearch (sbyte_array, (sbyte) value,  MonoEnumInfo.sbyte_comparer);
-			
 			byte [] byte_array = values as byte [];
 			if (byte_array != null)
 				return Array.BinarySearch (byte_array, (byte) value);
-			
-			long [] long_array = values as long [];
-			if (long_array != null)
-				return Array.BinarySearch (long_array, (long) value,  MonoEnumInfo.long_comparer);
+
+			sbyte [] sbyte_array = values as sbyte [];
+			if (sbyte_array != null)
+				return Array.BinarySearch (sbyte_array, (sbyte) value,  MonoEnumInfo.sbyte_comparer);
 
 			ulong [] ulong_array = values as ulong [];
 			if (ulong_array != null)
 				return Array.BinarySearch (ulong_array, (ulong) value);
+			
+			long [] long_array = values as long [];
+			if (long_array != null)
+				return Array.BinarySearch (long_array, (long) value,  MonoEnumInfo.long_comparer);
 
 			// This should never happen
 			return Array.BinarySearch (values, value);

--- a/mcs/class/corlib/System/Enum.cs
+++ b/mcs/class/corlib/System/Enum.cs
@@ -200,14 +200,20 @@ namespace System
 			get_enum_info (enumType, out info);
 
 			IComparer ic = null;
-			if (info.values is int [])
-				ic = int_comparer;
-			else if (info.values is short [])
-				ic = short_comparer;
-			else if (info.values is sbyte [])
-				ic = sbyte_comparer;
-			else if (info.values is long [])
-				ic = long_comparer;
+			if (!(info.values is byte[]) &&
+				!(info.values is ushort[]) &&
+				!(info.values is uint[]) &&
+				!(info.values is ulong[]))
+			{
+				if (info.values is int [])
+					ic = int_comparer;
+				else if (info.values is short [])
+					ic = short_comparer;
+				else if (info.values is sbyte [])
+					ic = sbyte_comparer;
+				else if (info.values is long [])
+					ic = long_comparer;
+			}
 			
 			Array.Sort (info.values, info.names, ic);
 			if (info.names.Length > 50) {


### PR DESCRIPTION
I'm not sure how I missed this the first time, but we have another odd bug related to System.Enum that occurs with the IL2CPP runtime. We need to compare the unisgned array types first, because of a Mono bug in the isinst opcode implementation.