### PR TITLE
call mono_runtime_class_init_full so that the exception is returned

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -219,7 +219,8 @@ mono_gc_run_finalize (void *obj, void *data)
 	exc = mono_runtime_class_init_full (o->vtable, FALSE);
 	if (exc) {
 		mono_unhandled_exception(exc);
-		exc = NULL;
+		mono_domain_set_internal (caller_domain);
+		return;
 	}
 
 	runtime_invoke (o, NULL, &exc, NULL);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -216,7 +216,11 @@ mono_gc_run_finalize (void *obj, void *data)
 
 	runtime_invoke = domain->finalize_runtime_invoke;
 
-	mono_runtime_class_init (o->vtable);
+	exc = mono_runtime_class_init_full (o->vtable, FALSE);
+	if (exc) {
+		mono_unhandled_exception(exc);
+		exc = NULL;
+	}
 
 	runtime_invoke (o, NULL, &exc, NULL);
 


### PR DESCRIPTION
On the mac platform, some of us are seeing a lock up of the editor after selecting a project.  It is reproducible upwards of 50% of the time.  The Socket class was throwing an exception in it's constructor during a finalization cycle.  This was causing the finalizer_thread to exit.  This change returns any exceptions raised during class initialization, saving the finalizer_thread from exiting. 