### PR TITLE
Register and unregister function table callbacks at the code chunk level

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1480,6 +1480,8 @@ MONO_GET_RUNTIME_FUNCTION_CALLBACK ( DWORD64 ControlPc, IN PVOID Context )
 	
 	targetinfo = (PMonoUnwindInfo)ALIGN_TO (pos, 8);
 
+	targetinfo->runtimeFunction.BeginAddress = ((DWORD64)ji->code_start) - ((DWORD64)Context);
+	targetinfo->runtimeFunction.EndAddress = pos - ((DWORD64)Context);
 	targetinfo->runtimeFunction.UnwindData = ((DWORD64)&targetinfo->unwindInfo) - ((DWORD64)Context);
 
 	return &targetinfo->runtimeFunction;
@@ -1511,8 +1513,6 @@ mono_arch_unwindinfo_install_unwind_info (gpointer* monoui, gpointer code, guint
 
 	g_free (unwindinfo);
 	*monoui = 0;
-
-	RtlInstallFunctionTableCallback (((DWORD64)code) | 0x3, (DWORD64)code, code_size, MONO_GET_RUNTIME_FUNCTION_CALLBACK, code, NULL);
 }
 
 #endif

--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -78,7 +78,7 @@ struct _MonoCodeManager {
 
 #define ALIGN_INT(val,alignment) (((val) + (alignment - 1)) & ~(alignment - 1))
 
-#ifndef MONO_ARCH_HAVE_UNWIND_TABLE && (defined(__ia64__) || defined(__x86_64__)) && PLATFORM_WIN32
+#if !defined(MONO_ARCH_HAVE_UNWIND_TABLE) && (defined(__ia64__) || defined(__x86_64__)) && PLATFORM_WIN32
 #define MONO_ARCH_HAVE_UNWIND_TABLE 1
 #endif
 


### PR DESCRIPTION
Windows x64 only: Stack unwinding information for SEH is provided to
Windows via a callback function. Currently we install this callback for
every JITted function individually, at the same time as we calculate the
unwind information. Aside from this being inefficient, we also never
unregister the callback - meaning that after a domain reload, Windows
may ask us to provide unwind information for code that does not belong
to us, but just happens to have been loaded into addresses we used to
own (case 809003).

This commit changes the registration to be done at the code-chunk level
instead, such that we register the callback once per chunk, and also
unregister it again when the chunk is freed.

The unwind information itself is still calculated exactly as before and
stored in the same location (following the generated code itself). The
RUNTIME_FUNCTION structure is also stored in the same place, but because
it stores addresses relative to the one in the function table (which is
now the start of the entire code chunk, rather than the start of the
specific function being unwound), the members are updated accordingly.
In principle this could be done only when the function is first JITted,
but looking up the page to use would add a cost to the JIT of every
function, while this way we only add a much smaller cost to the specific
functions being unwound.