### PR TITLE
Debugger agent fix for trunk

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3039,6 +3039,9 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 		}
 	}
    
+	if (event == EVENT_KIND_THREAD_DEATH)
+		suspend_policy = SUSPEND_POLICY_NONE;
+	
 	if (event == EVENT_KIND_VM_DEATH) {
 		vm_death_event_sent = TRUE;
 		suspend_policy = SUSPEND_POLICY_NONE;


### PR DESCRIPTION
Do not suspend the vm when a thread has been terminated. Fixes null pointer crash when using newer versions of the soft debugger client in MonoDevelop.