### PR TITLE
Double traverse object count to avoid stack overflow when free huge a…

### DIFF
--- a/unity/unity_liveness.c
+++ b/unity/unity_liveness.c
@@ -311,8 +311,8 @@ static void mono_traverse_array (MonoArray* array, LivenessState* state)
 			MonoObject* object = (MonoObject*)mono_array_addr_with_size (array, elementClassSize, i);
 			mono_traverse_object_internal (object, 1, element_class, state);
 			
-			// Add 64 objects at a time and then traverse
-			if( ((i+1) & 63) == 0)
+			// Add 128 objects at a time and then traverse, 64 seems not be enough
+			if( ((i+1) & 127) == 0)
 				mono_traverse_objects(state);
 		}
 	}
@@ -323,8 +323,8 @@ static void mono_traverse_array (MonoArray* array, LivenessState* state)
 			MonoObject* val =  mono_array_get(array, MonoObject*, i);
 			mono_add_process_object(val, state);
 			
-			// Add 64 objects at a time and then traverse
-			if( ((i+1) & 63) == 0)
+			// Add 128 objects at a time and then traverse, 64 seems not be enough
+			if( ((i+1) & 127) == 0)
 				mono_traverse_objects(state);
 		}
 	}


### PR DESCRIPTION
…mounts of objects