### PR TITLE
mono-poll.c: poll() is broken on osx in several cases, so we use a select based mono_poll() instead.

### DIFF
--- a/mono/utils/mono-poll.c
+++ b/mono/utils/mono-poll.c
@@ -2,7 +2,7 @@
 #include "mono/metadata/threads.h"
 #include <errno.h>
 
-#ifdef HAVE_POLL
+#if defined(HAVE_POLL) && !defined(__APPLE__)
 int
 mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 {


### PR DESCRIPTION
Back port of https://github.com/mono/mono/commit/5a23e0b04cdbfbf87815498b5467950e32cd94da