### PR TITLE
Fix verification of constrained on enums

### DIFF
--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -3589,7 +3589,7 @@ do_invoke_method (VerifyContext *ctx, int method_token, gboolean virtual)
 		if (constrained && virtual) {
 			if (!stack_slot_is_managed_pointer (value))
 				CODE_NOT_VERIFIABLE (ctx, g_strdup_printf ("Object is not a managed pointer for a constrained call at 0x%04x", ctx->ip_offset));
-			if (!mono_metadata_type_equal_full (mono_type_get_type_byval (value->type), ctx->constrained_type, TRUE))
+			if (!mono_metadata_type_equal_full (mono_type_get_type_byval (value->type), mono_type_get_underlying_type (ctx->constrained_type), TRUE))
 				CODE_NOT_VERIFIABLE (ctx, g_strdup_printf ("Object not compatible with constrained type at 0x%04x", ctx->ip_offset));
 			copy.stype |= BOXED_MASK;
 		} else {


### PR DESCRIPTION
The following pattern triggered a VerificationException:

constrained. [Foo]Foo.Enum
callvirt     instance string [mscorlib]System.Object::ToString()

VS2015 compiled binaries are using that pattern while it previously used box+callvirt.