### PR TITLE
mono_method_get_index: return zero for constructed array methods as they...

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2355,6 +2355,10 @@ mono_method_get_index (MonoMethod *method) {
 	MonoClass *klass = method->klass;
 	int i;
 
+	if (klass->rank)
+		/* constructed array methods are not in the MethodDef table */
+		return 0;
+
 	if (method->token)
 		return mono_metadata_token_index (method->token);
 


### PR DESCRIPTION
... don't exist in the MethodDef table