### PR TITLE
Allow -1 as exit code on windows

### DIFF
--- a/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/Process.cs
+++ b/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/Process.cs
@@ -218,7 +218,7 @@ namespace System.Diagnostics {
             get {
                 EnsureState(State.Exited);
 #if MONO
-                if (exitCode == -1)
+                if (exitCode == -1 && !Environment.IsRunningOnWindows)
                     throw new InvalidOperationException ("Cannot get the exit code from a non-child process on Unix");
 #endif
                 return exitCode;


### PR DESCRIPTION
On windows -1 is a valid and commonly used ExitCode and should not throw any exceptions. It is also the current default exit code for any process killed through Process.Kill.

This is a follow up to PR #447 
