### PR TITLE
Fixed monotonic timer overflow

### DIFF
--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -25,12 +25,16 @@ gint64
 mono_100ns_ticks (void)
 {
 	static LARGE_INTEGER freq;
+	static double ticks_with_freq;
 	LARGE_INTEGER value;
 
-	if (!freq.QuadPart && !QueryPerformanceFrequency (&freq))
-		return mono_100ns_datetime ();
+	if (!freq.QuadPart) {
+		if (!QueryPerformanceFrequency (&freq))
+			return mono_100ns_datetime ();
+		ticks_with_freq = (double)MTICKS_PER_SEC / freq.QuadPart;
+	}
 	QueryPerformanceCounter (&value);
-	return value.QuadPart * MTICKS_PER_SEC / freq.QuadPart;
+	return value.QuadPart * ticks_with_freq;
 }
 
 /*


### PR DESCRIPTION
Fixed monotonic timer overflow by changing order of operations so the timer never gets multiplied by ten million (causing the overflow). Additionally, caching the division since both values are static.

This fixes the use of some System.Threading features for a more than a few days. An uptime test was performed before and after the fix. Without the fix, System.Threading.Timer stopped working in ~3 days (depending on CPU hardware) and with the fix, it can run orders of magnitude longer.