### PR TITLE
[debugger-agent] Fix crash when inspecting enums/structs.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5904,8 +5904,33 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		if (err)
 			return err;
 
-		// FIXME:
-		g_assert (domain == domain2);
+		/* 
+		   The assert below is commented to fix a crash when inspecting enums/structs in a multi-domain setup.
+		 
+		   When the debugger wants to inspect an enum/struct, it first creates a boxed value of it.
+
+		   In this version of the debugger agent there is a bug where the boxed value is created in
+		   the same domain as the current System.Threading.Thread object was originally created. 
+		   Instead of creating the boxed value in the domain that is currently active for the thread.
+		 
+		   This means that if the managed thread object was created in a root domain, then the
+		   debugger client will ALWAYS create the boxed value in the root domain. If you change
+		   the active domain later, this does not change the domain in which the thread object was created.
+		 
+		   If you have an enum/struct in a child domain that you want to inspect, then the 'domain' variable
+		   above will be set to the root domain (for the thread) and 'domain2' will be set to the child domain
+		   (for the enum/struct). Which causes the assert below to fail and crash/abort the application.
+		 
+		   The correct fix for this is to fix the debugger client, so the correct active domain is returned for the
+		   current thread. This has been fixed in newer versions of the debugger client/agent (protocol).
+
+		   Fixing this issue in this version of the debugger agent and the latest debugger client has proven
+		   to be very difficult, so instead we just comment the assert and let the debugger client create the
+	       (child domain) boxed value in the root domain for the purpose of inspecting the enum/structs when
+		   debugging.
+		 */
+		
+		/* g_assert (domain == domain2); Fixes enum/struct inspection, see comment above */
 
 		o = mono_object_new (domain, klass);
 


### PR DESCRIPTION
See code comment for additional details.