### PR TITLE
Only allocate 1 empty string instance per AppDomain (case 842382)

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -261,7 +261,11 @@ mono_runtime_init (MonoDomain *domain, MonoThreadStartCB start_cb,
 	mono_type_initialization_init ();
 
 	if (!mono_runtime_get_no_exec ())
+	{
 		create_exceptions (domain);
+
+		mono_string_initialize_empty (domain, mono_defaults.string_class);
+	}
 
 	/* GC init has to happen after thread init */
 	mono_gc_init ();
@@ -467,6 +471,8 @@ mono_domain_create_appdomain_internal (char *friendly_name, MonoAppDomainSetup *
 #endif
 
 	create_exceptions (data);
+
+	mono_string_initialize_empty (data, mono_defaults.string_class);
 
 	return ad;
 }

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -188,6 +188,7 @@ struct _MonoDomain {
 	MonoException      *divide_by_zero_ex;
 	/* typeof (void) */
 	MonoObject         *typeof_void;
+	MonoString         *empty_string;
 	/* 
 	 * The fields between FIRST_GC_TRACKED and LAST_GC_TRACKED are roots, but
 	 * not object references.

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1609,8 +1609,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	_mono_debug_init_corlib (domain);
 
-	mono_string_initialize_empty (domain, mono_defaults.string_class);
-
 	return domain;
 }
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1609,6 +1609,8 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	_mono_debug_init_corlib (domain);
 
+	mono_string_initialize_empty (domain, mono_defaults.string_class);
+
 	return domain;
 }
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1446,6 +1446,9 @@ mono_method_clear_object (MonoDomain *domain, MonoMethod *method) MONO_INTERNAL;
 void
 mono_class_compute_gc_descriptor (MonoClass *class) MONO_INTERNAL;
 
+void
+mono_string_initialize_empty (MonoDomain *domain, MonoClass *stringClass);
+
 char *
 mono_string_to_utf8_checked (MonoString *s, MonoError *error) MONO_INTERNAL;
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4441,6 +4441,18 @@ mono_array_new_specific (MonoVTable *vtable, mono_array_size_t n)
 	return ao;
 }
 
+void
+mono_string_initialize_empty(MonoDomain *domain, MonoClass *stringClass)
+{
+	MonoVTable *vtable;
+
+	vtable = mono_class_vtable (domain, stringClass);
+	g_assert (vtable);
+	domain->empty_string = mono_object_allocate_ptrfree (sizeof (MonoString) + 2, vtable);
+	domain->empty_string->length = 0;
+	domain->empty_string->chars [0] = 0;
+}
+
 /**
  * mono_string_new_utf16:
  * @text: a pointer to an utf16 string
@@ -4452,7 +4464,6 @@ MonoString *
 mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
 {
 	MonoString *s;
-	
 	s = mono_string_new_size (domain, len);
 	g_assert (s != NULL);
 
@@ -4471,27 +4482,32 @@ mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
 MonoString *
 mono_string_new_size (MonoDomain *domain, gint32 len)
 {
-	MonoString *s;
-	MonoVTable *vtable;
-	size_t size = (sizeof (MonoString) + ((len + 1) * 2));
+	if (len == 0) {
+		g_assert (domain->empty_string);
+		return domain->empty_string;
+	} else {
+		MonoString *s;
+		MonoVTable *vtable;
+		size_t size = (sizeof (MonoString) + ((len + 1) * 2));
 
-	/* overflow ? can't fit it, can't allocate it! */
-	if (len > size)
-		mono_gc_out_of_memory (-1);
+		/* overflow ? can't fit it, can't allocate it! */
+		if (len > size)
+			mono_gc_out_of_memory (-1);
 
-	vtable = mono_class_vtable (domain, mono_defaults.string_class);
-	g_assert (vtable);
+		vtable = mono_class_vtable (domain, mono_defaults.string_class);
+		g_assert (vtable);
 
-	s = mono_object_allocate_ptrfree (size, vtable);
+		s = mono_object_allocate_ptrfree (size, vtable);
 
-	s->length = len;
-#if NEED_TO_ZERO_PTRFREE
-	s->chars [len] = 0;
-#endif
-	if (G_UNLIKELY (profile_allocs))
-		mono_profiler_allocation ((MonoObject*)s, mono_defaults.string_class);
+		s->length = len;
+	#if NEED_TO_ZERO_PTRFREE
+		s->chars [len] = 0;
+	#endif
+		if (G_UNLIKELY (profile_allocs))
+			mono_profiler_allocation ((MonoObject*)s, mono_defaults.string_class);
 
-	return s;
+		return s;
+	}
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4445,12 +4445,19 @@ void
 mono_string_initialize_empty(MonoDomain *domain, MonoClass *stringClass)
 {
 	MonoVTable *vtable;
-
+	g_assert(stringClass);
 	vtable = mono_class_vtable (domain, stringClass);
 	g_assert (vtable);
+	g_assert (domain->empty_string == NULL);
 	domain->empty_string = mono_object_allocate_ptrfree (sizeof (MonoString) + 2, vtable);
 	domain->empty_string->length = 0;
+
+#if NEED_TO_ZERO_PTRFREE
 	domain->empty_string->chars [0] = 0;
+#endif
+
+	if (G_UNLIKELY (profile_allocs))
+		mono_profiler_allocation ((MonoObject*)domain->empty_string, stringClass);
 }
 
 /**
@@ -4500,9 +4507,9 @@ mono_string_new_size (MonoDomain *domain, gint32 len)
 		s = mono_object_allocate_ptrfree (size, vtable);
 
 		s->length = len;
-	#if NEED_TO_ZERO_PTRFREE
+#if NEED_TO_ZERO_PTRFREE
 		s->chars [len] = 0;
-	#endif
+#endif
 		if (G_UNLIKELY (profile_allocs))
 			mono_profiler_allocation ((MonoObject*)s, mono_defaults.string_class);
 


### PR DESCRIPTION
The class library code already has logic to reuse the same empty string instance, however, these checks don't help from the embedding api.  Our serialization api creates strings via the embedding api, which resulted in an allocation per empty string of all serialized fields.