### PR TITLE
Only allocate 1 empty string instance per AppDomain (case 842382)

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -187,6 +187,7 @@ create_domain_objects (MonoDomain *domain)
 	MonoString *empty_str = mono_string_intern_checked (mono_string_new (domain, ""), &error);
 	mono_error_assert_ok (&error);
 	mono_field_static_set_value (string_vt, string_empty_fld, empty_str);
+	domain->empty_string = empty_str;
 
 	/*
 	 * Create an instance early since we can't do it when there is no memory.

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -315,6 +315,7 @@ struct _MonoDomain {
 	MonoObject         *ephemeron_tombstone;
 	/* new MonoType [0] */
 	MonoArray          *empty_types;
+	MonoString         *empty_string;
 	/* 
 	 * The fields between FIRST_GC_TRACKED and LAST_GC_TRACKED are roots, but
 	 * not object references.

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6073,32 +6073,36 @@ mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoString *s;
-	MonoVTable *vtable;
-	size_t size;
+	if (len == 0 && domain->empty_string != NULL) {
+		return domain->empty_string;
+	} else {
+		MonoString *s;
+		MonoVTable *vtable;
+		size_t size;
 
-	mono_error_init (error);
+		mono_error_init (error);
 
-	/* check for overflow */
-	if (len < 0 || len > ((SIZE_MAX - G_STRUCT_OFFSET (MonoString, chars) - 8) / 2)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %i bytes", -1);
-		return NULL;
+		/* check for overflow */
+		if (len < 0 || len > ((SIZE_MAX - G_STRUCT_OFFSET (MonoString, chars) - 8) / 2)) {
+			mono_error_set_out_of_memory (error, "Could not allocate %i bytes", -1);
+			return NULL;
+		}
+
+		size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)len + 1) * 2));
+		g_assert (size > 0);
+
+		vtable = mono_class_vtable (domain, mono_defaults.string_class);
+		g_assert (vtable);
+
+		s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
+
+		if (G_UNLIKELY (!s)) {
+			mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", size);
+			return NULL;
+		}
+
+		return s;
 	}
-
-	size = (G_STRUCT_OFFSET (MonoString, chars) + (((size_t)len + 1) * 2));
-	g_assert (size > 0);
-
-	vtable = mono_class_vtable (domain, mono_defaults.string_class);
-	g_assert (vtable);
-
-	s = (MonoString *)mono_gc_alloc_string (vtable, size, len);
-
-	if (G_UNLIKELY (!s)) {
-		mono_error_set_out_of_memory (error, "Could not allocate %zd bytes", size);
-		return NULL;
-	}
-
-	return s;
 }
 
 /**


### PR DESCRIPTION
The class library code already has logic to reuse the same empty string instance, however, these checks don't help from the embedding api. 