### PR TITLE
Timer collision fix

### DIFF
--- a/mcs/class/corlib/System.Threading/Timer.cs
+++ b/mcs/class/corlib/System.Threading/Timer.cs
@@ -182,7 +182,7 @@ namespace System.Threading
 					return 1;
 				long result = tx.next_run - ty.next_run;
 				if (result == 0)
-					return x == y ? 0 : -1;
+					return 0;
 				return result > 0 ? 1 : -1;
 			}
 		}


### PR DESCRIPTION
I updated the TimerComparer used by the Timer and Scheduler to rely solely on the next run time value, as opposed to also checking references.

By comparing references and returning a mismatch (when the timer's next run time did match), the code was allowing the SortedList to corrupt through improper insertion and sorting.  This happens under rare conditions when a two timers are scheduled for the same tick.  Once a 2nd timer tries to get scheduled for the same tick, the TimerComparer says they are different (because the Timer reference is different) and two timers are inserted for the same tick, which the Scheduler and the SortedList do not handle well.

When inserting with the fix, there is already some code which handles finding a next run time at the next unique tick if the TimerComparer returns a match.

Tested with repro project locally and with client project.