### PR TITLE
Expose the eglib alloc on the embedding API

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1074,3 +1074,9 @@ mono_unity_class_get(MonoImage* image, guint32 type_token)
 	return klass;
 }
 
+MONO_API gpointer
+mono_unity_alloc(gsize size)
+{
+	return g_malloc(size);
+}
+

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -158,5 +158,6 @@ MonoType* mono_unity_reflection_type_get_type(MonoReflectionType *type);
 void mono_unity_set_data_dir(const char* dir);
 char* mono_unity_get_data_dir();
 MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token);
+gpointer mono_unity_alloc(gsize size);
 
 #endif


### PR DESCRIPTION
* For the Unity platform backend, we need to allow IL2CPP to allocate.
* Mono needs to give IL2CPP an allocation function, so we need to expose a wrapper.