### PR TITLE
Unhandled exception handling:

### DIFF
--- a/mono/interpreter/interp.c
+++ b/mono/interpreter/interp.c
@@ -3930,7 +3930,7 @@ array_constructed:
 		}
 die_on_ex:
 		ex_obj = (MonoObject*)frame->ex;
-		mono_unhandled_exception (ex_obj);
+		mono_unhandled_exception (ex_obj, TRUE);
 		exit (1);
 	}
 	handle_finally:
@@ -4047,7 +4047,7 @@ ves_exec_method (MonoInvocation *frame)
 	frame->ex = NULL;
 
 	if (setjmp(env)) {
-		mono_unhandled_exception ((MonoObject*)frame->ex);
+		mono_unhandled_exception ((MonoObject*)frame->ex, TRUE);
 		return;
 	}
 	if (context == NULL) {
@@ -4073,7 +4073,7 @@ ves_exec_method (MonoInvocation *frame)
 			longjmp (*context->current_env, 1);
 		}
 		else
-			mono_unhandled_exception ((MonoObject*)frame->ex);
+			mono_unhandled_exception ((MonoObject*)frame->ex, TRUE);
 	}
 	if (context->base_frame == frame)
 		TlsSetValue (thread_context_id, NULL);
@@ -4095,7 +4095,7 @@ ves_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[])
 
 	rval = mono_runtime_run_main (method, argc, argv, &exc);
 	if (exc != NULL)
-		mono_unhandled_exception (exc);
+		mono_unhandled_exception (exc, TRUE);
 
 	return rval;
 }

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -221,7 +221,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	runtime_invoke (o, NULL, &exc, NULL);
 
 	if (exc) {
-		/* fixme: do something useful */
+		mono_unhandled_exception(exc, FALSE);
 	}
 
 	mono_domain_set_internal (caller_domain);

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -66,6 +66,7 @@ typedef struct {
 typedef MonoObject* (*MonoInvokeFunc)	     (MonoMethod *method, void *obj, void **params, MonoObject **exc);
 typedef gpointer    (*MonoCompileFunc)	     (MonoMethod *method);
 typedef void	    (*MonoMainThreadFunc)    (gpointer user_data);
+typedef void		(*MonoUnhandledExceptionHandler)	(MonoException* exception);
 
 #define mono_object_class(obj) (((MonoObject*)(obj))->vtable->klass)
 #define mono_object_domain(obj) (((MonoObject*)(obj))->vtable->domain)
@@ -281,10 +282,16 @@ void
 mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg);
 
 void
-mono_unhandled_exception    (MonoObject *exc);
+mono_unhandled_exception    (MonoObject *exc, gboolean executedManagedHandlers);
 
 void
 mono_print_unhandled_exception (MonoObject *exc);
+
+MonoUnhandledExceptionHandler 
+mono_runtime_unhandled_exception_handler_get ();
+
+void
+mono_runtime_unhandled_exception_handler_set (MonoUnhandledExceptionHandler handler);
 
 gpointer 
 mono_compile_method	   (MonoMethod *method);

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -329,7 +329,7 @@ async_invoke_io_thread (gpointer data)
 					/*
 					ac = (ASyncCall *) ar->object_data;
 					if (ac->msg->exc != NULL)
-						mono_unhandled_exception (ac->msg->exc);
+						mono_unhandled_exception (ac->msg->exc, TRUE);
 					*/
 					mono_domain_set (mono_get_root_domain (), TRUE);
 				}
@@ -1458,7 +1458,7 @@ async_invoke_thread (gpointer data)
 					/*
 					ac = (ASyncCall *) ar->object_data;
 					if (ac->msg->exc != NULL)
-						mono_unhandled_exception (ac->msg->exc);
+						mono_unhandled_exception (ac->msg->exc, TRUE);
 					*/
 					mono_domain_set (mono_get_root_domain (), TRUE);
 				}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1207,7 +1207,7 @@ mono_handle_exception_internal (MonoContext *ctx, gpointer obj, gpointer origina
 			mono_debugger_agent_handle_exception (obj, ctx, NULL);
 			// FIXME: This runs managed code so it might cause another stack overflow when
 			// we are handling a stack overflow
-			mono_unhandled_exception (obj);
+			mono_unhandled_exception (obj, TRUE);
 		} else {
 			mono_debugger_agent_handle_exception (obj, ctx, &ctx_cp);
 		}


### PR DESCRIPTION
* Introduce 'execute managed handlers' parameter for mono_unhandled_exception to control whether managed handlers (i.e. AppDomain.UnhandledException) can be run
* Introduced mono_runtime_unhandled_exception_handler_get/set() for mono embedder to set a callback for all unhandled exceptions
* Make GC finaliser call mono_unhandled_exception if running finalizer throws an exception

By calling mono_runtime_unhandled_exception_handler_set() from Unity, we can trap and report managed exceptions happening off the main thread, instead of silently dropping them. Users are currently able to catch exceptions from regular worker threads via AppDomain.UnhandledException, but not the finaliser thread (see 633905).