### PR TITLE
Unity staging memory tracking

### DIFF
--- a/unity/unity_liveness.c
+++ b/unity/unity_liveness.c
@@ -125,7 +125,7 @@ void array_safe_grow(LivenessState* state, custom_growable_array* array)
 	mono_unity_liveness_start_gc_world(state);
 
 	array_grow(array);
-	GC_stop_world_external ();
+	mono_unity_liveness_stop_gc_world(state);
 	for (i = 0; i < state->all_objects->len; i++)
 	{
 		MonoObject* object = array_at_index(state->all_objects,i);

--- a/unity/unity_liveness.c
+++ b/unity/unity_liveness.c
@@ -70,7 +70,7 @@ struct _LivenessState
 	void*               callback_userdata;
 
 	register_object_callback filter_callback;
-	WorldStateChanged        onWorldStartCallback;
+	WorldStateChanged        onWorldStartCallback ;
 	WorldStateChanged        onWorldStopCallback;
 };
 
@@ -122,7 +122,8 @@ void array_safe_grow(LivenessState* state, custom_growable_array* array)
 		MonoObject* object = array_at_index(state->all_objects,i);
 		CLEAR_OBJ(object);
 	}
-	GC_start_world_external ();
+	mono_unity_liveness_start_gc_world(state);
+
 	array_grow(array);
 	GC_stop_world_external ();
 	for (i = 0; i < state->all_objects->len; i++)

--- a/unity/unity_liveness.c
+++ b/unity/unity_liveness.c
@@ -440,8 +440,8 @@ void mono_unity_liveness_add_object_callback(gpointer* objs, gint count, void* a
  *
  * Returns a gchandle to an array of MonoObject* that are reachable from the static roots
  * in the current domain and derive from type retrieved from @filter_handle (if not NULL).
- *
-gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_handle)
+ */
+gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_handle, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback)
 {
 	int i = 0;
 	MonoArray *res = NULL;
@@ -456,7 +456,7 @@ gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_ha
 	objects = g_ptr_array_sized_new(1000);
 	objects->len = 0;
 
-	liveness_state = mono_unity_liveness_calculation_begin (filter, 1000, mono_unity_liveness_add_object_callback, (void*)objects);
+	liveness_state = mono_unity_liveness_calculation_begin (filter, 1000, mono_unity_liveness_add_object_callback, (void*)objects, onWorldStartCallback, onWorldStopCallback);
 
 	mono_unity_liveness_calculation_from_statics (liveness_state);
 
@@ -473,7 +473,7 @@ gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_ha
 	return (gpointer)mono_gchandle_new ((MonoObject*)res, FALSE);
 
 }
-*/
+
 /**
  * mono_unity_liveness_calculation_from_root:
  *


### PR DESCRIPTION
Changes necessary to enable memory tracking using Unity's allocator

**Do Not Merge**
Merging this will break the API between Mono and Unity. We need to wait until the Unity side changes have been PR'd and then merge for minimal friction.