### PR TITLE
Two bug fixes

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4415,9 +4415,13 @@ handle_enum:
 	case MONO_TYPE_U8:
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_TYPEDBYREF:
-	case MONO_TYPE_GENERICINST:
 		/* box value types */
 		mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (sig->ret));
+		break;
+	case MONO_TYPE_GENERICINST:
+		/* only box value type generic insts */
+		if (mono_type_generic_inst_is_valuetype (sig->ret))
+			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (sig->ret));
 		break;
 	case MONO_TYPE_STRING:
 	case MONO_TYPE_CLASS:  

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -270,6 +270,9 @@ _mono_debug_init_corlib (MonoDomain *domain)
 void
 mono_debug_open_image_from_memory (MonoImage *image, const guint8 *raw_contents, int size)
 {
+	if (!mono_debug_initialized)
+		return;
+
 	mono_debug_open_image (image, raw_contents, size);
 }
 


### PR DESCRIPTION
- Avoid calling debugger APIs if debugger is not initialized (case 827833)
- Avoid boxing reference type generics as return values in runtime invoke wrappers. Helps to avoid a random memory corruption (case 829757)