### PR TITLE
Make the personal folder be the same on all profiles

### DIFF
--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -553,11 +553,7 @@ namespace System {
 #endif
 			// personal == ~
 			case SpecialFolder.Personal:
-#if MONOTOUCH
-				return Path.Combine (home, "Documents");
-#else
 				return home;
-#endif
 			// use FDO's CONFIG_HOME. This data will be synced across a network like the windows counterpart.
 			case SpecialFolder.ApplicationData:
 				return config;

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -553,7 +553,11 @@ namespace System {
 #endif
 			// personal == ~
 			case SpecialFolder.Personal:
+#if MONOTOUCH && !UNITY
+				return Path.Combine (home, "Documents");
+#else
 				return home;
+#endif
 			// use FDO's CONFIG_HOME. This data will be synced across a network like the windows counterpart.
 			case SpecialFolder.ApplicationData:
 				return config;


### PR DESCRIPTION
We should not return a different value for the personal folder on
different profiles. This is unnecessary and confusing. This change
corrects case 776268.