### PR TITLE
Check the number of entires in the list, and don't attempt to index i…

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -700,7 +700,7 @@ namespace System.Net.Sockets
 				}
 
 				// Remove non-signaled sockets before the current one
-				if (currentList.Count > 0)
+				if (currentIdx < currentList.Count)
 				{
 					while ((cur_sock = (Socket) currentList [currentIdx]) != sock) {
 						currentList.RemoveAt (currentIdx);

--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -700,9 +700,11 @@ namespace System.Net.Sockets
 				}
 
 				// Remove non-signaled sockets before the current one
-				int max = currentList.Count;
-				while ((cur_sock = (Socket) currentList [currentIdx]) != sock) {
-					currentList.RemoveAt (currentIdx);
+				if (currentList.Count > 0)
+				{
+					while ((cur_sock = (Socket) currentList [currentIdx]) != sock) {
+						currentList.RemoveAt (currentIdx);
+					}
 				}
 				currentIdx++;
 			}


### PR DESCRIPTION
…nto it if none are present.

With IL2CPP, the behavior of the icall for Socket select is slightly different from Mono. For Mono, I don't believe this list will ever be empty, but for IL2CPP it can be.