### PR TITLE
Merge the latest Mono fixes

### DIFF
--- a/mcs/class/System/Test/System.IO.Compression/DeflateStreamTest.cs
+++ b/mcs/class/System/Test/System.IO.Compression/DeflateStreamTest.cs
@@ -6,7 +6,7 @@
 // 	Christopher James Lahey  <clahey@ximian.com>
 //
 // (C) 2004 Novell, Inc. <http://www.novell.com>
-// 
+//
 
 #if NET_2_0
 
@@ -294,6 +294,95 @@ namespace MonoTests.System.IO.Compression
 					Console.WriteLine(len == 1);
 				}
 			}
+		}
+
+		class Bug19313Stream : MemoryStream
+		{
+			public Bug19313Stream (byte [] buffer)
+				: base (buffer)
+			{
+			}
+
+			public override int Read (byte [] buffer, int offset, int count)
+			{
+				// Thread was blocking when DeflateStream uses a NetworkStream.
+				// Because the NetworkStream.Read calls Socket.Receive that
+				// blocks the thread waiting for at least a byte to return.
+				// This assert guarantees that Read is called only when there
+				// is something to be read.
+				Assert.IsTrue (Position < Length, "Trying to read empty stream.");
+
+				return base.Read (buffer, offset, count);
+			}
+		}
+
+		[Test]
+		public void Bug19313 ()
+		{
+			byte [] buffer  = new byte [512];
+			using (var backing = new Bug19313Stream (compressed_data))
+			using (var decompressing = new DeflateStream (backing, CompressionMode.Decompress))
+				decompressing.Read (buffer, 0, buffer.Length);
+		}
+
+		public MemoryStream GenerateStreamFromString(string s)
+		{
+			return new MemoryStream (Encoding.UTF8.GetBytes (s));
+		}
+
+#if NET_4_5
+		[Test]
+		public void CheckNet45Overloads () // Xambug #21982
+		{
+			MemoryStream dataStream = GenerateStreamFromString("Hello");
+			MemoryStream backing = new MemoryStream ();
+			DeflateStream compressing = new DeflateStream (backing, CompressionLevel.Fastest, true);
+			CopyStream (dataStream, compressing);
+			dataStream.Close();
+			compressing.Close();
+
+			backing.Seek (0, SeekOrigin.Begin);
+			DeflateStream decompressing = new DeflateStream (backing, CompressionMode.Decompress);
+			StreamReader reader = new StreamReader (decompressing);
+			Assert.AreEqual ("Hello", reader.ReadLine ());
+			decompressing.Close();
+			backing.Close();
+		}
+#endif
+
+		[Test]
+		[ExpectedException (typeof (ArgumentException))]
+		public void CheckBufferOverrun ()
+		{
+			byte[] data = new byte [20];
+			MemoryStream backing = new MemoryStream ();
+			DeflateStream compressing = new DeflateStream (backing, CompressionLevel.Fastest, true);
+			compressing.Write (data, 0, data.Length + 1);
+			compressing.Close ();
+			backing.Close ();
+		}
+
+		[Test]
+		public void Bug28777_EmptyFlush ()
+		{
+			MemoryStream backing = new MemoryStream ();
+			DeflateStream compressing = new DeflateStream (backing, CompressionLevel.Fastest, true);
+			compressing.Flush ();
+			compressing.Close ();
+			backing.Close ();
+		}
+
+		[Test]
+		public void Bug28777_DoubleFlush ()
+		{
+			byte[] buffer = new byte [4096];
+			MemoryStream backing = new MemoryStream ();
+			DeflateStream compressing = new DeflateStream (backing, CompressionLevel.Fastest, true);
+			compressing.Write (buffer, 0, buffer.Length);
+			compressing.Flush ();
+			compressing.Flush ();
+			compressing.Close ();
+			backing.Close ();
 		}
 	}
 }

--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -90,6 +90,8 @@ CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle)
 	result->gchandle = gchandle;
 	result->compress = compress;
 	result->buffer = g_new (guchar, BUFFER_SIZE);
+	result->stream->next_out = result->buffer;
+	result->stream->avail_out = BUFFER_SIZE;
 	return result;
 }
 
@@ -148,7 +150,7 @@ flush_internal (ZStream *stream, gboolean is_final)
 	if (!stream->compress)
 		return 0;
 
-	if (!is_final) {
+	if (!is_final && stream->stream->avail_in != 0) {
 		status = deflate (stream->stream, Z_PARTIAL_FLUSH);
 		if (status != Z_OK && status != Z_STREAM_END)
 			return status;


### PR DESCRIPTION
These changes correct a few issues in Mono.

* Unity case 889296
* An intermittent lock-up in the editor on OSX.
