### PR TITLE
Compatible for NDK nightly builds

### DIFF
--- a/external/buildscripts/PrepareAndroidSDK.pm
+++ b/external/buildscripts/PrepareAndroidSDK.pm
@@ -446,8 +446,8 @@ sub PrepareNDK
 		my $current = $content[0];
 		print "\tCurrently installed = " . $current . "\n";
 
-		# remove the possible '(64-bit)' from the end
-		my @curr_arr = split(' ', $current);
+		# remove the possible '-nightly builds' and '(64-bit)' string
+		my @curr_arr = split(/\-|\s/, $current);
 		$current = $curr_arr[0];
 		
 		if ($ndk eq $current)


### PR DESCRIPTION
Pick the major version of NDK from NDK_directory/RELEASE.txt
original:
It only split space. (64-bit)
modified:
Add regex to support nightly builds.
ex: android-ndk-r10e-linux-x86_64
r10e-rc4 (64-bit) -> r10e