### PR TITLE
Add support for virtual path remapping

### DIFF
--- a/mcs/class/corlib/System.IO/MonoIO.cs
+++ b/mcs/class/corlib/System.IO/MonoIO.cs
@@ -456,6 +456,9 @@ namespace System.IO
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		public extern static int GetTempPath(out string path);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		public extern static bool RemapPath (string path, out string newPath);
 	}
 }
 

--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -373,6 +373,9 @@ namespace System.IO {
 			if (IsDsc (end) && (path [path.Length - 1] != DirectorySeparatorChar))
 				path += DirectorySeparatorChar;
 
+			string newPath;
+			if (MonoIO.RemapPath(path, out newPath))
+				path = newPath;
 			return path;
 		}
 

--- a/mono/metadata/file-io.h
+++ b/mono/metadata/file-io.h
@@ -239,6 +239,11 @@ ves_icall_System_IO_MonoIO_ReplaceFile (MonoString *sourceFileName, MonoString *
 					MonoString *destinationBackupFileName, MonoBoolean ignoreMetadataErrors,
 					gint32 *error) MONO_INTERNAL;
 
+extern MonoBoolean
+ves_icall_System_IO_MonoIO_RemapPath  (MonoString *path, MonoString **new_path) MONO_INTERNAL;
+
+gboolean mono_file_remap_path(const char** path) MONO_INTERNAL;
+
 G_END_DECLS
 
 #endif /* _MONO_METADATA_FILEIO_H_ */

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -333,6 +333,7 @@ ICALL(MONOIO_15, "MoveFile(string,string,System.IO.MonoIOError&)", ves_icall_Sys
 #endif /* !PLATFORM_RO_FS */
 ICALL(MONOIO_16, "Open(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.IO.FileOptions,System.IO.MonoIOError&)", ves_icall_System_IO_MonoIO_Open)
 ICALL(MONOIO_17, "Read(intptr,byte[],int,int,System.IO.MonoIOError&)", ves_icall_System_IO_MonoIO_Read)
+ICALL(MONOIO_35, "RemapPath(string,string&)", ves_icall_System_IO_MonoIO_RemapPath)
 #ifndef PLATFORM_RO_FS
 ICALL(MONOIO_18, "RemoveDirectory(string,System.IO.MonoIOError&)", ves_icall_System_IO_MonoIO_RemoveDirectory)
 ICALL(MONOIO_18M, "ReplaceFile(string,string,string,bool,System.IO.MonoIOError&)", ves_icall_System_IO_MonoIO_ReplaceFile)

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -948,6 +948,8 @@ do_mono_image_open (const char *fname, MonoImageOpenStatus *status,
 	MonoImage *image;
 	MonoFileMap *filed;
 
+	gboolean remapped = mono_file_remap_path(&fname);
+
 	if ((filed = mono_file_map_open (fname)) == NULL){
 		if (IS_PORTABILITY_SET) {
 			gchar *ffname = mono_portability_find_file (fname, TRUE);
@@ -960,6 +962,8 @@ do_mono_image_open (const char *fname, MonoImageOpenStatus *status,
 		if (filed == NULL) {
 			if (status)
 				*status = MONO_IMAGE_ERROR_ERRNO;
+			if (remapped)
+				g_free((void*)fname);
 			return NULL;
 		}
 	}
@@ -973,6 +977,8 @@ do_mono_image_open (const char *fname, MonoImageOpenStatus *status,
 		g_free (image);
 		if (status)
 			*status = MONO_IMAGE_IMAGE_INVALID;
+		if (remapped)
+			g_free((void*)fname);
 		return NULL;
 	}
 	iinfo = g_new0 (MonoCLIImageInfo, 1);
@@ -982,6 +988,8 @@ do_mono_image_open (const char *fname, MonoImageOpenStatus *status,
 	image->ref_count = 1;
 	
 	mono_file_map_close (filed);
+	if (remapped)
+		g_free((void*)fname);
 	return do_mono_image_load (image, status, care_about_cli, care_about_pecoff);
 }
 

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1208,6 +1208,7 @@ static MonoDl*
 cached_module_load (const char *name, int flags, char **err)
 {
 	MonoDl *res;
+	gboolean remapped = mono_file_remap_path(&name);
 	mono_loader_lock ();
 	if (!global_module_map)
 		global_module_map = g_hash_table_new (g_str_hash, g_str_equal);
@@ -1215,12 +1216,16 @@ cached_module_load (const char *name, int flags, char **err)
 	if (res) {
 		*err = NULL;
 		mono_loader_unlock ();
+		if (remapped)
+			g_free((void*)name);
 		return res;
 	}
 	res = mono_dl_open (name, flags, err);
 	if (res)
 		g_hash_table_insert (global_module_map, g_strdup (name), res);
 	mono_loader_unlock ();
+	if (remapped)
+		g_free((void*)name);
 	return res;
 }
 

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -827,3 +827,4 @@ mono_unity_loader_get_last_error_and_error_prepare_exception
 mono_unity_jit_cleanup
 mono_unity_g_free
 mono_unity_install_memory_callbacks
+mono_unity_register_path_remapper

--- a/msvc/monoposixhelper.vcxproj
+++ b/msvc/monoposixhelper.vcxproj
@@ -300,7 +300,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\mono\eglib\src;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\eglib\src;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;__x86_64__;WIN64;_WIN64;WIN32;_WIN32;__WIN32__;_WINDOWS;WINDOWS;PLATFORM_WIN32;TARGET_WIN32;_CRT_SECURE_NO_DEPRECATE;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>


### PR DESCRIPTION
add support for virtual path remapping through mono_unity_register_path_remapper() & MonoIO.RemapPath()

* compile warning and error fixes to virtual path remapping

* fix leak with virtual path remapping