### PR TITLE
Disable .NET remoting in mono for il2cpp running on libmonoruntime

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -1002,6 +1002,9 @@ ICALL_TYPE(REMSER, "System.Runtime.Remoting.RemotingServices", REMSER_0)
 ICALL(REMSER_0, "GetVirtualMethod", ves_icall_Remoting_RemotingServices_GetVirtualMethod)
 ICALL(REMSER_1, "InternalExecute", ves_icall_InternalExecute)
 ICALL(REMSER_2, "IsTransparentProxy", ves_icall_IsTransparentProxy)
+#else
+ICALL_TYPE(REMSER, "System.Runtime.Remoting.RemotingServices", REMSER_0)
+ICALL(REMSER_0, "IsTransparentProxy", ves_icall_IsTransparentProxy)
 #endif
 
 ICALL_TYPE(RVH, "System.Runtime.Versioning.VersioningHelper", RVH_1)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7107,6 +7107,12 @@ ves_icall_System_Runtime_Activation_ActivationServices_EnableProxyActivation (Mo
 	g_assert_not_reached ();
 }
 
+ICALL_EXPORT MonoBoolean
+ves_icall_IsTransparentProxy (MonoObject *proxy)
+{
+	return 0;
+}
+
 #endif
 
 ICALL_EXPORT MonoObject *

--- a/msvc/il2cpp.props
+++ b/msvc/il2cpp.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <IL2CPP_DEFINES>IL2CPP_ON_MONO=1;DISABLE_JIT=1</IL2CPP_DEFINES>
+    <IL2CPP_DEFINES>IL2CPP_ON_MONO=1;DISABLE_JIT=1;DISABLE_REMOTING=1</IL2CPP_DEFINES>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Pulling in the monobuildtools build.pl change to disable remoting for the mac build.  
Setting DISABLE_REMOTING in il2cpp.prop file for visual studio build.
Creating default version of IsTransparentProxy that always returns false for when remoting is disabled.  This method is called by the BinaryFormatter class.