### PR TITLE
Remove counter registration warning

### DIFF
--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -160,7 +160,7 @@ register_internal (const char *name, int type, void *addr, int size)
 
 	for (counter = counters; counter; counter = counter->next) {
 		if (counter->addr == addr) {
-			g_warning ("you are registering twice the same counter address");
+			//g_warning ("you are registering twice the same counter address");
 			mono_os_mutex_unlock (&counters_mutex);
 			return;
 		}


### PR DESCRIPTION
This warning outputs to the console when running Benchmark.NET benchmarks and breaks the parsing code that analyzes the output of the run.