### PR TITLE
Back port one C# compiler fixe to 5.6

### DIFF
--- a/mcs/mcs/membercache.cs
+++ b/mcs/mcs/membercache.cs
@@ -373,8 +373,13 @@ namespace Mono.CSharp {
 					var entry_pm = entry as IParametersMember;
 					if (entry_pm != null) {
 						entry_param = entry_pm.Parameters;
-						if (!TypeSpecComparer.Override.IsEqual (entry_param, member_param))
-							continue;
+						if (entry.DeclaringType != member.DeclaringType) {
+							if (!TypeSpecComparer.Override.IsEqual (entry_param, member_param))
+								continue;
+						} else {
+							if (!TypeSpecComparer.Equals (entry_param, member_param))
+								continue;
+						}
 					}
 				}
 

--- a/mcs/mcs/membercache.cs
+++ b/mcs/mcs/membercache.cs
@@ -377,7 +377,7 @@ namespace Mono.CSharp {
 							if (!TypeSpecComparer.Override.IsEqual (entry_param, member_param))
 								continue;
 						} else {
-							if (!TypeSpecComparer.Equals (entry_param, member_param))
+							if (!TypeSpecComparer.Equals (entry_param.Types, member_param.Types))
 								continue;
 						}
 					}

--- a/mcs/tests/gtest-645-lib.cs
+++ b/mcs/tests/gtest-645-lib.cs
@@ -1,0 +1,10 @@
+// Compiler options: -target:library
+
+namespace SeparateAssembly
+{
+	public interface IGenericAction<T1, T2>
+	{
+		void AddAction(IGenericAction<T1, T2> action);
+		void AddAction(IGenericAction<T2, T1> action);
+	}
+}

--- a/mcs/tests/gtest-645.cs
+++ b/mcs/tests/gtest-645.cs
@@ -1,0 +1,17 @@
+// Compiler options: -r:gtest-645-lib.dll
+
+using System;
+using SeparateAssembly;
+
+class Program
+{
+	public static void Main()
+	{
+	}
+
+	public static void AddChildButton<T1, T2>(IGenericAction<T1, T2> action)
+	{
+		IGenericAction<T2, T1> childAction = null;
+		action.AddAction (childAction);
+	}
+}

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -19960,6 +19960,158 @@
       </method>
     </type>
   </test>
+  <test name="gtest-640.cs">
+    <type name="Test">
+      <method name="Test op_Addition[T](Test, T)" attrs="150">
+        <size>7</size>
+      </method>
+      <method name="Int32 op_Addition[T](T, Int32)" attrs="150">
+        <size>7</size>
+      </method>
+      <method name="Test op_Addition(Test, Test)" attrs="2198">
+        <size>7</size>
+      </method>
+      <method name="Int64 op_Addition(Test, Int32)" attrs="2198">
+        <size>11</size>
+      </method>
+    </type>
+    <type name="Program">
+      <method name="Int32 Main()" attrs="150">
+        <size>44</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
+  <test name="gtest-641.cs">
+    <type name="SomeClass">
+      <method name="Void Main()" attrs="150">
+        <size>8</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
+  <test name="gtest-642.cs">
+    <type name="Program">
+      <method name="Void Main()" attrs="145">
+        <size>2</size>
+      </method>
+      <method name="Void Transform[V](Area`1[V], System.Func`2[V,V])" attrs="150">
+        <size>37</size>
+      </method>
+      <method name="IB`1[W] GetIB[W]()" attrs="145">
+        <size>10</size>
+      </method>
+      <method name="Void Test[T](T, System.Func`2[T,T])" attrs="145">
+        <size>2</size>
+      </method>
+      <method name="IB`1[U] Transform2[U](IB`1[U], System.Func`2[U,U])" attrs="150">
+        <size>10</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Area`1[TVector]">
+      <method name="IB`1[TVector] GetSegments()" attrs="134">
+        <size>10</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+&lt;Transform&gt;c__AnonStorey0`1[V]">
+      <method name="IB`1[V] &lt;&gt;m__0(IB`1[V])" attrs="131">
+        <size>20</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
+  <test name="gtest-643.cs">
+    <type name="Program">
+      <method name="Void Main()" attrs="150">
+        <size>2</size>
+      </method>
+      <method name="System.Collections.Generic.IEnumerable`1[System.Single] FindIntersections[TVector](IBezier`1, Ray`1, Single, Range`1, Int32)" attrs="145">
+        <size>37</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+Intersect">
+      <method name="Boolean s[TVector](Ray`1, BoundingBoxN`1)" attrs="150">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+Ray`1[TVector]">
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Program+&lt;FindIntersections&gt;c__Iterator0`1[TVector]">
+      <method name="Boolean MoveNext()" attrs="486">
+        <size>336</size>
+      </method>
+      <method name="Single System.Collections.Generic.IEnumerator&lt;float&gt;.get_Current()" attrs="2529">
+        <size>14</size>
+      </method>
+      <method name="System.Object System.Collections.IEnumerator.get_Current()" attrs="2529">
+        <size>19</size>
+      </method>
+      <method name="Void Dispose()" attrs="486">
+        <size>15</size>
+      </method>
+      <method name="Void Reset()" attrs="486">
+        <size>6</size>
+      </method>
+      <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
+        <size>14</size>
+      </method>
+      <method name="System.Collections.Generic.IEnumerator`1[System.Single] System.Collections.Generic.IEnumerable&lt;float&gt;.GetEnumerator()" attrs="481">
+        <size>52</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
+  <test name="gtest-644.cs">
+    <type name="MoneyValue">
+      <method name="System.Decimal op_Implicit(MoneyValue)" attrs="2198">
+        <size>16</size>
+      </method>
+      <method name="Void .ctor(Decimal)" attrs="6278">
+        <size>9</size>
+      </method>
+    </type>
+    <type name="Program">
+      <method name="Void Main()" attrs="145">
+        <size>75</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
+  <test name="gtest-645.cs">
+    <type name="Program">
+      <method name="Void Main()" attrs="150">
+        <size>2</size>
+      </method>
+      <method name="Void AddChildButton[T1,T2](SeparateAssembly.IGenericAction`2[T1,T2])" attrs="150">
+        <size>11</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
   <test name="gtest-anontype-01.cs">
     <type name="Test">
       <method name="Int32 Main()" attrs="150">


### PR DESCRIPTION
These changes correct the Unity bug case 869169.