### PR TITLE
Fix NetworkInterface.GetAllNetworkInterfaces() on Linux

### DIFF
--- a/external/buildscripts/build_runtime_linux.pl
+++ b/external/buildscripts/build_runtime_linux.pl
@@ -56,7 +56,7 @@ if (not $skipbuild)
 	#rmtree($bintarget);
 	#rmtree($libtarget);
 
-	my $archflags = '';
+	my $archflags = '-DLINUX';
 
 	if (not $build64 and not $build_armel)
 	{

--- a/external/buildscripts/build_runtime_linux.pl
+++ b/external/buildscripts/build_runtime_linux.pl
@@ -56,7 +56,7 @@ if (not $skipbuild)
 	#rmtree($bintarget);
 	#rmtree($libtarget);
 
-	my $archflags = '-DLINUX';
+	my $archflags = '-DLINUX=1';
 
 	if (not $build64 and not $build_armel)
 	{

--- a/mono/xamarin-android/xamarin_getifaddrs.c
+++ b/mono/xamarin-android/xamarin_getifaddrs.c
@@ -19,6 +19,7 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_arp.h>
+#include <gnu/lib-names.h> // for LIBC_SO define
 #endif /* def LINUX */
 #ifndef WIN32
 #include <netinet/in.h>
@@ -254,7 +255,7 @@ get_ifaddrs_impl (int (**getifaddrs_impl) (struct _monodroid_ifaddrs **ifap), vo
 	assert (getifaddrs_impl);
 	assert (freeifaddrs_impl);
 
-	libc = dlopen ("libc.so", RTLD_NOW);
+	libc = dlopen (LIBC_SO, RTLD_NOW);
 	if (libc) {
 		*getifaddrs_impl = dlsym (libc, "getifaddrs");
 		if (*getifaddrs_impl)

--- a/mono/xamarin-android/xamarin_getifaddrs.c
+++ b/mono/xamarin-android/xamarin_getifaddrs.c
@@ -19,7 +19,11 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_arp.h>
+#if ANDROID
+#define LIBC_SO "libc.so.6"
+#else
 #include <gnu/lib-names.h> // for LIBC_SO define
+#endif
 #endif /* def LINUX */
 #ifndef WIN32
 #include <netinet/in.h>


### PR DESCRIPTION
Regression was introduced when fixing Android. I've manually verified that everything works as expected on Ubuntu (both Editor and standalone player) and Android. Unity also has a runtime test that invokes NetworkInterface.GetAllNetworkInterfaces.