### PR TITLE
[debugger-agent] Return ERR_NOT_IMPLEMENTED when evaluating non-infated generic methods

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5174,8 +5174,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke)
 	
 	sig = mono_method_signature (m);
 
-	// The client may request the container instead of the inflated method
-	if (sig && sig->ret && MONO_TYPE_MVAR == sig->ret->type)
+	if (m->is_generic && !m->is_inflated)
 		return ERR_NOT_IMPLEMENTED;
 
 	if (m->klass->valuetype)


### PR DESCRIPTION
Changed existing work around to check for generic and not-inflated. Fixes case 589577 

Invoking generic methods requires the debugger agent to support version 2.24 of the protocol.

https://github.com/Unity-Technologies/debugger-libs/blob/unity-trunk/Mono.Debugging.Soft/SoftDebuggerAdaptor.cs#L1776

So in our case it always tries to invoke the generic definition (non-inflated method) instead of the generic instance (inflated).