### PR TITLE
Reenable Mono Object Counters

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -668,6 +668,8 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (obj);
 
+    mono_stats.new_object_count++;
+
 	return obj;
 }
 
@@ -701,6 +703,8 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (&obj->obj);
+
+    mono_stats.new_object_count++;
 
 	return obj;
 }
@@ -739,6 +743,8 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (&obj->obj);
 
+    mono_stats.new_object_count++;
+
 	return obj;
 }
 
@@ -756,6 +762,8 @@ mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (&obj->object);
+
+    mono_stats.new_object_count++;
 
 	return obj;
 }

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -668,7 +668,7 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (obj);
 
-    mono_stats.new_object_count++;
+	gc_stats.new_object_count++;
 
 	return obj;
 }
@@ -704,7 +704,7 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (&obj->obj);
 
-    mono_stats.new_object_count++;
+	gc_stats.new_object_count++;
 
 	return obj;
 }
@@ -743,7 +743,7 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (&obj->obj);
 
-    mono_stats.new_object_count++;
+	gc_stats.new_object_count++;
 
 	return obj;
 }
@@ -763,7 +763,7 @@ mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 	if (G_UNLIKELY (mono_profiler_events & MONO_PROFILE_ALLOCATIONS))
 		mono_profiler_allocation (&obj->object);
 
-    mono_stats.new_object_count++;
+	gc_stats.new_object_count++;
 
 	return obj;
 }

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -972,7 +972,7 @@ mono_gc_init (void)
 	mono_coop_mutex_init_recursive (&finalizer_mutex);
 	mono_coop_mutex_init_recursive (&reference_queue_mutex);
 
-    mono_counters_register ("Created object count", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &mono_stats.new_object_count);
+	mono_counters_register ("Created object count", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &gc_stats.new_object_count);
 	mono_counters_register ("Minor GC collections", MONO_COUNTER_GC | MONO_COUNTER_UINT, &gc_stats.minor_gc_count);
 	mono_counters_register ("Major GC collections", MONO_COUNTER_GC | MONO_COUNTER_UINT, &gc_stats.major_gc_count);
 	mono_counters_register ("Minor GC time", MONO_COUNTER_GC | MONO_COUNTER_ULONG | MONO_COUNTER_TIME, &gc_stats.minor_gc_time);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -972,6 +972,7 @@ mono_gc_init (void)
 	mono_coop_mutex_init_recursive (&finalizer_mutex);
 	mono_coop_mutex_init_recursive (&reference_queue_mutex);
 
+    mono_counters_register ("Created object count", MONO_COUNTER_GC | MONO_COUNTER_ULONG, &mono_stats.new_object_count);
 	mono_counters_register ("Minor GC collections", MONO_COUNTER_GC | MONO_COUNTER_UINT, &gc_stats.minor_gc_count);
 	mono_counters_register ("Major GC collections", MONO_COUNTER_GC | MONO_COUNTER_UINT, &gc_stats.major_gc_count);
 	mono_counters_register ("Minor GC time", MONO_COUNTER_GC | MONO_COUNTER_ULONG | MONO_COUNTER_TIME, &gc_stats.minor_gc_time);

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -990,7 +990,7 @@ mono_mem_counter (ImplVtable *vtable, MonoBoolean only_value, MonoCounterSample 
 	sample->counterType = predef_counters [predef_categories [CATEGORY_MONO_MEM].first_counter + id].type;
 	switch (id) {
 	case COUNTER_MEM_NUM_OBJECTS:
-		sample->rawValue = mono_stats.new_object_count;
+		sample->rawValue = gc_stats.new_object_count;
 		return TRUE;
 	case COUNTER_MEM_PHYS_TOTAL:
 		sample->rawValue = mono_determine_physical_ram_size ();;

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -990,7 +990,7 @@ mono_mem_counter (ImplVtable *vtable, MonoBoolean only_value, MonoCounterSample 
 	sample->counterType = predef_counters [predef_categories [CATEGORY_MONO_MEM].first_counter + id].type;
 	switch (id) {
 	case COUNTER_MEM_NUM_OBJECTS:
-		sample->rawValue = 0;
+		sample->rawValue = mono_stats.new_object_count;
 		return TRUE;
 	case COUNTER_MEM_PHYS_TOTAL:
 		sample->rawValue = mono_determine_physical_ram_size ();;

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -67,6 +67,7 @@ typedef struct {
 	guint64 minor_gc_time;
 	guint64 major_gc_time;
 	guint64 major_gc_time_concurrent;
+    guint64 new_object_count;
 } GCStats;
 
 extern GCStats gc_stats;

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -67,7 +67,7 @@ typedef struct {
 	guint64 minor_gc_time;
 	guint64 major_gc_time;
 	guint64 major_gc_time_concurrent;
-    guint64 new_object_count;
+	guint64 new_object_count;
 } GCStats;
 
 extern GCStats gc_stats;


### PR DESCRIPTION
Object counters were disabled in upstream mono with this changeset in favor of sgen's "more accurate" counter
https://github.com/Unity-Technologies/mono/commit/a27ab44e3547a62c9380c655c2292778a69a7b90

re-enable the counters for il2cpp on mono
