### PR TITLE
Update TcpBinaryFrameManager.cs

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TcpBinaryFrameManager.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TcpBinaryFrameManager.cs
@@ -159,9 +159,6 @@ namespace System.ServiceModel.Channels
 			if (length == 0)
 				return empty_bytes;
 
-			if (length > 65536)
-				throw new InvalidOperationException ("The message is too large.");
-
 			byte [] buffer = new byte [length];
 			for (int readSize = 0; readSize < length; )
 				readSize += reader.Read (buffer, readSize, length - readSize);


### PR DESCRIPTION
This hard coded limit prevents you from streaming or sending large strings via WCF web services.  It has been removed (along with other changes).  I haven't compiled or tested this, but this was the best way I knew to get a request in to fix it. :)

This is the latest ReadSizedChunk() implementation which doesn't have the limitation.
There may be other limitations.
Latest Source: https://github.com/mono/mono/blob/ef407901f8fdd9ed8c377dbec8123b5afb932ebb/mcs/class/System.ServiceModel/System.ServiceModel.Channels.NetTcp/TcpBinaryFrameManager.cs
```

public byte [] ReadSizedChunk ()
		{
			lock (read_lock) {

			int length = reader.ReadVariableInt ();
			if (length == 0)
				return empty_bytes;

			byte [] buffer = new byte [length];
			for (int readSize = 0; readSize < length; )
				readSize += reader.Read (buffer, readSize, length - readSize);
			return buffer;

			}
		}
```