### PR TITLE
Support for unpacking custom attribute parameter values

### DIFF
--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -291,12 +291,13 @@ void unity_mono_unpack_custom_attr_params(MonoImage* image, MonoCustomAttrEntry*
 	// Also helpful: http://geekswithblogs.net/simonc/archive/2011/06/03/anatomy-of-a-.net-assembly---custom-attribute-encoding.aspx
 	const char *src = (const char*)entry->data;
 	char *dest = (char*)output;
+	int i;
 	
 	MonoMethodSignature *sig = mono_method_signature(entry->ctor);
 	
 	// Skip prolog
 	src += 2;
-	for(int i = 0; i < sig->param_count; ++i)
+	for(i = 0; i < sig->param_count; ++i)
 	{
 		MonoType* paramType = sig->params[i];
 		int type = paramType->type;
@@ -353,7 +354,7 @@ void unity_mono_unpack_custom_attr_params(MonoImage* image, MonoCustomAttrEntry*
 	if(namedParameterHandler == NULL) return;
 	guint32 num_named = read16(src);
 	src += 2;
-	for (int j = 0; j < num_named; ++j)
+	for (i = 0; i < num_named; ++i)
 	{
 		UnityMonoMetadataString* paramName;
 		src++; // skip the field/property specifier

--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -10,8 +10,10 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/metadata-internals.h>
+#include <mono/metadata/mono-endian.h>
 #include <mono/metadata/threads.h>
 #include <mono/metadata/tokentype.h>
+#include <mono/metadata/reflection.h>
 #include <mono/utils/mono-string.h>
 
 #include <glib.h>
@@ -197,4 +199,209 @@ gboolean
 unity_mono_method_is_generic (MonoMethod* method)
 {
 	return method->is_generic;
+}
+
+static size_t unpack_custom_attr_value(const char* src, int type, char* dest, MonoImage* image)
+{
+	// Pretty much mimicing load_cattr_value in reflection.c here now, but without the allocs:
+	switch(type)
+	{
+		case MONO_TYPE_U1:
+		case MONO_TYPE_I1:
+		case MONO_TYPE_BOOLEAN:
+		{
+			*(MonoBoolean*)dest = *(MonoBoolean*)src;
+			return 1;
+		}
+		case MONO_TYPE_CHAR:
+		case MONO_TYPE_U2:
+		case MONO_TYPE_I2:
+		{
+			*(guint16*)dest = *(guint16*)src;
+			return 2;
+		}
+#if SIZEOF_VOID_P == 4
+		case MONO_TYPE_U:
+		case MONO_TYPE_I:
+#endif
+		case MONO_TYPE_R4:
+		case MONO_TYPE_U4:
+		case MONO_TYPE_I4: {
+			*(guint32*)dest = *(guint32*)src;
+			return 4;
+		}
+#if SIZEOF_VOID_P == 8
+		case MONO_TYPE_U: /* error out instead? this should probably not happen */
+		case MONO_TYPE_I:
+#endif
+		case MONO_TYPE_U8:
+		case MONO_TYPE_I8: {
+			*(guint64*)dest = *(guint64*)src;
+			return 8;
+		}
+		case MONO_TYPE_R8: {
+			*(double*)dest = *(double*)src;
+			return 8;
+		}
+		case MONO_TYPE_STRING: {
+			// if the first byte is 0xFF, it's a null/empty string
+			UnityMonoMetadataString** str = (UnityMonoMetadataString**)dest;
+			if(*src == (char)0xFF)
+			{
+				*str = NULL;
+				return 1;
+			}
+			
+			*str = (UnityMonoMetadataString*)src;
+			const char* oldSrc = src;
+			src += mono_metadata_decode_value(src, &src);
+			return src - oldSrc;
+		}
+		case MONO_TYPE_CLASS: {
+			// type references (i.e. typeof(SomeClass)) are stored as string names
+			MonoType** result = (MonoType**)dest;
+			if(*src == (char)0xFF)
+			{
+				*result = NULL;
+				return 1;
+			}
+			
+			const char* oldSrc = src;
+			guint32 length = mono_metadata_decode_value (src, &src);
+			char *utf8Str = g_memdup (src, length + 1);
+			utf8Str [length] = 0;
+			src += length;
+			*result = mono_reflection_type_from_name (utf8Str, image);
+			if (!*result)
+				g_warning ("Cannot load type '%s'", utf8Str);
+			g_free (utf8Str);
+			return src - oldSrc;
+		}
+		default:
+		{
+			g_error ("Type 0x%02x not handled in custom attr value decoding", type);
+			return 0;
+		}
+	}
+}
+
+void unity_mono_unpack_custom_attr_params(MonoImage* image, MonoCustomAttrEntry* entry, void* output, UnityMonoCustomAttrNamedParameterFunc namedParameterHandler)
+{
+	// Mimicing create_custom_attr in mono/metadata/reflection.c for unpacking the params
+	// Also helpful: http://geekswithblogs.net/simonc/archive/2011/06/03/anatomy-of-a-.net-assembly---custom-attribute-encoding.aspx
+	const char *src = (const char*)entry->data;
+	char *dest = (char*)output;
+	
+	MonoMethodSignature *sig = mono_method_signature(entry->ctor);
+	
+	// Skip prolog
+	src += 2;
+	for(int i = 0; i < sig->param_count; ++i)
+	{
+		MonoType* paramType = sig->params[i];
+		int type = paramType->type;
+		
+		if (type == MONO_TYPE_VALUETYPE && paramType->data.klass->enumtype)
+			type = mono_class_enum_basetype(paramType->data.klass)->type;
+		
+		src += unpack_custom_attr_value(src, type, dest, image);
+		
+		// Advance dest as well
+		switch(type)
+		{
+			case MONO_TYPE_U1:
+			case MONO_TYPE_I1:
+			case MONO_TYPE_BOOLEAN:
+				dest += 1;
+				break;
+			case MONO_TYPE_CHAR:
+			case MONO_TYPE_U2:
+			case MONO_TYPE_I2:
+				dest += 2;
+				break;
+#if SIZEOF_VOID_P == 4
+			case MONO_TYPE_U:
+			case MONO_TYPE_I:
+#endif
+			case MONO_TYPE_R4:
+			case MONO_TYPE_U4:
+			case MONO_TYPE_I4:
+				dest += 4;
+				break;
+#if SIZEOF_VOID_P == 8
+			case MONO_TYPE_U:
+			case MONO_TYPE_I:
+#endif
+			case MONO_TYPE_U8:
+			case MONO_TYPE_I8:
+			case MONO_TYPE_R8:
+				dest += 8;
+				break;
+			case MONO_TYPE_STRING:
+				dest += sizeof(UnityMonoMetadataString*);
+				break;
+			case MONO_TYPE_CLASS:
+				dest += sizeof(MonoType*);
+				break;
+			default:
+				g_error("Unknown/unsupported parameter type");
+				break;
+		}
+	}
+	
+	// Now, named parameters
+	if(namedParameterHandler == NULL) return;
+	guint32 num_named = read16(src);
+	src += 2;
+	for (int j = 0; j < num_named; ++j)
+	{
+		UnityMonoMetadataString* paramName;
+		src++; // skip the field/property specifier
+		int type = *(src++);
+		
+		if (type == MONO_TYPE_SZARRAY)
+		{
+			g_error("Array types are not supported for named parameter unpacking");
+			type = *(src++);
+		}
+		
+		if (type == MONO_TYPE_ENUM)
+		{
+			// Enum typed parameters pack the actual name of the enum type
+			// We don't really care about it for our purposes, just skip past it
+			gint type_len = mono_metadata_decode_blob_size (src, &src);
+			src += type_len;
+		}
+		
+		paramName = (UnityMonoMetadataString*)src;
+		src += mono_metadata_decode_blob_size (src, &src);
+		
+		// Unpack the attribute value to a buffer. The unpacked size depends on the data type
+		// but right now the largest thing we could unpack is an int64 so make the buffer that big.
+		char buffer[8];
+		src += unpack_custom_attr_value(src, type, buffer, image);
+		
+		namedParameterHandler(output, paramName, type, &buffer[0]);
+	}
+}
+
+guint32 unity_mono_metadata_string_length(UnityMonoMetadataString* string)
+{
+	if(string == NULL) return 0;
+	return mono_metadata_decode_blob_size(string, &string);
+}
+
+void unity_mono_metadata_string_copy(UnityMonoMetadataString* string, char* buffer, size_t bufferSize)
+{
+	if(bufferSize == 0) return;
+	if(string == NULL)
+	{
+		buffer[0] = 0;
+		return;
+	}
+	guint32 strLen = mono_metadata_decode_blob_size(string, &string);
+	if(strLen + 1 > bufferSize)
+		strLen = bufferSize - 1;
+	memcpy(buffer, string, strLen);
+	buffer[strLen + 1] = 0;
 }

--- a/unity/unity_utils.h
+++ b/unity/unity_utils.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <mono/metadata/object.h>
+#include <mono/metadata/reflection.h>
 
 /**
  *	Custom exit function, called instead of system exit()
@@ -38,5 +39,15 @@ unity_mono_method_is_inflated (MonoMethod* method);
 
 gboolean
 unity_mono_method_is_generic (MonoMethod* method);
+
+// Opaque struct that represents a length-prefixed string in the metadata.
+typedef const char UnityMonoMetadataString;
+
+typedef void (*UnityMonoCustomAttrNamedParameterFunc)(void* output, UnityMonoMetadataString* parameterName, int type, void* parameterValue);
+
+void unity_mono_unpack_custom_attr_params(MonoImage* image, MonoCustomAttrEntry* entry, void* output, UnityMonoCustomAttrNamedParameterFunc namedParameterHandler);
+
+guint32 unity_mono_metadata_string_length(UnityMonoMetadataString* string);
+void unity_mono_metadata_string_copy(UnityMonoMetadataString* string, char* buffer, size_t bufferSize);
 
 #endif


### PR DESCRIPTION
At the moment, if we want to access the values a user has used to construct an attribute, the only way to do that is to actually construct the attribute on the managed side, and then read the values back. This is both slow (a full trip into managed land + allocating the attribute object) and bad for GC (as the attribute is then garbage). This is the only way to be sure that an attribute has performed any logic needed to populate all of its properties.

The vast majority of the time, though, we are working with attributes that do not have special logic in, or even properties we care about - we just want to know the values that the user was passing to the attribute's constructor when they declared the attribute. Fortunately, this is exactly what is stored in the CIL metadata...

This change introduces a simple API for retrieving the constructor parameters, unpacking them into a struct. The user is responsible for ensuring that the layout of the struct matches the types of the positional arguments given to the constructor; named arguments, if present, are passed to a callback function, if present.

Strings in the metadata are also encoded in a special length-prefixed way, so a pair of functions are provided for retrieving the length of such a string and for copying the string into a regular null-terminated buffer.
