### PR TITLE
Merge latest changes from unity-staging to unity-trunk

### DIFF
--- a/mcs/build/common/Consts.cs.in
+++ b/mcs/build/common/Consts.cs.in
@@ -68,7 +68,7 @@ internal
 	public const string VsVersion = "8.0.0.0";
 	public const string FxFileVersion = "3.0.4506.648";
 	public const string VsFileVersion = "6.0.6001.17014";
-#elif NET_2_1 && !UNITY
+#elif NET_2_1
 	// Versions of .NET Framework for Silverlight 3.0
 	public const string FxVersion = "2.0.5.0";
 	public const string VsVersion = "9.0.0.0"; // unused, but needed for compilation

--- a/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
@@ -685,7 +685,7 @@ namespace System.Net.Sockets {
 		internal int Receive_nochecks (byte [] buf, int offset, int size, SocketFlags flags, out SocketError error)
 		{
 #if NET_2_0 && (!NET_2_1 || MONOTOUCH)
-			if (protocol_type == ProtocolType.Udp) {
+			if (protocol_type == ProtocolType.Udp && System.Environment.SocketSecurityEnabled) {
 				var ipAddress = IPAddress.Any;
 				if (address_family == AddressFamily.InterNetworkV6)
 					ipAddress = IPAddress.IPv6Any;

--- a/mcs/class/System/System.Net.Sockets/UdpClient.cs
+++ b/mcs/class/System/System.Net.Sockets/UdpClient.cs
@@ -328,7 +328,13 @@ namespace System.Net.Sockets
 			CheckDisposed ();
 
 			byte [] recBuffer = new byte [65536]; // Max. size
-			EndPoint endPoint = new IPEndPoint (IPAddress.Any, 0);
+			EndPoint endPoint;
+			
+			if (family == AddressFamily.InterNetwork) {
+				endPoint = new IPEndPoint (IPAddress.Any, 0);
+			} else {
+				endPoint = new IPEndPoint (IPAddress.IPv6Any, 0);
+			}
 			int dataRead = socket.ReceiveFrom (recBuffer, ref endPoint);
 			if (dataRead < recBuffer.Length)
 				recBuffer = CutArray (recBuffer, dataRead);

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -6614,14 +6614,21 @@ mono_param_get_objects_internal (MonoDomain *domain, MonoMethod *method, MonoCla
 		mono_memory_barrier ();
 		System_Reflection_ParameterInfo_array = klass;
 	}
-	
-	if (!mono_method_signature (method)->param_count)
-		return mono_array_new_specific (mono_class_vtable (domain, System_Reflection_ParameterInfo_array), 0);
 
 	/* Note: the cache is based on the address of the signature into the method
 	 * since we already cache MethodInfos with the method as keys.
 	 */
 	CHECK_OBJECT (MonoArray*, &(method->signature), refclass);
+
+	if (!mono_method_signature (method)->param_count)
+	{
+		res = mono_array_new_specific (mono_class_vtable (domain, System_Reflection_ParameterInfo_array), 0);
+
+		CACHE_OBJECT (MonoArray *, &(method->signature), res, refclass);
+
+		// note the CACHE_OBJECT macro above actually has a 'return' call in it, but add an assert for sanity
+		g_assert_not_reached ();
+	}
 
 	sig = mono_method_signature (method);
 	member = mono_method_get_object (domain, method, refclass);


### PR DESCRIPTION
* Fix mono AOT code generation for some Linq cases
* Fix GC_approx_sp on gcc 5
* Only allocate in UdpClient::Receive if we have security enabled (case 763848)
* Cache empty parameter array for methods with no parameters to avoid allocating in every call to Method.Invoke on method with no parameters (case 780377)