### PR TITLE
Merge latest changes from unity-staging to unity-trunk

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -700,7 +700,7 @@ namespace System.Net.Sockets
 				}
 
 				// Remove non-signaled sockets before the current one
-				if (currentIdx < currentList.Count)
+				if (currentList != null && currentIdx < currentList.Count)
 				{
 					while ((cur_sock = (Socket) currentList [currentIdx]) != sock) {
 						currentList.RemoveAt (currentIdx);

--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -1651,11 +1651,12 @@ namespace System
 					iswapper = null;
 				else 
 					iswapper = get_swapper<TValue> (items);
+
 				if (keys is double[]) {
 					combsort (keys as double[], index, length, iswapper);
 					return;
 				}
-				if (keys is int[]) {
+				if (!(keys is uint[]) && (keys is int[])) {
 					combsort (keys as int[], index, length, iswapper);
 					return;
 				}

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -1348,7 +1348,7 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 	 * is private to this thread.  Therefore even if the event was
 	 * signalled before we wait, we still succeed.
 	 */
-	ret = WaitForSingleObjectEx (event, ms, TRUE);
+	ret = mono_unity_wait_for_multiple_objects_processing_apc (1, &event, TRUE, ms);
 
 	/* Reset the thread state fairly early, so we don't have to worry
 	 * about the monitor error checking

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -198,4 +198,6 @@ void mono_thread_set_execution_context (MonoObject *ec) MONO_INTERNAL;
 void mono_runtime_set_has_tls_get (gboolean val) MONO_INTERNAL;
 gboolean mono_runtime_has_tls_get (void) MONO_INTERNAL;
 
+guint32 mono_unity_wait_for_multiple_objects_processing_apc (gint32 handle_count, HANDLE* handles, gboolean wait_all, gint32 ms) MONO_INTERNAL;
+
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */


### PR DESCRIPTION
* Improve GZipStream story (case 569612)
* Rename wait_and_ignore_interrupt to mono_unity_wait_for_multiple_objects_processing_apc and use for Monitor waits as well. Prevents debugger APCs from interrupting (case 772064).