### PR TITLE
Save and restore r8:r11 on AMD64

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -211,6 +211,7 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 		ctx->R8 = sctx->r8;
 		ctx->R9 = sctx->r9;
 		ctx->R10 = sctx->r10;
+		ctx->R11 = sctx->r11;
 		ctx->R12 = sctx->r12;
 		ctx->R13 = sctx->r13;
 		ctx->R14 = sctx->r14;

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -160,6 +160,10 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 	sctx->rsi = ctx->Rsi;
 	sctx->rdi = ctx->Rdi;
 	sctx->rip = ctx->Rip;
+	sctx->r8 = ctx->R8;
+	sctx->r9 = ctx->R9;
+	sctx->r10 = ctx->R10;
+	sctx->r11 = ctx->R11;
 	sctx->r12 = ctx->R12;
 	sctx->r13 = ctx->R13;
 	sctx->r14 = ctx->R14;
@@ -204,6 +208,9 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 		ctx->Rsi = sctx->rsi;
 		ctx->Rbx = sctx->rbx;
 		ctx->Rbp = sctx->rbp;
+		ctx->R8 = sctx->r8;
+		ctx->R9 = sctx->r9;
+		ctx->R10 = sctx->r10;
 		ctx->R12 = sctx->r12;
 		ctx->R13 = sctx->r13;
 		ctx->R14 = sctx->r14;
@@ -289,9 +296,9 @@ mono_arch_get_restore_context_full (guint32 *code_size, MonoJumpInfo **ji, gbool
 	amd64_mov_reg_membase (code, AMD64_RBP, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, rbp), 8);
 	amd64_mov_reg_membase (code, AMD64_RSI, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, rsi), 8);
 	amd64_mov_reg_membase (code, AMD64_RDI, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, rdi), 8);
-	//amd64_mov_reg_membase (code, AMD64_R8, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r8), 8);
-	//amd64_mov_reg_membase (code, AMD64_R9, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r9), 8);
-	//amd64_mov_reg_membase (code, AMD64_R10, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r10), 8);
+	amd64_mov_reg_membase (code, AMD64_R8, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r8), 8);
+	amd64_mov_reg_membase (code, AMD64_R9, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r9), 8);
+	amd64_mov_reg_membase (code, AMD64_R10, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r10), 8);
 	amd64_mov_reg_membase (code, AMD64_R12, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r12), 8);
 	amd64_mov_reg_membase (code, AMD64_R13, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r13), 8);
 	amd64_mov_reg_membase (code, AMD64_R14, AMD64_R11,  G_STRUCT_OFFSET (MonoContext, r14), 8);
@@ -935,6 +942,10 @@ mono_arch_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	mctx->rsi = ctx->rsi;
 	mctx->rdi = ctx->rdi;
 	mctx->rip = ctx->rip;
+	mctx->r8 = ctx->r8;
+	mctx->r9 = ctx->r9;
+	mctx->r10 = ctx->r10;
+	mctx->r11 = ctx->r11;
 	mctx->r12 = ctx->r12;
 	mctx->r13 = ctx->r13;
 	mctx->r14 = ctx->r14;
@@ -991,6 +1002,10 @@ mono_arch_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 	ctx->rsi = mctx->rsi;
 	ctx->rdi = mctx->rdi;
 	ctx->rip = mctx->rip;
+	ctx->r8 = mctx->r8;
+	ctx->r9 = mctx->r9;
+	ctx->r10 = mctx->r10;
+	ctx->r11 = mctx->r11;
 	ctx->r12 = mctx->r12;
 	ctx->r13 = mctx->r13;
 	ctx->r14 = mctx->r14;

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -198,6 +198,10 @@ typedef struct {
     guint64 rsi;
 	guint64 rdi;
 	guint64 rip;
+	guint64 r8;
+	guint64 r9;
+	guint64 r10;
+	guint64 r11;
 	guint64 r12;
 	guint64 r13;
 	guint64 r14;


### PR DESCRIPTION
We found that the new C# compiler inserts sequence points in a few
places where the old compiler did not. These additional sequence points
cause the context to be switched more often. Since the third integer
argument for a function call is passed in r8 in the Windows AMD64 ABI,
we found that not preserving r8 across a sequence point could corrupt
the value of that third argument when the debugger is attached.

So this issue has probably existed for some time, but we've just
noticed is now with the new C# compiler and the new sequence points.

The fix here is the preserve r8 (as well as r9, r10, and r11). We may
not need to preserve r10 and r11, since they are not used for function
arguments. However, there seems to be little cost to preserving them as
well, so I've kept them for completeness.

This corrects case 825988, case 828073, and case 816067 in Unity.