### PR TITLE
Wrap mono_class_get with a Unity version.

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1062,3 +1062,15 @@ mono_unity_class_get_generic_parameter_count (MonoClass* klass)
 
 	return klass->generic_container->type_argc;
 }
+
+MONO_API MonoClass*
+mono_unity_class_get(MonoImage* image, guint32 type_token)
+{
+	// Unity expects to try to get classes that don't exist, and
+	// have a value of NULL returned. So eat the error message.
+	MonoError unused;
+	MonoClass* klass= mono_class_get_checked(image, type_token, &unused);
+	mono_error_cleanup(&unused);
+	return klass;
+}
+

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -157,5 +157,6 @@ void mono_unity_stackframe_set_method(MonoStackFrame *sf, MonoMethod *method);
 MonoType* mono_unity_reflection_type_get_type(MonoReflectionType *type);
 void mono_unity_set_data_dir(const char* dir);
 char* mono_unity_get_data_dir();
+MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token);
 
 #endif

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -980,3 +980,4 @@ mono_unity_get_data_dir
 mono_unity_class_get_generic_type_definition
 mono_unity_class_get_generic_parameter_at
 mono_unity_class_get_generic_parameter_count
+mono_unity_class_get


### PR DESCRIPTION
Unity assumes scripting_class_get returns NULL for types that don't
exist. Create a wrapper that does this on the Mono embedding API.