### PR TITLE
Fix NullReferenceExceptions on Android/x86 (L and M)

### DIFF
--- a/external/buildscripts/PrepareAndroidSDK.pm
+++ b/external/buildscripts/PrepareAndroidSDK.pm
@@ -138,6 +138,12 @@ our $ndks =
 						"macosx" => "android-ndk-r9-darwin-x86.tar.bz2",
 						"linux" => "android-ndk-r9-linux-x86.tar.bz2",
 					},
+	"r10e"		=>
+					{
+						"windows" => "android-ndk-r10e-windows-x86.exe",
+						"macosx" => "android-ndk-r10e-darwin-x86_64.bin",
+						"linux" => "android-ndk-r10e-linux-x86.bin",
+					},
 };
 
 our ($HOST_ENV, $TMP, $HOME, $WINZIP);
@@ -391,6 +397,14 @@ sub DownloadAndUnpackArchive
 		elsif (lc $suffix eq '.bz2')
 		{
 			system("tar", "-xf", $temporary_download_path, "-C", $temporary_unpack_path);
+		}
+		elsif (lc $suffix eq '.bin')
+		{	chmod(0755, $temporary_download_path);
+			system($temporary_download_path, "-o" . $temporary_unpack_path);
+		}
+		elsif (lc $suffix eq '.exe')
+		{	chmod(0755, $temporary_download_path);
+			system($temporary_download_path, "-o" . $temporary_unpack_path);
 		}
 		else
 		{

--- a/external/buildscripts/build_runtime_android.sh
+++ b/external/buildscripts/build_runtime_android.sh
@@ -11,7 +11,7 @@ CWD="$(pwd)"
 PREFIX="$CWD/builds/android"
 BUILDSCRIPTSDIR=external/buildscripts
 
-perl ${BUILDSCRIPTSDIR}/PrepareAndroidSDK.pl -ndk=r9 -env=envsetup.sh && source envsetup.sh
+perl ${BUILDSCRIPTSDIR}/PrepareAndroidSDK.pl -ndk=r10e -env=envsetup.sh && source envsetup.sh
 
 NDK_ROOT=`cd $ANDROID_NDK_ROOT && pwd`
 
@@ -23,10 +23,10 @@ fi
 HOST_ENV=`uname -s`
 case "$HOST_ENV" in
     Darwin)
-        HOST_ENV=darwin-x86
+        HOST_ENV=darwin
         ;;
     Linux)
-        HOST_ENV=linux-x86
+        HOST_ENV=linux
         ;;
     CYGWIN*|*_NT-*)
         HOST_ENV=windows
@@ -39,6 +39,13 @@ esac
 
 PLATFORM_ROOT=$NDK_ROOT/platforms/$ANDROID_PLATFORM/arch-arm
 TOOLCHAIN=$NDK_ROOT/toolchains/$GCC_PREFIX$GCC_VERSION/prebuilt/$HOST_ENV
+
+if [ ! -d $TOOLCHAIN ]; then
+	TOOLCHAIN=${TOOLCHAIN}-x86
+	if [ ! -d $TOOLCHAIN ]; then
+		TOOLCHAIN=${TOOLCHAIN}_64
+	fi
+fi
 
 if [ ! -a $TOOLCHAIN -o ! -a $PLATFORM_ROOT ]; then
 	NDK_NAME=`basename $NDK_ROOT`

--- a/external/buildscripts/build_runtime_android_x86.sh
+++ b/external/buildscripts/build_runtime_android_x86.sh
@@ -19,10 +19,10 @@ fi
 HOST_ENV=`uname -s`
 case "$HOST_ENV" in
     Darwin)
-        HOST_ENV=darwin-x86
+        HOST_ENV=darwin
         ;;
     Linux)
-        HOST_ENV=linux-x86
+        HOST_ENV=linux
         ;;
     CYGWIN*|*_NT-*)
         HOST_ENV=windows
@@ -35,6 +35,13 @@ esac
 
 PLATFORM_ROOT=$NDK_ROOT/platforms/$ANDROID_PLATFORM/arch-x86
 TOOLCHAIN=$NDK_ROOT/toolchains/x86-$GCC_VERSION/prebuilt/$HOST_ENV
+
+if [ ! -d $TOOLCHAIN ]; then
+	TOOLCHAIN=${TOOLCHAIN}-x86
+	if [ ! -d $TOOLCHAIN ]; then
+		TOOLCHAIN=${TOOLCHAIN}_64
+	fi
+fi
 
 if [ ! -a $TOOLCHAIN -o ! -a $PLATFORM_ROOT ]; then
 	NDK_NAME=`basename $NDK_ROOT`

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -44,7 +44,7 @@ LONG CALLBACK seh_handler(EXCEPTION_POINTERS* ep);
 
 #endif /* PLATFORM_WIN32 */
 
-#if defined( __linux__) && !defined(ANDROID) || defined(__sun) || defined(__APPLE__) || defined(__NetBSD__) || \
+#if defined( __linux__) || defined(__sun) || defined(__APPLE__) || defined(__NetBSD__) || \
        defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__QNXNTO__)
 #define MONO_ARCH_USE_SIGACTION
 #endif


### PR DESCRIPTION
Use MONO_ARCH_USE_SIGACTION on Android/x86
The other code path does not work on Android 5.0 or newer which leads to infinite recursion in signal handler.
Upgraded to NDK r10e because MONO_ARCH_USE_SIGACTION requires ucontext, which wasn't exposed in NDK r9.