### PR TITLE
call mono_runtime_class_init_full so that the exception is returned

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -216,7 +216,12 @@ mono_gc_run_finalize (void *obj, void *data)
 
 	runtime_invoke = domain->finalize_runtime_invoke;
 
-	mono_runtime_class_init (o->vtable);
+	exc = mono_runtime_class_init_full (o->vtable, FALSE);
+	if (exc) {
+		mono_unhandled_exception(exc);
+		mono_domain_set_internal (caller_domain);
+		return;
+	}
 
 	runtime_invoke (o, NULL, &exc, NULL);
 


### PR DESCRIPTION
backport to 5.5 of this PR: https://github.com/Unity-Technologies/mono/pull/479