### PR TITLE
libgc fixes from legacy Mono

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,9 +197,6 @@ case "$host" in
 		with_tls=pthread
 		with_sigaltstack=no
 		with_static_mono=no
-
-		# Android doesn't support boehm, as it's missing <link.h>
-		support_boehm=no
 		with_gc=sgen
 
 		# isinf(3) requires -lm; see isinf check below

--- a/libgc/allchblk.c
+++ b/libgc/allchblk.c
@@ -579,8 +579,8 @@ int n;
     register hdr * hhdr;		/* Header corr. to hbp */
     register struct hblk *thishbp;
     register hdr * thishdr;		/* Header corr. to hbp */
-    signed_word size_needed;    /* number of bytes in requested objects */
-    signed_word size_avail;	/* bytes available in this block	*/
+    size_t size_needed;    /* number of bytes in requested objects */
+    size_t size_avail;	/* bytes available in this block	*/
 
     size_needed = HBLKSIZE * OBJ_SZ_TO_BLOCKS(sz);
 
@@ -619,12 +619,12 @@ int n;
 	    /* This prevents us from disassembling a single large block */
 	    /* to get tiny blocks.					*/
 	    {
-	      signed_word next_size;
+	      size_t next_size;
 	      
 	      thishbp = hhdr -> hb_next;
 	      if (thishbp != 0) {
 		GET_HDR(thishbp, thishdr);
-	        next_size = (signed_word)(thishdr -> hb_sz);
+	        next_size = (size_t)(thishdr -> hb_sz);
 	        if (next_size < size_avail
 	          && next_size >= size_needed
 	          && !GC_is_black_listed(thishbp, (word)size_needed)) {
@@ -668,9 +668,9 @@ int n;
 		      /* We must now allocate thishbp, since it may	*/
 		      /* be on the wrong free list.			*/
 		}
-	      } else if (size_needed > (signed_word)BL_LIMIT
+	      } else if (size_needed > (size_t)BL_LIMIT
 	                 && orig_avail - size_needed
-			    > (signed_word)BL_LIMIT) {
+			    > (size_t)BL_LIMIT) {
 	        /* Punt, since anything else risks unreasonable heap growth. */
 		if (++GC_large_alloc_warn_suppressed
 		    >= GC_large_alloc_warn_interval) {

--- a/libgc/include/gc.h
+++ b/libgc/include/gc.h
@@ -1011,6 +1011,8 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
 
 #endif /* defined(GC_WIN32_THREADS)  && !cygwin */
 
+#define UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS 1
+
  /*
   * Fully portable code should call GC_INIT() from the main program
   * before making any other GC_ calls.  On most platforms this is a

--- a/libgc/include/private/gc_priv.h
+++ b/libgc/include/private/gc_priv.h
@@ -799,14 +799,14 @@ struct exclusion {
 struct roots {
 	ptr_t r_start;
 	ptr_t r_end;
-#	if !defined(MSWIN32) && !defined(MSWINCE)
+#	if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 	  struct roots * r_next;
 #	endif
 	GC_bool r_tmp;
 	  	/* Delete before registering new dynamic libraries */
 };
 
-#if !defined(MSWIN32) && !defined(MSWINCE)
+#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
     /* Size of hash table index to roots.	*/
 #   define LOG_RT_SIZE 6
 #   define RT_SIZE (1 << LOG_RT_SIZE) /* Power of 2, may be != MAX_ROOT_SETS */
@@ -1000,7 +1000,7 @@ struct _GC_arrays {
     		/* Commited lengths of memory regions obtained from kernel. */
 # endif
   struct roots _static_roots[MAX_ROOT_SETS];
-# if !defined(MSWIN32) && !defined(MSWINCE)
+# if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
     struct roots * _root_index[RT_SIZE];
 # endif
   struct exclusion _excl_table[MAX_EXCLUSIONS];

--- a/libgc/include/private/gc_priv.h
+++ b/libgc/include/private/gc_priv.h
@@ -799,14 +799,14 @@ struct exclusion {
 struct roots {
 	ptr_t r_start;
 	ptr_t r_end;
-#	if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+#	if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 	  struct roots * r_next;
 #	endif
 	GC_bool r_tmp;
 	  	/* Delete before registering new dynamic libraries */
 };
 
-#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+#if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
     /* Size of hash table index to roots.	*/
 #   define LOG_RT_SIZE 6
 #   define RT_SIZE (1 << LOG_RT_SIZE) /* Power of 2, may be != MAX_ROOT_SETS */
@@ -1000,7 +1000,7 @@ struct _GC_arrays {
     		/* Commited lengths of memory regions obtained from kernel. */
 # endif
   struct roots _static_roots[MAX_ROOT_SETS];
-# if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+# if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
     struct roots * _root_index[RT_SIZE];
 # endif
   struct exclusion _excl_table[MAX_EXCLUSIONS];

--- a/libgc/include/private/gcconfig.h
+++ b/libgc/include/private/gcconfig.h
@@ -2537,4 +2537,10 @@
 #   define __STDC__ 0
 #endif
 
+#if defined(PLATFORM_ANDROID)
+# ifdef DYNAMIC_LOADING	// we don't need to scan the static segments of dynamic libraries
+	#undef DYNAMIC_LOADING
+# endif
+#endif
+
 # endif /* GCCONFIG_H */

--- a/libgc/include/private/gcconfig.h
+++ b/libgc/include/private/gcconfig.h
@@ -2538,6 +2538,7 @@
 #endif
 
 #if defined(PLATFORM_ANDROID)
+# define DONT_REGISTER_DATA_SEGMENTS 1
 # ifdef DYNAMIC_LOADING	// we don't need to scan the static segments of dynamic libraries
 	#undef DYNAMIC_LOADING
 # endif

--- a/libgc/include/private/gcconfig.h
+++ b/libgc/include/private/gcconfig.h
@@ -241,6 +241,9 @@
 # if defined(LINUX) && (defined(i386) || defined(__i386__))
 #    define I386
 #    define mach_type_known
+     /* Unity: Don't scan data segments */
+#    define GC_DONT_REGISTER_MAIN_STATIC_DATA
+#    define LARGE_CONFIG 1
 # endif
 # if defined(OPENBSD) && defined(__amd64__)
 #    define X86_64
@@ -249,6 +252,9 @@
 # if defined(LINUX) && defined(__x86_64__)
 #    define X86_64
 #    define mach_type_known
+     /* Unity: Don't scan data segments */
+#    define GC_DONT_REGISTER_MAIN_STATIC_DATA
+#    define LARGE_CONFIG 1
 # endif
 # if defined(LINUX) && (defined(__ia64__) || defined(__ia64))
 #    define IA64
@@ -319,6 +325,9 @@
 # endif
 # ifdef DARWIN
 #    include "TargetConditionals.h"
+     /* Unity: Don't scan data segments */
+#    define GC_DONT_REGISTER_MAIN_STATIC_DATA
+#    define LARGE_CONFIG 1
 #   if defined(__ppc__)  || defined(__ppc64__)
 #    define POWERPC
 #    define mach_type_known
@@ -428,6 +437,7 @@
 # else
 #   if (defined(_MSDOS) || defined(_MSC_VER)) && (_M_IX86 >= 300) \
         || defined(_WIN32) && !defined(__CYGWIN32__) && !defined(__CYGWIN__)
+#     define LARGE_CONFIG 1
 #     if defined(__LP64__) || defined(_WIN64)
 #	define X86_64
 #     else

--- a/libgc/malloc.c
+++ b/libgc/malloc.c
@@ -63,7 +63,7 @@ unsigned flags;
     if (h == 0) {
 	result = 0;
     } else {
-	int total_bytes = n_blocks * HBLKSIZE;
+	size_t total_bytes = n_blocks * HBLKSIZE;
 	if (n_blocks > 1) {
 	    GC_large_allocd_bytes += total_bytes;
 	    if (GC_large_allocd_bytes > GC_max_large_allocd_bytes)

--- a/libgc/mark_rts.c
+++ b/libgc/mark_rts.c
@@ -245,7 +245,7 @@ GC_bool tmp;
     GC_static_roots[n_root_sets].r_start = (ptr_t)b;
     GC_static_roots[n_root_sets].r_end = (ptr_t)e;
     GC_static_roots[n_root_sets].r_tmp = tmp;
-#   if !defined(MSWIN32) && !defined(MSWINCE)
+#   if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
       GC_static_roots[n_root_sets].r_next = 0;
 #   endif
     add_roots_to_index(GC_static_roots + n_root_sets);
@@ -264,7 +264,7 @@ void GC_clear_roots GC_PROTO((void))
     roots_were_cleared = TRUE;
     n_root_sets = 0;
     GC_root_size = 0;
-#   if !defined(MSWIN32) && !defined(MSWINCE)
+#   if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
     {
     	register int i;
     	
@@ -309,7 +309,7 @@ void GC_remove_tmp_roots()
     	    i++;
     }
     }
-    #if !defined(MSWIN32) && !defined(MSWINCE)
+    #if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
     GC_rebuild_root_index();
     #endif
 }

--- a/libgc/mark_rts.c
+++ b/libgc/mark_rts.c
@@ -32,6 +32,7 @@ struct roots {
 struct roots GC_static_roots[MAX_ROOT_SETS];
 */
 
+
 int GC_no_dls = 0;	/* Register dynamic library data segments.	*/
 
 static int n_root_sets = 0;
@@ -87,7 +88,7 @@ ptr_t p;
     return(FALSE);
 }
 
-#if !defined(MSWIN32) && !defined(MSWINCE)
+#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 /* 
 #   define LOG_RT_SIZE 6
 #   define RT_SIZE (1 << LOG_RT_SIZE)  -- Power of 2, may be != MAX_ROOT_SETS
@@ -175,7 +176,7 @@ GC_bool tmp;
 {
     struct roots * old;
     
-#   if defined(MSWIN32) || defined(MSWINCE)
+#   if defined(MSWIN32) || defined(MSWINCE) && !UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
       /* Spend the time to ensure that there are no overlapping	*/
       /* or adjacent intervals.					*/
       /* This could be done faster with e.g. a			*/
@@ -222,7 +223,7 @@ GC_bool tmp;
                   GC_root_size -= (other -> r_end - other -> r_start);
                   other -> r_start = GC_static_roots[n_root_sets-1].r_start;
                   other -> r_end = GC_static_roots[n_root_sets-1].r_end;
-                                  n_root_sets--;
+                  n_root_sets--;
               }
             }
           return;
@@ -285,7 +286,7 @@ int i;
     n_root_sets--;
 }
 
-#if !defined(MSWIN32) && !defined(MSWINCE)
+#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 static void GC_rebuild_root_index()
 {
     register int i;
@@ -313,7 +314,7 @@ void GC_remove_tmp_roots()
     #endif
 }
 
-#if !defined(MSWIN32) && !defined(MSWINCE)
+#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 void GC_remove_roots(b, e)
 char * b; char * e;
 {

--- a/libgc/mark_rts.c
+++ b/libgc/mark_rts.c
@@ -88,7 +88,7 @@ ptr_t p;
     return(FALSE);
 }
 
-#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+#if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 /* 
 #   define LOG_RT_SIZE 6
 #   define RT_SIZE (1 << LOG_RT_SIZE)  -- Power of 2, may be != MAX_ROOT_SETS
@@ -176,7 +176,7 @@ GC_bool tmp;
 {
     struct roots * old;
     
-#   if defined(MSWIN32) || defined(MSWINCE) && !UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+#   if (defined(MSWIN32) || defined(MSWINCE)) && !UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
       /* Spend the time to ensure that there are no overlapping	*/
       /* or adjacent intervals.					*/
       /* This could be done faster with e.g. a			*/
@@ -286,7 +286,7 @@ int i;
     n_root_sets--;
 }
 
-#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+#if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 static void GC_rebuild_root_index()
 {
     register int i;
@@ -314,7 +314,7 @@ void GC_remove_tmp_roots()
     #endif
 }
 
-#if !defined(MSWIN32) && !defined(MSWINCE) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
+#if (!defined(MSWIN32) && !defined(MSWINCE)) || UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS
 void GC_remove_roots(b, e)
 char * b; char * e;
 {

--- a/libgc/os_dep.c
+++ b/libgc/os_dep.c
@@ -1211,6 +1211,16 @@ ptr_t GC_get_stack_base()
  * Called with allocator lock held.
  */
 
+
+
+# if defined(DONT_REGISTER_DATA_SEGMENTS)
+
+void GC_register_data_segments()
+{
+}
+
+# else /* !DONT_REGISTER_DATA_SEGMENTS */
+
 # ifdef OS2
 
 void GC_register_data_segments()
@@ -1655,6 +1665,7 @@ void GC_register_data_segments()
 # endif  /* ! AMIGA */
 # endif  /* ! MSWIN32 && ! MSWINCE*/
 # endif  /* ! OS2 */
+# endif  /* ! DONT_REGISTER_DATA_SEGMENTS */
 
 /*
  * Auxiliary routines for obtaining memory from OS.

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -529,11 +529,8 @@ mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource s
 void
 mono_gc_deregister_root (char* addr)
 {
-#ifndef HOST_WIN32
-	/* FIXME: libgc doesn't define this work win32 for some reason */
 	/* FIXME: No size info */
 	GC_remove_roots (addr, addr + sizeof (gpointer) + 1);
-#endif
 }
 
 static void

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -529,8 +529,19 @@ mono_gc_register_root (char *start, size_t size, void *descr, MonoGCRootSource s
 void
 mono_gc_deregister_root (char* addr)
 {
+#if !defined(HOST_WIN32) || (UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS == 1)
 	/* FIXME: No size info */
 	GC_remove_roots (addr, addr + sizeof (gpointer) + 1);
+#endif
+}
+
+void
+mono_gc_deregister_root_size (char* addr, size_t size)
+{
+#if !defined(HOST_WIN32) || (UNITY_USE_REASONABLE_LOOKING_GCROOTS_CODEPATH_ON_WINDOWS == 1)
+	/* FIXME: libgc doesn't define this on win32 for some reason */
+	GC_remove_roots (addr, addr + size + 1);
+#endif
 }
 
 static void

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1269,7 +1269,7 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 
 	domain->setup = NULL;
 
-	mono_gc_deregister_root ((char*)&(domain->MONO_DOMAIN_FIRST_GC_TRACKED));
+	mono_gc_deregister_root_size ((char*)&(domain->MONO_DOMAIN_FIRST_GC_TRACKED), G_STRUCT_OFFSET (MonoDomain, MONO_DOMAIN_LAST_GC_TRACKED) - G_STRUCT_OFFSET (MonoDomain, MONO_DOMAIN_FIRST_GC_TRACKED));
 
 	/* FIXME: anything else required ? */
 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -24,7 +24,7 @@
 /* Register a memory area as a conservatively scanned GC root */
 #define MONO_GC_REGISTER_ROOT_PINNING(x,src,msg) mono_gc_register_root ((char*)&(x), sizeof(x), MONO_GC_DESCRIPTOR_NULL, (src), (msg))
 
-#define MONO_GC_UNREGISTER_ROOT(x) mono_gc_deregister_root ((char*)&(x))
+#define MONO_GC_UNREGISTER_ROOT(x) mono_gc_deregister_root_size ((char*)&(x), sizeof(x))
 
 /*
  * Register a memory location as a root pointing to memory allocated using
@@ -155,6 +155,7 @@ void  mono_gc_register_for_finalization (MonoObject *obj, void *user_data);
 void  mono_gc_add_memory_pressure (gint64 value);
 MONO_API int   mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, const char *msg);
 void  mono_gc_deregister_root (char* addr);
+void  mono_gc_deregister_root_size (char* addr, size_t size);
 void  mono_gc_finalize_domain (MonoDomain *domain);
 void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2489,6 +2489,12 @@ mono_gc_deregister_root (char* addr)
 	sgen_deregister_root (addr);
 }
 
+void
+mono_gc_deregister_root_size (char* addr, size_t size)
+{
+	sgen_deregister_root (addr);
+}
+
 /*
  * PThreads
  */


### PR DESCRIPTION
A few fixes for Windows, plus changes to Mono to allow building Boehm on iOS and Android.