### PR TITLE
debugger-agent: Return error instead of crashing

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6751,7 +6751,9 @@ thread_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		mono_loader_lock ();
 		tls = mono_g_hash_table_lookup (thread_to_tls, thread);
 		mono_loader_unlock ();
-		g_assert (tls);
+
+		if(!tls)
+			return ERR_INVALID_ARGUMENT;
 
 		compute_frame_info (thread, tls);
 


### PR DESCRIPTION
Unity crashes on this assert for some people when using VSTU, changing assert to return error to give more pleasant experience. VSTU team are looking into the issue.