### PR TITLE
Merge latest changes from unity-staging to unity-trunk

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -81,11 +81,6 @@
 static char* inet_ntop(int af, const void* src, char* dst, size_t size);
 #endif
 
-#ifdef PLATFORM_ANDROID
-// not yet actually implemented...
-#undef AF_INET6
-#endif
-
 #define LOGDEBUG(...)  
 /* define LOGDEBUG(...) g_message(__VA_ARGS__)  */
 


### PR DESCRIPTION
This pull request includes two fixes:

* [ios] Fix incorrect ABI for int64 types (Unity case 774544)
* [android] Enable IPv6 support (case 767741)