### PR TITLE
Pass exceptions thrown by finalisers to mono_unhandled_exception

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -221,7 +221,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	runtime_invoke (o, NULL, &exc, NULL);
 
 	if (exc) {
-		/* fixme: do something useful */
+		mono_unhandled_exception(exc);
 	}
 
 	mono_domain_set_internal (caller_domain);


### PR DESCRIPTION
If an exception is thrown when executing a finaliser, pass it to mono_unhandled_exception so that it invokes the AppDomain.UnhandledException event; this brings Mono in line with the behaviour shown by WinRT.