### PR TITLE
[amd64] Fix conversion of floats to int. Fixes case 678032

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -2942,7 +2942,10 @@ cc_signed_table [] = {
 static unsigned char*
 emit_float_to_int (MonoCompile *cfg, guchar *code, int dreg, int sreg, int size, gboolean is_signed)
 {
-	amd64_sse_cvttsd2si_reg_reg (code, dreg, sreg);
+	if(size == 8)
+		amd64_sse_cvttsd2si_reg_reg (code, dreg, sreg); // Convert to long
+	else
+		amd64_sse_cvttsd2si_reg_reg_size (code, dreg, sreg, 4); // Convert to int
 
 	if (size == 1)
 		amd64_widen_reg (code, dreg, dreg, is_signed, FALSE);


### PR DESCRIPTION
Before this fix (int)float.MaxValue would have been stored as 0x8000000000000000 (long max value) in for instance $rax (64-bit reg) and would be return as int value 0. Due to the double -> long instruction always being emitted: 

`cvttsd2si %xmm0, %rax`

With this fix, (int)float.MaxValue is stored as 0x80000000 (int max value) in $eax (32-bit reg) by emitting double -> int instruction for int types less than 8 bytes wide.

`cvttsd2si %xmm0, %eax`

