### PR TITLE
Correct a problem with deep profiling in Unity

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5661,7 +5661,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	gboolean args_clobbered = FALSE;
 	gboolean trace = FALSE;
 
-	cfg->code_size =  MAX (((MonoMethodNormal *)method)->header->code_size * 4, 10240);
+	cfg->code_size =  MAX (((MonoMethodNormal *)method)->header->code_size * 4, 10640);
 
 	code = cfg->native_code = g_malloc (cfg->code_size);
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3185,14 +3185,6 @@ mono_codegen (MonoCompile *cfg)
 
 		if (bb == cfg->bb_exit) {
 			cfg->epilog_begin = cfg->code_len;
-
-			if (cfg->prof_options & MONO_PROFILE_ENTER_LEAVE) {
-				code = cfg->native_code + cfg->code_len;
-				code = mono_arch_instrument_epilog (cfg, mono_profiler_method_leave, code, FALSE);
-				cfg->code_len = code - cfg->native_code;
-				g_assert (cfg->code_len < cfg->code_size);
-			}
-
 			mono_arch_emit_epilog (cfg);
 		}
 	}

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3185,6 +3185,14 @@ mono_codegen (MonoCompile *cfg)
 
 		if (bb == cfg->bb_exit) {
 			cfg->epilog_begin = cfg->code_len;
+
+			if (cfg->prof_options & MONO_PROFILE_ENTER_LEAVE) {
+				code = cfg->native_code + cfg->code_len;
+				code = mono_arch_instrument_epilog (cfg, mono_profiler_method_leave, code, FALSE);
+				cfg->code_len = code - cfg->native_code;
+				g_assert (cfg->code_len < cfg->code_size);
+			}
+
 			mono_arch_emit_epilog (cfg);
 		}
 	}


### PR DESCRIPTION
This change corrects case 878859 in Unity. It prevents the editor code from hitting an assert when deep profiling is enabled in Unity 5.5 and later.