### PR TITLE
Enable IPv6 support on Android

### DIFF
--- a/mono/metadata/socket-io.c
+++ b/mono/metadata/socket-io.c
@@ -79,11 +79,6 @@
 #undef AF_INET6
 #endif
 
-#ifdef PLATFORM_ANDROID
-// not yet actually implemented...
-#undef AF_INET6
-#endif
-
 #define LOGDEBUG(...)  
 /* define LOGDEBUG(...) g_message(__VA_ARGS__)  */
 


### PR DESCRIPTION
This change might correct case 847914. We're not sure yet, but it is at least necessary for that bug to be corrected.