### PR TITLE
Do not crash if we are inserting a breakpoint for a line that does not have a sequence point.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3472,7 +3472,8 @@ insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo
 
 	if (i == seq_points->len) {
 		/* Have to handle this somehow */
-		g_error ("Unable to insert breakpoint at %s:%d, seq_points=%d\n", mono_method_full_name (ji->method, TRUE), bp->il_offset, seq_points->len);
+		g_warning ("Unable to insert breakpoint at %s:%d, seq_points=%d\n", mono_method_full_name (ji->method, TRUE), bp->il_offset, seq_points->len);
+		return;
 	}
 
 	inst = g_new0 (BreakpointInstance, 1);


### PR DESCRIPTION
Instead of crashing, we do not insert the breakpoint and the breakpoint then gets moved to the next possible sequence point in the source file.

Fixes part of case 735335. 