### PR TITLE
Wrap mono_class_get with a Unity version.

### DIFF
--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -833,3 +833,4 @@ mono_unity_class_get_generic_parameter_at
 mono_unity_class_get_generic_parameter_count
 mono_unity_set_data_dir
 mono_unity_get_data_dir
+mono_unity_class_get

--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -294,3 +294,8 @@ mono_unity_get_data_dir()
 {
 	return data_dir;
 }
+
+MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token)
+{
+	return mono_class_get(image, type_token);
+}

--- a/unity/unity_utils.h
+++ b/unity/unity_utils.h
@@ -41,5 +41,6 @@ unity_mono_method_is_generic (MonoMethod* method);
 
 void mono_unity_set_data_dir(const char* dir);
 char* mono_unity_get_data_dir();
+MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token);
 
 #endif


### PR DESCRIPTION
Unity assumes scripting_class_get returns NULL for types that don't
exist. Create a wrapper that does this on the Mono embedding API. We
need to have the embedding API match for the old an new Mono. Since
mono_class_get already had the proper behavior in the old Mono, this is
just a pass-through function.