### PR TITLE
Increase size of per-class user data storage

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -258,6 +258,7 @@ typedef struct {
 #define MONO_RGCTX_SLOT_INDEX(s)	((s) & 0x7fffffff)
 #define MONO_RGCTX_SLOT_IS_MRGCTX(s)	(((s) & 0x80000000) ? TRUE : FALSE)
 
+#define MONO_CLASS_USERDATA_SIZE (sizeof(void*) + 4)
 
 #define MONO_CLASS_PROP_EXCEPTION_DATA 0
 
@@ -421,7 +422,7 @@ struct _MonoClass {
 	/* Rarely used fields of classes */
 	MonoClassExt *ext;
 
-	void *user_data;
+	guint8 user_data[MONO_CLASS_USERDATA_SIZE];
 };
 
 #define MONO_CLASS_IMPLEMENTS_INTERFACE(k,uiid) (((uiid) <= (k)->max_interface_id) && ((k)->interface_bitmap [(uiid) >> 3] & (1 << ((uiid)&7))))


### PR DESCRIPTION
We want to pack a pointer to the class's SerializationCommandQueue as well as the classID/sealedness. Instead of doing complicated packing things, let's just increase the amount of space we have to store things in.