### PR TITLE
OP_CHECK_THIS relies on signal handling to catch NRE's. This causes p…

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6620,6 +6620,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			}
 
 			if (check_this) {
+				// MONO_EMIT_NULL_CHECK will only throw an exception for platforms that request explicit-null-check
+				MONO_EMIT_NULL_CHECK(cfg, sp [0]->dreg);
+
 				MonoInst *check;
 
 				MONO_INST_NEW (cfg, check, OP_CHECK_THIS);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6620,10 +6620,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			}
 
 			if (check_this) {
-				// MONO_EMIT_NULL_CHECK will only throw an exception for platforms that request explicit-null-check
-				MONO_EMIT_NULL_CHECK(cfg, sp [0]->dreg);
-
 				MonoInst *check;
+				// MONO_EMIT_NULL_CHECK will only throw an exception for platforms that request explicit-null-check
+				// otherwise the platforms that require explicit null checks will not gracefully handle the null exception.
+				MONO_EMIT_NULL_CHECK(cfg, sp [0]->dreg);
 
 				MONO_INST_NEW (cfg, check, OP_CHECK_THIS);
 				check->sreg1 = sp [0]->dreg;


### PR DESCRIPTION
…latforms (such as Samsung TV) that require explicit null checking to crash.