### PR TITLE
Revert "Fix HasExited for non-child process"

### DIFF
--- a/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/Process.cs
+++ b/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/Process.cs
@@ -217,10 +217,6 @@ namespace System.Diagnostics {
         public int ExitCode {
             get {
                 EnsureState(State.Exited);
-#if MONO
-                if (exitCode == -1)
-                    throw new InvalidOperationException ("Cannot get the exit code from a non-child process on Unix");
-#endif
                 return exitCode;
             }
           }
@@ -279,9 +275,6 @@ namespace System.Diagnostics {
                                 }
                                 if (signaled) 
                                 {
-                                    /* If it's a non-child process, it's impossible to get its exit code on
-                                     * Unix. We don't throw here, but GetExitCodeProcess (in the io-layer)
-                                     * will set exitCode to -1, and we will throw if we try to call ExitCode */
                                     if (!NativeMethods.GetExitCodeProcess(handle, out exitCode))                               
                                         throw new Win32Exception();
                                 


### PR DESCRIPTION
This reverts commit 63eb8475d8e5e65b47df2f074ac9b85b1ae718e4.

On windows `-1` is a valid and commonly used `ExitCode` and should not throw any exceptions. It is also the current default exit code for any process killed through `Process.Kill`. 