### PR TITLE
Make the code size larger.

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5661,7 +5661,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	gboolean args_clobbered = FALSE;
 	gboolean trace = FALSE;
 
-	cfg->code_size =  MAX (((MonoMethodNormal *)method)->header->code_size * 4, 12000);
+	cfg->code_size =  MAX (((MonoMethodNormal *)method)->header->code_size * 4, 14000);
 
 	code = cfg->native_code = g_malloc (cfg->code_size);
 


### PR DESCRIPTION
Deep profiling on 5.6 requires a larger size for the test cases we have.