### PR TITLE
Work around the Mono array casting bug during array sort.

### DIFF
--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -1651,11 +1651,12 @@ namespace System
 					iswapper = null;
 				else 
 					iswapper = get_swapper<TValue> (items);
+
 				if (keys is double[]) {
 					combsort (keys as double[], index, length, iswapper);
 					return;
 				}
-				if (keys is int[]) {
+				if (!(keys is uint[]) && (keys is int[])) {
 					combsort (keys as int[], index, length, iswapper);
 					return;
 				}


### PR DESCRIPTION
Details about the array casting bug are here: https://github.com/Unity-Technologies/mono/commit/acca62e1c3b5f1bff27f637e693f57a5417bf57d

This is another case of the same issue. We need to explicitly check for a uint[] array, as the behavior of Mono, MonoBleedingEdge, and IL2CPP all match for that case. This change corrects case 774085.