### PR TITLE
Export mono_debug_domain_create, unload (as with vanilla)

### DIFF
--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -242,6 +242,8 @@ mono_custom_attrs_has_attr
 mono_debug_add_method
 mono_debug_cleanup
 mono_debug_close_mono_symbol_file
+mono_debug_domain_create
+mono_debug_domain_unload
 mono_debug_find_method
 mono_debug_free_source_location
 mono_debug_init


### PR DESCRIPTION
Follow-up to #395.

This change-set doesn't expose `mono_debug_enabled`, which doesn't exist.  I'm sorry for breaking the build with my previous PR.

----

The symbols are public on non-Windows platforms and are exported on Windows in vanilla mono: https://github.com/mono/mono/blob/master/msvc/mono.def#L200

Making the symbols public would remove the need for any address hackery and offset guessing on Windows when trying to access it:
```csharp
    // REPLACE THOSE ADDRESSES WITH THOSE IN THE mono.dll SHIPPING WITH YOUR GAME!
    private static long WINDOWS_f_mono_debug_init = 0x0000000180074cd4;
    private static long WINDOWS_f_mono_debug_domain_create = 0x0000000180074ac0;
    // ...
    public static bool/*-if-it-returns-at-all*/ Force(MonoDebugFormat format = MonoDebugFormat.MONO_DEBUG_FORMAT_MONO) {
    // ...
        if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
            Debug.Log("On Windows, mono_debug_domain_create is not public. Creating delegate from pointer.");
            // The function is not in the export table on Windows... although it should
            // See https://github.com/Unity-Technologies/mono/blob/unity-staging/msvc/mono.def
            // Compare with https://github.com/mono/mono/blob/master/msvc/mono.def, where mono_debug_domain_create is exported
            IntPtr m_mono = GetModuleHandle("mono.dll");
            IntPtr p_mono_debug_init = GetProcAddress(m_mono, "mono_debug_init");
            IntPtr p_mono_debug_domain_create = new IntPtr(WINDOWS_f_mono_debug_domain_create - WINDOWS_f_mono_debug_init + (p_mono_debug_init.ToInt64()));
            mono_debug_domain_create = (d_mono_debug_domain_create) Marshal.GetDelegateForFunctionPointer(p_mono_debug_domain_create, typeof(d_mono_debug_domain_create));

        }
```