### PR TITLE
Fix sizeof(T) in non-gshared code. Fixes #580189.

### DIFF
--- a/mono/mini/iltests.il.in
+++ b/mono/mini/iltests.il.in
@@ -2513,4 +2513,19 @@ OK_2:
 			  ldc.i4.0
 			  ret
     }
+
+	.method public hidebysig static int32 SizeOfT<T>() cil managed
+  	{
+		.maxstack  8
+    
+		sizeof !!0
+    	ret
+  	}
+
+	.method public static default int32 test_1_sizeof_gshared () cil managed {
+	    call   int32 Tests::SizeOfT<int8>()
+		ldc.i4.1
+		ceq
+		ret
+	}
 }

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -10010,7 +10010,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				CHECK_STACK_OVF (1);
 				CHECK_OPSIZE (6);
 				token = read32 (ip + 2);
-				if (mono_metadata_token_table (token) == MONO_TABLE_TYPESPEC && !method->klass->image->dynamic) {
+				if (mono_metadata_token_table (token) == MONO_TABLE_TYPESPEC && !method->klass->image->dynamic && !generic_context) {
 					MonoType *type = mono_type_create_from_typespec (image, token);
 					token = mono_type_size (type, &ialign);
 				} else {


### PR DESCRIPTION
This PR is a backport of a old fix for sizeof(T) for generics.