### PR TITLE
Fix issue which causes mono to incorrectly parse assemblies lists with paths that contain a semicolon on windows

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -287,6 +287,56 @@ mono_set_assemblies_path (const char* path)
 	}
 }
 
+/**
+* mono_set_assemblies_path_null_separated:
+* @path: list of paths that contain directories where Mono will look for assemblies
+*
+* Use this method to override the standard assembly lookup system and
+* override any assemblies coming from the GAC.  This is the method
+* that supports the MONO_PATH variable.
+*
+* Notice that MONO_PATH and this method are really a very bad idea as
+* it prevents the GAC from working and it prevents the standard
+* resolution mechanisms from working.  Nonetheless, for some debugging
+* situations and bootstrapping setups, this is useful to have.
+*/
+void
+mono_set_assemblies_path_null_separated(const char* path)
+{
+    char **dest;
+
+    int numPaths = 0;
+    char* path_count_ptr = path;
+    while (*path_count_ptr)
+    {
+        path_count_ptr += strlen(path_count_ptr) + 1;
+        numPaths++;
+    }
+    dest = g_new(char**, sizeof(char*) * (numPaths + 1));
+
+    if (assemblies_path)
+        g_strfreev(assemblies_path);
+    assemblies_path = dest;
+    char* current_path = path;
+    while (*current_path)
+    {
+        *dest++ = mono_path_canonicalize(current_path);
+        current_path += strlen(current_path) + 1;
+    }
+    *dest = NULL;
+
+    if (g_getenv("MONO_DEBUG") == NULL)
+        return;
+
+    char** print_assembly_str = assemblies_path;
+    while (*print_assembly_str) {
+        if (**print_assembly_str && !g_file_test(*print_assembly_str, G_FILE_TEST_IS_DIR))
+            g_warning("'%s' in MONO_PATH doesn't exist or has wrong permissions.", *print_assembly_str);
+
+        print_assembly_str++;
+    }
+}
+
 /* Native Client can't get this info from an environment variable so */
 /* it's passed in to the runtime, or set manually by embedding code. */
 #ifdef __native_client__

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -107,6 +107,7 @@ MONO_API void	      mono_register_machine_config (const char *config_xml);
 MONO_API void          mono_set_rootdir (void);
 MONO_API void          mono_set_dirs (const char *assembly_dir, const char *config_dir);
 MONO_API void          mono_set_assemblies_path (const char* path);
+MONO_API void          mono_set_assemblies_path_null_separated(const char* path);
 MONO_END_DECLS
 
 #endif

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -780,6 +780,7 @@ mono_security_enable_core_clr
 mono_security_set_core_clr_platform_callback
 mono_set_allocator_vtable
 mono_set_assemblies_path
+mono_set_assemblies_path_null_separated
 mono_set_break_policy
 mono_set_config_dir
 mono_set_crash_chaining


### PR DESCRIPTION
Add function to allow passing in null delimited assembly lists into mono instead of a semicolon delimited list to support semicolons in path names and filenames.