### PR TITLE
Compute the proper managed size for a packed hierarchy

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1759,18 +1759,15 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 		return;
 
 	if (klass->blittable) {
-		int msize = mono_class_value_size (klass, NULL);
-		int usize = msize;
-		g_assert (msize == info->native_size);
+		int usize = mono_class_value_size (klass, NULL);
+		g_assert (usize == info->native_size);
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_icon (mb, usize);
 		mono_mb_emit_byte (mb, CEE_PREFIX1);
 		mono_mb_emit_byte (mb, CEE_CPBLK);
 
-		msize = offset_of_first_child_field;
-		
-		mono_mb_emit_add_to_local (mb, 0, msize);
+		mono_mb_emit_add_to_local (mb, 0, offset_of_first_child_field);
 		mono_mb_emit_add_to_local (mb, 1, usize);
 		return;
 	}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1748,7 +1748,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 {
 	MonoMarshalType *info;
 	int i;
-	int first_field_offset = (klass->field.count != 0 ? klass->fields[0].offset : 0) - sizeof(MonoObject);
+	int first_field_offset = klass->field.count != 0 ? klass->fields[0].offset - sizeof(MonoObject) : 0;
 
 	if (klass->parent)
 		emit_struct_conv_full(mb, klass->parent, to_object, first_field_offset);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1748,7 +1748,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 {
 	MonoMarshalType *info;
 	int i;
-	int first_field_offset = klass->field.count != 0 ? klass->fields[0].offset - sizeof(MonoObject) : 0;
+	int first_field_offset = klass->field.count > 0 ? klass->fields[0].offset - sizeof(MonoObject) : 0;
 
 	if (klass->parent)
 		emit_struct_conv_full(mb, klass->parent, to_object, first_field_offset);


### PR DESCRIPTION
This change corrects another issue related to the changes on
marshal-struct-hierachy-fix, merged to unity-staging at
6605fdac06b4a50ace3dc24f4d659ce7c511d28f.

We can't quite assume that the first field in a child is aligned with
the minimum alignment for the parent. Instead, we'll let the child tell
the parent about the offset of its first field, and use that.

For example, given this code:

[StructLayout(LayoutKind.Sequential, Pack = 4)]
public class Base
{
public ushort a;
public ushort b;
}

[StructLayout(LayoutKind.Sequential, Pack = 4, CharSet = CharSet.Ansi)]
public class Person : Base
{
public uint unType;
[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
public string Name;
    public uint foo;
   }

The minimum alignment of Person is 8 on 64-bit (since the Name field is
a pointer). But the offset of the uType field in Person is at 4, since
that still meets the minimum alignment requirements. So the first field
of Person has an offset of 4 in the managed representation of the
structure. The previous code here assumed that offset is 8.