### PR TITLE
Correct the Tizen build

### DIFF
--- a/external/buildscripts/SDKDownloader.pm
+++ b/external/buildscripts/SDKDownloader.pm
@@ -176,17 +176,20 @@ sub UpdateSDKRepo
 
 	my $parent_rev = "parent";
 
-	# check if we're in a mercurial repo
-	if (system("hg parent --template \"{node}\"") == 0)
+	if (-d $repo_name)
 	{
-		$parent_rev = `hg parent --template "{node}"`;
+		my $cwd = getcwd;
+		chdir($repo_name);
+
+		# check if we're in a mercurial repo
+		if (system("hg parent --template \"{node}\"") == 0)
+		{
+			$parent_rev = `hg parent --template "{node}"`;
+		}
+		# else we'll just pull every time
+
+		chdir($cwd);
 	}
-	# check if we're in a git repo
-	elsif (system("git rev-parse HEAD") == 0)
-	{
-		$parent_rev = `git rev-parse HEAD`;
-	}
-	# else we'll just pull every time
 
 	my $old_rev = "";
 


### PR DESCRIPTION
Change the SDKDownloader.pm script
* Remove the check for a git repo, as we are always in the Mono git
repo, and never an SDK git repo. All of the SDKs we use this for now
are in Mercurial.
*  Make the Mercurial parent revision check actually work by changing
to the SDK repo directory.