### PR TITLE
Fix for Android crash caused by executing the wrong method

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -5262,7 +5262,7 @@ mono_arch_build_imt_thunk (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckI
 			ARM_CMP_REG_REG (code, ARMREG_R0, ARMREG_R1);
 
 			item->jmp_code = (guint8*)code;
-			ARM_B_COND (code, ARMCOND_GE, 0);
+			ARM_B_COND (code, ARMCOND_HS, 0);
 			++extra_space;
 		}
 	}

--- a/mono/utils/mono-membar.h
+++ b/mono/utils/mono-membar.h
@@ -129,7 +129,11 @@ static inline void mono_memory_write_barrier (void)
 #elif defined(__arm__)
 static inline void mono_memory_barrier (void)
 {
-	__asm__ __volatile__ ("" : : : "memory");
+#ifdef __GNUC__
+	__sync_synchronize();
+#else
+	__asm__ __volatile__ ("" : : : "memory"); /* just a compiler barrier */
+#endif
 }
 
 static inline void mono_memory_read_barrier (void)


### PR DESCRIPTION
Fix for case 655263 (signed compare was used to compare pointers).
mono_memory_barrier() was implemented as compiler barrier on ARM (this is still the case on some other platforms), now it's implemented using __sync_synchronize().