### PR TITLE
Fix crash when marshalling struct hierarchies

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1958,7 +1958,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 			mono_mb_emit_stloc (mb, 1);
 		}
 		}
-		
+
 		if (to_object) {
 			mono_mb_emit_add_to_local (mb, 0, usize);
 			mono_mb_emit_add_to_local (mb, 1, msize);


### PR DESCRIPTION
Fix crash when marshalling struct hierarchies where the parent struct size does not align with the child struct alignment requirement. Fixes case 696317

Fixes marshalling of structs such TestPacket_1 below on 64-bit, because PacketHeader4Byte is not a multiple of 8 bytes, which the alignment forced for szUserID on 64-bit.

[StructLayout( LayoutKind.Sequential, Pack = 1 )]
public class PacketHeader4Byte
{
	public UInt16 Length;
	public UInt16 Id;
}

[StructLayout( LayoutKind.Sequential, Pack = 1 )]
public class TestPacket_1 : PacketHeader4Byte
{
	[MarshalAs( UnmanagedType.ByValArray, SizeConst = 10 )]
	public byte[] szUserID;
}
