### PR TITLE
Expose unity_mono_reflection_method_get_method

### DIFF
--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -55,6 +55,7 @@ mono_unity_class_is_abstract
 mono_backtrace_from_context
 mono_unity_thread_clear_domain_fields
 mono_unity_get_all_classes_with_name_case
+unity_mono_reflection_method_get_method
 
 ;Exports that should have been here, but I dont understand why they're not.
 mono_security_enable_core_clr

--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -198,3 +198,12 @@ unity_mono_method_is_generic (MonoMethod* method)
 {
 	return method->is_generic;
 }
+
+MonoMethod*
+unity_mono_reflection_method_get_method(MonoReflectionMethod* mrf)
+{
+	if(!mrf)
+		return NULL;
+
+	return mrf->method;
+}


### PR DESCRIPTION
Expose unity_mono_reflection_method_get_method to retrieve MonoMethod from MonoReflectionMethod. Allows matching methods correctly instead of relying on method names.