### PR TITLE
[mcs] Ignore constraints on enumerator generic methods. Fixes #51506

### DIFF
--- a/mcs/mcs/field.cs
+++ b/mcs/mcs/field.cs
@@ -257,7 +257,8 @@ namespace Mono.CSharp
 				Report.Error (625, Location, "`{0}': Instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute", GetSignatureForError ());
 			}
 
-			ConstraintChecker.Check (this, member_type, type_expr.Location);
+			if (!IsCompilerGenerated)
+				ConstraintChecker.Check (this, member_type, type_expr.Location);
 
 			base.Emit ();
 		}

--- a/mcs/tests/gtest-643.cs
+++ b/mcs/tests/gtest-643.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+	public static void Main()
+	{
+	}
+
+	private static IEnumerable<float> FindIntersections<TVector>(
+		IBezier<TVector> bezier,
+		Ray<TVector> ray,
+		float epsilon,
+		Range<float> t1,
+		int depth) where TVector : IVector<TVector>
+	{
+		var bounds = bezier.GetBounds();
+		if (Intersect.s(ray, bounds))
+		{
+			var intersections1 = new float[] { };
+			var intersections2 = new float[] { };
+			foreach (var t in intersections1) { yield return t; }
+			foreach (var t in intersections2) { yield return t; }
+		}
+	}
+
+	public static class Intersect
+	{
+		public static bool s<TVector>(Ray<TVector> ray, BoundingBoxN<TVector> box) where TVector : IVector<TVector>
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	public struct Range<T>
+	{
+	}
+
+	public class Ray<TVector> where TVector : IVector<TVector>
+	{
+	}
+
+	public interface IBezier<TVector>
+		where TVector : IVector<TVector>
+	{
+		BoundingBoxN<TVector> GetBounds();
+	}
+
+	public interface IVector<T> : IEpsilonEquatable<T, float>
+		where T : IVector<T>
+	{
+	}
+
+	public interface IEpsilonEquatable<TType, TEpsilon> // ReSharper enable TypeParameterCanBeVariant
+	{
+	}
+
+	public struct BoundingBoxN<T>
+		where T : IVector<T>
+	{
+	}
+}

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+ï»¿<?xml version="1.0" encoding="utf-8"?>
 <!--This file contains expected IL and metadata produced by compiler for each test-->
 <tests>
   <test name="dtest-001.cs">
@@ -41478,14 +41478,14 @@
     </type>
   </test>
   <test name="test-444.cs">
-    <type name="쯠쯡쯢">
+    <type name="ì¯ ì¯¡ì¯¢">
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
       </method>
-      <method name="Void P̀ः०‿()" attrs="145">
+      <method name="Void PÌà¤à¥¦â¿()" attrs="145">
         <size>2</size>
       </method>
     </type>
@@ -43915,7 +43915,7 @@
     </type>
   </test>
   <test name="test-550.cs">
-    <type name="Bla.Blub.Fo‿o">
+    <type name="Bla.Blub.Foâ¿o">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
       </method>


### PR DESCRIPTION
This is similar to the change at 30f6c9933a6c0595a5d1d5cf681be39b4367446e