### PR TITLE
Improve the GZipStream story

### DIFF
--- a/external/buildscripts/build_runtime_win.pl
+++ b/external/buildscripts/build_runtime_win.pl
@@ -25,10 +25,7 @@ if (-e $remove)
 #have a duplicate for now...
 copy("$root/builds/embedruntimes/win32/mono.dll","$root/builds/monodistribution/bin/mono.dll");
 copy("$root/builds/embedruntimes/win32/mono.pdb","$root/builds/monodistribution/bin/mono.pdb");
-
-mkdir("$root/builds/monodistribution/lib");
-mkdir("$root/builds/monodistribution/lib/win32");
-copy("$root/msvc/Win32_Release_eglib/bin/MonoPosixHelper.dll","$root/builds/monodistribution/lib/win32/MonoPosixHelper.dll");
+copy("$root/msvc/Win32_Release_eglib/bin/MonoPosixHelper.dll","$root/builds/embedruntimes/win32/MonoPosixHelper.dll");
 
 if ($ENV{UNITY_THISISABUILDMACHINE})
 {

--- a/external/buildscripts/build_runtime_win.pl
+++ b/external/buildscripts/build_runtime_win.pl
@@ -26,6 +26,10 @@ if (-e $remove)
 copy("$root/builds/embedruntimes/win32/mono.dll","$root/builds/monodistribution/bin/mono.dll");
 copy("$root/builds/embedruntimes/win32/mono.pdb","$root/builds/monodistribution/bin/mono.pdb");
 
+mkdir("$root/builds/monodistribution/lib");
+mkdir("$root/builds/monodistribution/lib/win32");
+copy("$root/msvc/Win32_Release_eglib/bin/MonoPosixHelper.dll","$root/builds/monodistribution/lib/win32/MonoPosixHelper.dll");
+
 if ($ENV{UNITY_THISISABUILDMACHINE})
 {
 	system("git log --pretty=format:\"mono-runtime-win32 = %H %d %ad\" --no-abbrev-commit --date=short -1 > $root\\builds\\versions.txt");

--- a/external/buildscripts/build_runtime_win64.pl
+++ b/external/buildscripts/build_runtime_win64.pl
@@ -26,6 +26,10 @@ if (-e $remove)
 copy("$root/builds/embedruntimes/win64/mono.dll","$root/builds/monodistribution/bin-x64/mono.dll");
 copy("$root/builds/embedruntimes/win64/mono.pdb","$root/builds/monodistribution/bin-x64/mono.pdb");
 
+mkdir("$root/builds/monodistribution/lib");
+mkdir("$root/builds/monodistribution/lib/win64");
+copy("$root/msvc/x64_Release_eglib/bin/MonoPosixHelper.dll","$root/builds/monodistribution/lib/win64/MonoPosixHelper.dll");
+
 if ($ENV{UNITY_THISISABUILDMACHINE})
 {
 	system("git log --pretty=format:\"mono-runtime-win64 = %H %d %ad\" --no-abbrev-commit --date=short -1 > $root\\builds\\versions.txt");

--- a/external/buildscripts/build_runtime_win64.pl
+++ b/external/buildscripts/build_runtime_win64.pl
@@ -25,10 +25,7 @@ if (-e $remove)
 #have a duplicate for now...
 copy("$root/builds/embedruntimes/win64/mono.dll","$root/builds/monodistribution/bin-x64/mono.dll");
 copy("$root/builds/embedruntimes/win64/mono.pdb","$root/builds/monodistribution/bin-x64/mono.pdb");
-
-mkdir("$root/builds/monodistribution/lib");
-mkdir("$root/builds/monodistribution/lib/win64");
-copy("$root/msvc/x64_Release_eglib/bin/MonoPosixHelper.dll","$root/builds/monodistribution/lib/win64/MonoPosixHelper.dll");
+copy("$root/msvc/x64_Release_eglib/bin/MonoPosixHelper.dll","$root/builds/embedruntimes/win64/MonoPosixHelper.dll");
 
 if ($ENV{UNITY_THISISABUILDMACHINE})
 {

--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -416,11 +416,7 @@ namespace System.IO.Compression {
 			set { throw new NotSupportedException(); }
 		}
 
-#if MONOTOUCH
-		const string LIBNAME = "__Internal";
-#else
 		const string LIBNAME = "MonoPosixHelper";
-#endif
 
 		[DllImport (LIBNAME, CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr CreateZStream (CompressionMode compress, bool gzip, UnmanagedReadOrWrite feeder, IntPtr data);


### PR DESCRIPTION
These changes correct case 569612.

* We need to copy the MonoPosixHelper.dll into the output directory of the Windows builds.
* In the class libraries, there is no reason to use __Internal here, as we're only supporting this now on the editor and standalones. We want both the full profile and the subset profile to work though, so we don't want to use __Internal on the subset profile.