### PR TITLE
[DO NOT MERGE TO 2017.1] Backport 5.0 MMAP Support To 4.8.0

### DIFF
--- a/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafeMemoryMappedViewHandle.cs
+++ b/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafeMemoryMappedViewHandle.cs
@@ -44,6 +44,10 @@ namespace Microsoft.Win32.SafeHandles
 			Initialize ((ulong)size);
 		}
 
+		internal void Flush () {
+			MemoryMapImpl.Flush (this.mmap_handle);
+		}
+
 		protected override bool ReleaseHandle () {
 			if (this.handle != (IntPtr) (-1))
 				return MemoryMapImpl.Unmap (this.mmap_handle);

--- a/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedFile.cs
+++ b/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedFile.cs
@@ -70,7 +70,7 @@ namespace System.IO.MemoryMappedFiles
 			case 1:
 				return new ArgumentException ("A positive capacity must be specified for a Memory Mapped File backed by an empty file.");
 			case 2:
-				return new ArgumentOutOfRangeException ("The capacity may not be smaller than the file size.");
+				return new ArgumentOutOfRangeException ("capacity", "The capacity may not be smaller than the file size.");
 			case 3:
 				return new FileNotFoundException (path);
 			case 4:
@@ -85,6 +85,10 @@ namespace System.IO.MemoryMappedFiles
 				return new ArgumentException ("Invalid FileMode value.");
 			case 9:
 				return new IOException ("Could not map file");
+			case 10:
+				return new UnauthorizedAccessException ("Access to the path is denied.");
+			case 11:
+				return new ArgumentOutOfRangeException ("capacity", "The capacity cannot be greater than the size of the system's logical address space.");
 			default:
 				return new IOException ("Failed with unknown error code " + error);
 			}
@@ -140,7 +144,7 @@ namespace System.IO.MemoryMappedFiles
 			if (mode == FileMode.Append)
 				throw new ArgumentException ("mode");
 
-			IntPtr handle = MemoryMapImpl.OpenFile (path, mode, null, out capacity, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.DelayAllocatePages);
+			IntPtr handle = MemoryMapImpl.OpenFile (path, mode, null, out capacity, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None);
 
 			return new MemoryMappedFile () {
 				handle = handle,
@@ -172,7 +176,7 @@ namespace System.IO.MemoryMappedFiles
 			if (capacity < 0)
 				throw new ArgumentOutOfRangeException ("capacity");
 
-			IntPtr handle = MemoryMapImpl.OpenFile (path, mode, mapName, out capacity, access, MemoryMappedFileOptions.DelayAllocatePages);
+			IntPtr handle = MemoryMapImpl.OpenFile (path, mode, mapName, out capacity, access, MemoryMappedFileOptions.None);
 			
 			return new MemoryMappedFile () {
 				handle = handle,
@@ -193,7 +197,7 @@ namespace System.IO.MemoryMappedFiles
 			if ((!MonoUtil.IsUnix && capacity == 0 && fileStream.Length == 0) || (capacity > fileStream.Length))
 				throw new ArgumentException ("capacity");
 
-			IntPtr handle = MemoryMapImpl.OpenHandle (fileStream.Handle, mapName, out capacity, access, MemoryMappedFileOptions.DelayAllocatePages);
+			IntPtr handle = MemoryMapImpl.OpenHandle (fileStream.SafeFileHandle.DangerousGetHandle (), mapName, out capacity, access, MemoryMappedFileOptions.None);
 			
 			MemoryMapImpl.ConfigureHandleInheritability (handle, inheritability);
 				
@@ -220,7 +224,7 @@ namespace System.IO.MemoryMappedFiles
 			if ((!MonoUtil.IsUnix && capacity == 0 && fileStream.Length == 0) || (capacity > fileStream.Length))
 				throw new ArgumentException ("capacity");
 
-			IntPtr handle = MemoryMapImpl.OpenHandle (fileStream.Handle, mapName, out capacity, access, MemoryMappedFileOptions.DelayAllocatePages);
+			IntPtr handle = MemoryMapImpl.OpenHandle (fileStream.SafeFileHandle.DangerousGetHandle (), mapName, out capacity, access, MemoryMappedFileOptions.None);
 			
 			MemoryMapImpl.ConfigureHandleInheritability (handle, inheritability);
 				
@@ -258,13 +262,13 @@ namespace System.IO.MemoryMappedFiles
 		[MonoLimitation ("Named mappings scope is process local")]
 		public static MemoryMappedFile CreateNew (string mapName, long capacity)
 		{
-			return CreateNew (mapName, capacity, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.DelayAllocatePages, null, HandleInheritability.None);
+			return CreateNew (mapName, capacity, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, null, HandleInheritability.None);
 		}
 
 		[MonoLimitation ("Named mappings scope is process local")]
 		public static MemoryMappedFile CreateNew (string mapName, long capacity, MemoryMappedFileAccess access) 
 		{
-			return CreateNew (mapName, capacity, access, MemoryMappedFileOptions.DelayAllocatePages, null, HandleInheritability.None);
+			return CreateNew (mapName, capacity, access, MemoryMappedFileOptions.None, null, HandleInheritability.None);
 		}
 
 		[MonoLimitation ("Named mappings scope is process local; options is ignored")]
@@ -290,7 +294,7 @@ namespace System.IO.MemoryMappedFiles
 		[MonoLimitation ("Named mappings scope is process local")]
 		public static MemoryMappedFile CreateOrOpen (string mapName, long capacity, MemoryMappedFileAccess access)
 		{
-			return CreateOrOpen (mapName, capacity, access, MemoryMappedFileOptions.DelayAllocatePages, null, HandleInheritability.None);
+			return CreateOrOpen (mapName, capacity, access, MemoryMappedFileOptions.None, null, HandleInheritability.None);
 		}
 
 		[MonoLimitation ("Named mappings scope is process local")]

--- a/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedView.cs
+++ b/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedView.cs
@@ -92,7 +92,7 @@ namespace System.IO.MemoryMappedFiles
 
 		public void Flush (IntPtr capacity)
 		{
-			MemoryMapImpl.Flush (m_viewHandle.DangerousGetHandle ());
+			m_viewHandle.Flush ();
 		}
 		
 		protected virtual void Dispose (bool disposing)

--- a/mcs/class/System.Core/Test/System.IO.MemoryMappedFiles/MemoryMappedFileTest.cs
+++ b/mcs/class/System.Core/Test/System.IO.MemoryMappedFiles/MemoryMappedFileTest.cs
@@ -56,16 +56,28 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 			return "test-" + named_index++;
 		}
 
-
+		static string baseTempDir = Path.Combine (Path.GetTempPath (), typeof (MemoryMappedFileTest).FullName);
 		static string tempDir = Path.Combine (Path.GetTempPath (), typeof (MemoryMappedFileTest).FullName);
 
 		string fname;
 
-		[SetUp]
-		protected void SetUp () {
-			if (Directory.Exists (tempDir))
-				Directory.Delete (tempDir, true);
+		[TestFixtureSetUp]
+		public void FixtureSetUp ()
+		{
+			try {
+				// Try to cleanup from any previous NUnit run.
+				Directory.Delete (baseTempDir, true);
+			} catch (Exception) {
+			}
+		}
 
+		[SetUp]
+		public void SetUp ()
+		{
+			int i = 0;
+			do {
+				tempDir = Path.Combine (baseTempDir, (++i).ToString());
+			} while (Directory.Exists (tempDir));
 			Directory.CreateDirectory (tempDir);
 
 			fname = Path.Combine (tempDir, "basic.txt");
@@ -77,9 +89,14 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 		}
 
 		[TearDown]
-		protected void TearDown () {
-			if (Directory.Exists (tempDir))
+		public void TearDown ()
+		{
+			try {
+				// This throws an exception under MS.NET and Mono on Windows,
+				// since the directory contains open files.
 				Directory.Delete (tempDir, true);
+			} catch (Exception) {
+			}
 		}
 
 		[Test]
@@ -102,26 +119,16 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 		public void CreateNew ()
 		{
 			// This must succeed
-			MemoryMappedFile.CreateNew (Path.Combine (tempDir, "createNew.test"), 8192);
-		}
-
-		[Test]
-		[ExpectedException (typeof (IOException))]
-		public void CreateNew_OnExistingFile ()
-		{
-			// This must succeed
-			MemoryMappedFile.CreateNew (Path.Combine (tempDir, "createNew.test"), 8192);
-			
-			// This should fail, the file exists
-			MemoryMappedFile.CreateNew (Path.Combine (tempDir, "createNew.test"), 8192);
+			MemoryMappedFile.CreateNew (MkNamedMapping (), 8192);
 		}
 
 		// Call this twice, it should always work
 		[Test]
 		public void CreateOrOpen_Multiple ()
 		{
-			MemoryMappedFile.CreateOrOpen (Path.Combine (tempDir, "createOrOpen.test"), 8192);
-			MemoryMappedFile.CreateOrOpen (Path.Combine (tempDir, "createOrOpen.test"), 8192);
+			var name = MkNamedMapping ();
+			MemoryMappedFile.CreateOrOpen (name, 8192);
+			MemoryMappedFile.CreateOrOpen (name, 8192);
 		}
 
 		[Test]
@@ -134,7 +141,7 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 			// We are requesting fewer bytes to map.
 			MemoryMappedFile.CreateFromFile (f, FileMode.Open, "myMap", 4192);
 		}
-	
+
 		[Test]
 		public void CreateFromFile_Null () {
 			AssertThrows<ArgumentNullException> (delegate () {
@@ -252,6 +259,9 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 		[Test]
 		public void NamedMappingToInvalidFile ()
 		{
+			if (Environment.OSVersion.Platform != PlatformID.Unix) {
+				Assert.Ignore ("Backslashes in mapping names are disallowed on .NET and Mono on Windows");
+			}
 			var fileName = Path.Combine (tempDir, "temp_file_123");
 	        if (File.Exists (fileName))
 	            File.Delete (fileName);
@@ -352,7 +362,7 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 		}
 
 		[Test]
-		[ExpectedException(typeof(IOException))]
+		[ExpectedException(typeof(UnauthorizedAccessException))]
 		public void CreateViewStreamWithOffsetPastFileEnd ()
 		{
 			string f = Path.Combine (tempDir, "8192-file");
@@ -365,7 +375,7 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 		}
 
 		[Test]
-		[ExpectedException(typeof(IOException))]
+		[ExpectedException(typeof(UnauthorizedAccessException))]
 		public void CreateViewStreamWithOffsetPastFileEnd2 ()
 		{
 			string f = Path.Combine (tempDir, "8192-file");
@@ -394,7 +404,7 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 
 			MemoryMappedViewStream stream = mappedFile.CreateViewStream (pageSize * 2, 0, MemoryMappedFileAccess.ReadWrite);
 #if !MONOTOUCH
-			Assert.AreEqual (stream.Capacity, Environment.SystemPageSize);
+			Assert.AreEqual (Environment.SystemPageSize, stream.Capacity);
 #endif
 			stream.Write (new byte [pageSize], 0, pageSize);
 		}
@@ -407,9 +417,39 @@ namespace MonoTests.System.IO.MemoryMappedFiles {
 			File.WriteAllBytes (f, new byte [size]);
 
 			FileStream file = File.OpenRead (f);
-			MemoryMappedFile.CreateFromFile (file, null, size, MemoryMappedFileAccess.ReadExecute, null, 0, false);
+			MemoryMappedFile.CreateFromFile (file, null, size, MemoryMappedFileAccess.Read, null, 0, false);
 		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void CreateNewLargerThanLogicalAddressSpace ()
+		{
+			if (IntPtr.Size != 4) {
+				Assert.Ignore ("Only applies to 32-bit systems");
+			}
+			MemoryMappedFile.CreateNew (MkNamedMapping (), (long) uint.MaxValue + 1);
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void CreateOrOpenLargerThanLogicalAddressSpace ()
+		{
+			if (IntPtr.Size != 4) {
+				Assert.Ignore ("Only applies to 32-bit systems");
+			}
+			MemoryMappedFile.CreateOrOpen (MkNamedMapping (), (long) uint.MaxValue + 1);
+		}
+
+		[Test]
+		public void NamedMappingWithDelayAllocatePages ()
+		{
+			var name = MkNamedMapping ();
+			using (var m0 = MemoryMappedFile.CreateNew(name, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.DelayAllocatePages, HandleInheritability.None)) {
+				using (MemoryMappedViewAccessor v0 = m0.CreateViewAccessor ()) {
+					Assert.AreEqual (0, v0.ReadInt32 (0));
+				}
+			}
+		}
+
 	}
 }
-
-

--- a/mono/metadata/file-mmap-windows.c
+++ b/mono/metadata/file-mmap-windows.c
@@ -1,11 +1,15 @@
 /*
- * file-mmap-posix.c: File mmap internal calls
+ * file-mmap-windows.c: MemoryMappedFile internal calls for Windows
  *
- * Author:
- *	Rodrigo Kumpera
- *
- * Copyright 2014 Xamarin Inc (http://www.xamarin.com)
+ * Copyright 2016 Microsoft
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+/*
+ * The code in this file has been inspired by the CoreFX MemoryMappedFile Windows implementation contained in the files
+ *
+ * https://github.com/dotnet/corefx/blob/master/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
+ * https://github.com/dotnet/corefx/blob/master/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Windows.cs
  */
 
 #include <config.h>
@@ -13,59 +17,399 @@
 #ifdef HOST_WIN32
 
 #include <glib.h>
-#include <string.h>
-#include <errno.h>
 
-
-#include <mono/metadata/object.h>
 #include <mono/metadata/file-mmap.h>
 
-void *
-mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint64 *capacity, int access, int options, int *error)
+// These control the retry behaviour when lock violation errors occur during Flush:
+#define MAX_FLUSH_WAITS 15  // must be <=30
+#define MAX_FLUSH_RETIRES_PER_WAIT 20
+
+typedef struct {
+	void *address;
+	size_t length;
+} MmapInstance;
+
+enum {
+	BAD_CAPACITY_FOR_FILE_BACKED = 1,
+	CAPACITY_SMALLER_THAN_FILE_SIZE,
+	FILE_NOT_FOUND,
+	FILE_ALREADY_EXISTS,
+	PATH_TOO_LONG,
+	COULD_NOT_OPEN,
+	CAPACITY_MUST_BE_POSITIVE,
+	INVALID_FILE_MODE,
+	COULD_NOT_MAP_MEMORY,
+	ACCESS_DENIED,
+	CAPACITY_LARGER_THAN_LOGICAL_ADDRESS_SPACE
+};
+
+enum {
+	FILE_MODE_CREATE_NEW = 1,
+	FILE_MODE_CREATE = 2,
+	FILE_MODE_OPEN = 3,
+	FILE_MODE_OPEN_OR_CREATE = 4,
+	FILE_MODE_TRUNCATE = 5,
+	FILE_MODE_APPEND = 6,
+};
+
+enum {
+	MMAP_FILE_ACCESS_READ_WRITE = 0,
+	MMAP_FILE_ACCESS_READ = 1,
+	MMAP_FILE_ACCESS_WRITE = 2,
+	MMAP_FILE_ACCESS_COPY_ON_WRITE = 3,
+	MMAP_FILE_ACCESS_READ_EXECUTE = 4,
+	MMAP_FILE_ACCESS_READ_WRITE_EXECUTE = 5,
+};
+
+static DWORD get_page_access (int access)
 {
-	g_error ("No windows backend");
-	return NULL;
+	switch (access) {
+	case MMAP_FILE_ACCESS_READ:
+		return PAGE_READONLY;
+	case MMAP_FILE_ACCESS_READ_WRITE:
+		return PAGE_READWRITE;
+	case MMAP_FILE_ACCESS_COPY_ON_WRITE:
+		return PAGE_WRITECOPY;
+	case MMAP_FILE_ACCESS_READ_EXECUTE:
+		return PAGE_EXECUTE_READ;
+	case MMAP_FILE_ACCESS_READ_WRITE_EXECUTE:
+		return PAGE_EXECUTE_READWRITE;
+	default:
+		g_error ("unknown MemoryMappedFileAccess %d", access);
+	}
 }
 
-void *
-mono_mmap_open_handle (void *handle, MonoString *mapName, gint64 *capacity, int access, int options, int *error)
+static DWORD get_file_access (int access)
 {
-	g_error ("No windows backend");
-	return NULL;
+	switch (access) {
+	case MMAP_FILE_ACCESS_READ:
+	case MMAP_FILE_ACCESS_READ_EXECUTE:
+		return GENERIC_READ;
+	case MMAP_FILE_ACCESS_READ_WRITE:
+	case MMAP_FILE_ACCESS_COPY_ON_WRITE:
+	case MMAP_FILE_ACCESS_READ_WRITE_EXECUTE:
+		return GENERIC_READ | GENERIC_WRITE;
+	case MMAP_FILE_ACCESS_WRITE:
+		return GENERIC_WRITE;
+	default:
+		g_error ("unknown MemoryMappedFileAccess %d", access);
+	}
 }
 
-void
-mono_mmap_close (void *mmap_handle)
+static int get_file_map_access (int access)
 {
-	g_error ("No windows backend");
+	switch (access) {
+	case MMAP_FILE_ACCESS_READ:
+		return FILE_MAP_READ;
+	case MMAP_FILE_ACCESS_WRITE:
+		return FILE_MAP_WRITE;
+	case MMAP_FILE_ACCESS_READ_WRITE:
+		return FILE_MAP_READ | FILE_MAP_WRITE;
+	case MMAP_FILE_ACCESS_COPY_ON_WRITE:
+		return FILE_MAP_COPY;
+	case MMAP_FILE_ACCESS_READ_EXECUTE:
+		return FILE_MAP_EXECUTE | FILE_MAP_READ;
+	case MMAP_FILE_ACCESS_READ_WRITE_EXECUTE:
+		return FILE_MAP_EXECUTE | FILE_MAP_READ | FILE_MAP_WRITE;
+	default:
+		g_error ("unknown MemoryMappedFileAccess %d", access);
+	}
 }
 
-void
-mono_mmap_configure_inheritability (void *mmap_handle, gboolean inheritability)
+static int convert_win32_error (int error, int def)
 {
-	g_error ("No windows backend");
+	switch (error) {
+	case ERROR_FILE_NOT_FOUND:
+		return FILE_NOT_FOUND;
+	case ERROR_FILE_EXISTS:
+	case ERROR_ALREADY_EXISTS:
+		return FILE_ALREADY_EXISTS;
+	case ERROR_ACCESS_DENIED:
+		return ACCESS_DENIED;
+	}
+	return def;
 }
 
-void
-mono_mmap_flush (void *mmap_handle)
+static void *open_handle (void *handle, MonoString *mapName, int mode, gint64 *capacity, int access, int options, int *error)
 {
-	g_error ("No windows backend");
+	g_assert (handle != NULL);
+
+	wchar_t *w_mapName = NULL;
+	HANDLE result = NULL;
+
+	if (handle == INVALID_HANDLE_VALUE) {
+		if (*capacity <= 0) {
+			*error = CAPACITY_MUST_BE_POSITIVE;
+			return NULL;
+		}
+#if SIZEOF_VOID_P == 4
+		if (*capacity > UINT32_MAX) {
+			*error = CAPACITY_LARGER_THAN_LOGICAL_ADDRESS_SPACE;
+			return NULL;
+		}
+#endif
+		if (!(mode == FILE_MODE_CREATE_NEW || mode == FILE_MODE_OPEN_OR_CREATE || mode == FILE_MODE_OPEN)) {
+			*error = INVALID_FILE_MODE;
+			return NULL;
+		}
+	} else {
+		FILE_STANDARD_INFO info;
+		if (!GetFileInformationByHandleEx ((HANDLE) handle, FileStandardInfo, &info, sizeof (FILE_STANDARD_INFO))) {
+			*error = convert_win32_error (GetLastError (), COULD_NOT_OPEN);
+			return NULL;
+		}
+		if (*capacity == 0) {
+			if (info.EndOfFile.QuadPart == 0) {
+				*error = CAPACITY_SMALLER_THAN_FILE_SIZE;
+				return NULL;
+			}
+		} else if (*capacity < info.EndOfFile.QuadPart) {
+			*error = CAPACITY_SMALLER_THAN_FILE_SIZE;
+			return NULL;
+		}
+	}
+
+	w_mapName = mapName ? mono_string_to_utf16 (mapName) : NULL;
+
+	if (mode == FILE_MODE_CREATE_NEW || handle != INVALID_HANDLE_VALUE) {
+		result = CreateFileMappingW ((HANDLE)handle, NULL, get_page_access (access) | options, (DWORD)(((guint64)*capacity) >> 32), (DWORD)*capacity, w_mapName);
+		if (result && GetLastError () == ERROR_ALREADY_EXISTS) {
+			CloseHandle (result);
+			result = NULL;
+			*error = FILE_ALREADY_EXISTS;
+		} else if (!result && GetLastError () != NO_ERROR) {
+			*error = convert_win32_error (GetLastError (), COULD_NOT_OPEN);
+		}
+	} else if (mode == FILE_MODE_OPEN || mode == FILE_MODE_OPEN_OR_CREATE && access == MMAP_FILE_ACCESS_WRITE) {
+		result = OpenFileMappingW (get_file_map_access (access), FALSE, w_mapName);
+		if (!result) {
+			if (mode == FILE_MODE_OPEN_OR_CREATE && GetLastError () == ERROR_FILE_NOT_FOUND) {
+				*error = INVALID_FILE_MODE;
+			} else {
+				*error = convert_win32_error (GetLastError (), COULD_NOT_OPEN);
+			}
+		}
+	} else if (mode == FILE_MODE_OPEN_OR_CREATE) {
+
+		// This replicates how CoreFX does MemoryMappedFile.CreateOrOpen ().
+
+		/// Try to open the file if it exists -- this requires a bit more work. Loop until we can
+		/// either create or open a memory mapped file up to a timeout. CreateFileMapping may fail
+		/// if the file exists and we have non-null security attributes, in which case we need to
+		/// use OpenFileMapping.  But, there exists a race condition because the memory mapped file
+		/// may have closed between the two calls -- hence the loop. 
+		/// 
+		/// The retry/timeout logic increases the wait time each pass through the loop and times 
+		/// out in approximately 1.4 minutes. If after retrying, a MMF handle still hasn't been opened, 
+		/// throw an InvalidOperationException.
+
+		guint32 waitRetries = 14;   //((2^13)-1)*10ms == approximately 1.4mins
+		guint32 waitSleep = 0;
+
+		while (waitRetries > 0) {
+			result = CreateFileMappingW ((HANDLE)handle, NULL, get_page_access (access) | options, (DWORD)(((guint64)*capacity) >> 32), (DWORD)*capacity, w_mapName);
+			if (result)
+				break;
+			if (GetLastError() != ERROR_ACCESS_DENIED) {
+				*error = convert_win32_error (GetLastError (), COULD_NOT_OPEN);
+				break;
+			}
+			result = OpenFileMappingW (get_file_map_access (access), FALSE, w_mapName);
+			if (result)
+				break;
+			if (GetLastError () != ERROR_FILE_NOT_FOUND) {
+				*error = convert_win32_error (GetLastError (), COULD_NOT_OPEN);
+				break;
+			}
+			// increase wait time
+			--waitRetries;
+			if (waitSleep == 0) {
+				waitSleep = 10;
+			} else {
+				mono_thread_info_sleep (waitSleep, NULL);
+				waitSleep *= 2;
+			}
+		}
+
+		if (!result) {
+			*error = COULD_NOT_OPEN;
+		}
+	}
+
+	if (w_mapName)
+		g_free (w_mapName);
+	return result;
 }
 
-
-
-int
-mono_mmap_map (void *handle, gint64 offset, gint64 *size, int access, void **mmap_handle, void **base_address)
+void *mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint64 *capacity, int access, int options, int *error)
 {
-	g_error ("No windows backend");
+	g_assert (path != NULL || mapName != NULL);
+
+	wchar_t *w_path = NULL;
+	HANDLE hFile = INVALID_HANDLE_VALUE;
+	HANDLE result = NULL;
+	gboolean delete_on_error = FALSE;
+
+	if (path) {
+		w_path = mono_string_to_utf16 (path);
+		WIN32_FILE_ATTRIBUTE_DATA file_attrs;
+		gboolean existed = GetFileAttributesExW (w_path, GetFileExInfoStandard, &file_attrs);
+		if (!existed && mode == FILE_MODE_CREATE_NEW && *capacity == 0) {
+			*error = CAPACITY_SMALLER_THAN_FILE_SIZE;
+			goto done;
+		}
+		hFile = CreateFileW (w_path, get_file_access (access), FILE_SHARE_READ, NULL, mode, FILE_ATTRIBUTE_NORMAL, NULL);
+		if (hFile == INVALID_HANDLE_VALUE) {
+			*error = convert_win32_error (GetLastError (), COULD_NOT_OPEN);
+			goto done;
+		}
+		delete_on_error = !existed;
+	}
+
+	result = open_handle (hFile, mapName, mode, capacity, access, options, error);
+
+done:
+	if (hFile != INVALID_HANDLE_VALUE)
+		 CloseHandle(hFile);
+	if (!result && delete_on_error)
+		DeleteFileW (w_path);
+	if (w_path)
+		g_free (w_path);
+
+	return result;
+}
+
+void *mono_mmap_open_handle (void *handle, MonoString *mapName, gint64 *capacity, int access, int options, int *error)
+{
+	g_assert (handle != NULL);
+
+	return open_handle (handle, mapName, FILE_MODE_OPEN, capacity, access, options, error);
+}
+
+void mono_mmap_close (void *mmap_handle)
+{
+	g_assert (mmap_handle);
+	CloseHandle ((HANDLE) mmap_handle);
+}
+
+void mono_mmap_configure_inheritability (void *mmap_handle, gboolean inheritability)
+{
+	g_assert (mmap_handle);
+	if (!SetHandleInformation ((HANDLE) mmap_handle, HANDLE_FLAG_INHERIT, inheritability ? HANDLE_FLAG_INHERIT : 0)) {
+		g_error ("mono_mmap_configure_inheritability: SetHandleInformation failed with error %d!", GetLastError ());
+	}
+}
+
+void mono_mmap_flush (void *mmap_handle)
+{
+	g_assert (mmap_handle);
+	MmapInstance *h = (MmapInstance *)mmap_handle;
+
+	if (FlushViewOfFile (h->address, h->length))
+		return;
+
+	// This replicates how CoreFX does MemoryMappedView.Flush ().
+
+	// It is a known issue within the NTFS transaction log system that
+	// causes FlushViewOfFile to intermittently fail with ERROR_LOCK_VIOLATION
+	// As a workaround, we catch this particular error and retry the flush operation 
+	// a few milliseconds later. If it does not work, we give it a few more tries with
+	// increasing intervals. Eventually, however, we need to give up. In ad-hoc tests
+	// this strategy successfully flushed the view after no more than 3 retries.
+
+	if (GetLastError () != ERROR_LOCK_VIOLATION)
+		// TODO: Propagate error to caller
+		return;
+
+	for (int w = 0; w < MAX_FLUSH_WAITS; w++) {
+		int pause = (1 << w);  // MaxFlushRetries should never be over 30
+		mono_thread_info_sleep (pause, NULL);
+
+		for (int r = 0; r < MAX_FLUSH_RETIRES_PER_WAIT; r++) {
+			if (FlushViewOfFile (h->address, h->length))
+				return;
+
+			if (GetLastError () != ERROR_LOCK_VIOLATION)
+				// TODO: Propagate error to caller
+				return;
+
+			mono_thread_info_yield ();
+		}
+	}
+
+	// We got to here, so there was no success:
+	// TODO: Propagate error to caller
+}
+
+int mono_mmap_map (void *handle, gint64 offset, gint64 *size, int access, void **mmap_handle, void **base_address)
+{
+	static DWORD allocationGranularity = 0;
+	if (allocationGranularity == 0) {
+		SYSTEM_INFO info;
+		GetSystemInfo (&info);
+		allocationGranularity = info.dwAllocationGranularity;
+	}
+
+	gint64 extraMemNeeded = offset % allocationGranularity;
+	guint64 newOffset = offset - extraMemNeeded;
+	gint64 nativeSize = (*size != 0) ? *size + extraMemNeeded : 0;
+
+#if SIZEOF_VOID_P == 4
+	if (nativeSize > UINT32_MAX)
+		return CAPACITY_LARGER_THAN_LOGICAL_ADDRESS_SPACE;
+#endif
+	
+	void *address = MapViewOfFile ((HANDLE) handle, get_file_map_access (access), (DWORD) (newOffset >> 32), (DWORD) newOffset, (SIZE_T) nativeSize);
+	if (!address)
+		return convert_win32_error (GetLastError (), COULD_NOT_MAP_MEMORY);
+
+	// Query the view for its size and allocation type
+	MEMORY_BASIC_INFORMATION viewInfo;
+	VirtualQuery (address, &viewInfo, sizeof (MEMORY_BASIC_INFORMATION));
+	guint64 viewSize = (guint64) viewInfo.RegionSize;
+
+	// Allocate the pages if we were using the MemoryMappedFileOptions.DelayAllocatePages option
+	// OR check if the allocated view size is smaller than the expected native size
+	// If multiple overlapping views are created over the file mapping object, the pages in a given region
+	// could have different attributes(MEM_RESERVE OR MEM_COMMIT) as MapViewOfFile preserves coherence between 
+	// views created on a mapping object backed by same file.
+	// In which case, the viewSize will be smaller than nativeSize required and viewState could be MEM_COMMIT 
+	// but more pages may need to be committed in the region.
+	// This is because, VirtualQuery function(that internally invokes VirtualQueryEx function) returns the attributes 
+	// and size of the region of pages with matching attributes starting from base address.
+	// VirtualQueryEx: http://msdn.microsoft.com/en-us/library/windows/desktop/aa366907(v=vs.85).aspx
+	if (((viewInfo.State & MEM_RESERVE) != 0) || viewSize < (guint64) nativeSize) {
+		void *tempAddress = VirtualAlloc (address, nativeSize != 0 ? nativeSize : viewSize, MEM_COMMIT, get_page_access (access));
+		if (!tempAddress) {
+			return convert_win32_error (GetLastError (), COULD_NOT_MAP_MEMORY);
+		}
+		// again query the view for its new size
+		VirtualQuery (address, &viewInfo, sizeof (MEMORY_BASIC_INFORMATION));
+		viewSize = (guint64) viewInfo.RegionSize;
+	}
+
+	if (*size == 0)
+		*size = viewSize - extraMemNeeded;
+
+	MmapInstance *h = g_malloc0 (sizeof (MmapInstance));
+	h->address = address;
+	h->length = *size + extraMemNeeded;
+	*mmap_handle = h;
+	*base_address = (char*) address + (offset - newOffset);
+
 	return 0;
 }
 
-gboolean
-mono_mmap_unmap (void *mmap_handle)
+gboolean mono_mmap_unmap (void *mmap_handle)
 {
-	g_error ("No windows backend");
-	return TRUE;
+	g_assert (mmap_handle);
+
+	MmapInstance *h = (MmapInstance *) mmap_handle;
+
+	gboolean result = UnmapViewOfFile (h->address);
+
+	g_free (h);
+	return result;
 }
 
 #endif

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -1,0 +1,237 @@
+/*
+ * mono-mmap-windows.c: Windows support for mapping code into the process address space
+ *
+ * Author:
+ *   Mono Team (mono-list@lists.ximian.com)
+ *
+ * Copyright 2001-2008 Novell, Inc.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+#include <glib.h>
+
+#if defined(HOST_WIN32)
+#include <Windows.h>
+#include "mono/utils/mono-mmap-windows.h"
+#include "mono/utils/mono-mmap-internals.h"
+#include <mono/utils/mono-counters.h>
+#include <io.h>
+
+typedef struct {
+	int size;
+	int pid;
+	int reserved;
+	short stats_start;
+	short stats_end;
+} SAreaHeader;
+
+static void *malloced_shared_area = NULL;
+
+static void*
+malloc_shared_area(int pid)
+{
+	int size = mono_pagesize();
+	SAreaHeader *sarea = (SAreaHeader *)g_malloc0(size);
+	sarea->size = size;
+	sarea->pid = pid;
+	sarea->stats_start = sizeof(SAreaHeader);
+	sarea->stats_end = sizeof(SAreaHeader);
+
+	return sarea;
+}
+
+static char*
+aligned_address(char *mem, size_t size, size_t alignment)
+{
+	char *aligned = (char*)((size_t)(mem + (alignment - 1)) & ~(alignment - 1));
+	g_assert(aligned >= mem && aligned + size <= mem + size + alignment && !((size_t)aligned & (alignment - 1)));
+	return aligned;
+}
+
+int
+mono_pagesize (void)
+{
+	SYSTEM_INFO info;
+	static int saved_pagesize = 0;
+	if (saved_pagesize)
+		return saved_pagesize;
+	GetSystemInfo (&info);
+	saved_pagesize = info.dwPageSize;
+	return saved_pagesize;
+}
+
+int
+mono_valloc_granule (void)
+{
+	SYSTEM_INFO info;
+	static int saved_valloc_granule = 0;
+	if (saved_valloc_granule)
+		return saved_valloc_granule;
+	GetSystemInfo (&info);
+	saved_valloc_granule = info.dwAllocationGranularity;
+	return saved_valloc_granule;
+}
+
+int
+mono_mmap_win_prot_from_flags (int flags)
+{
+	int prot = flags & (MONO_MMAP_READ|MONO_MMAP_WRITE|MONO_MMAP_EXEC);
+	switch (prot) {
+	case 0: prot = PAGE_NOACCESS; break;
+	case MONO_MMAP_READ: prot = PAGE_READONLY; break;
+	case MONO_MMAP_READ|MONO_MMAP_EXEC: prot = PAGE_EXECUTE_READ; break;
+	case MONO_MMAP_READ|MONO_MMAP_WRITE: prot = PAGE_READWRITE; break;
+	case MONO_MMAP_READ|MONO_MMAP_WRITE|MONO_MMAP_EXEC: prot = PAGE_EXECUTE_READWRITE; break;
+	case MONO_MMAP_WRITE: prot = PAGE_READWRITE; break;
+	case MONO_MMAP_WRITE|MONO_MMAP_EXEC: prot = PAGE_EXECUTE_READWRITE; break;
+	case MONO_MMAP_EXEC: prot = PAGE_EXECUTE; break;
+	default:
+		g_assert_not_reached ();
+	}
+	return prot;
+}
+
+void*
+mono_valloc (void *addr, size_t length, int flags)
+{
+	void *ptr;
+	int mflags = MEM_RESERVE|MEM_COMMIT;
+	int prot = mono_mmap_win_prot_from_flags (flags);
+	/* translate the flags */
+
+	ptr = VirtualAlloc (addr, length, mflags, prot);
+
+	return ptr;
+}
+
+void*
+mono_valloc_aligned (size_t length, size_t alignment, int flags)
+{
+	int prot = mono_mmap_win_prot_from_flags (flags);
+	char *mem = VirtualAlloc (NULL, length + alignment, MEM_RESERVE, prot);
+	char *aligned;
+
+	if (!mem)
+		return NULL;
+
+	aligned = aligned_address (mem, length, alignment);
+
+	aligned = VirtualAlloc (aligned, length, MEM_COMMIT, prot);
+	g_assert (aligned);
+
+	return aligned;
+}
+
+int
+mono_vfree (void *addr, size_t length)
+{
+	MEMORY_BASIC_INFORMATION mbi;
+	SIZE_T query_result = VirtualQuery (addr, &mbi, sizeof (mbi));
+	BOOL res;
+
+	g_assert (query_result);
+
+	res = VirtualFree (mbi.AllocationBase, 0, MEM_RELEASE);
+
+	g_assert (res);
+
+	return 0;
+}
+
+void*
+mono_file_map (size_t length, int flags, int fd, guint64 offset, void **ret_handle)
+{
+	void *ptr;
+	int mflags = 0;
+	HANDLE file, mapping;
+	int prot = mono_mmap_win_prot_from_flags (flags);
+	/* translate the flags */
+	/*if (flags & MONO_MMAP_PRIVATE)
+		mflags |= MAP_PRIVATE;
+	if (flags & MONO_MMAP_SHARED)
+		mflags |= MAP_SHARED;
+	if (flags & MONO_MMAP_ANON)
+		mflags |= MAP_ANONYMOUS;
+	if (flags & MONO_MMAP_FIXED)
+		mflags |= MAP_FIXED;
+	if (flags & MONO_MMAP_32BIT)
+		mflags |= MAP_32BIT;*/
+
+	mflags = FILE_MAP_READ;
+	if (flags & MONO_MMAP_WRITE)
+		mflags = FILE_MAP_COPY;
+
+	file = (HANDLE) _get_osfhandle (fd);
+
+	mapping = CreateFileMapping (file, NULL, prot, 0, 0, NULL);
+
+	if (mapping == NULL)
+		return NULL;
+
+	ptr = MapViewOfFile (mapping, mflags, 0, offset, length);
+
+	if (ptr == NULL) {
+		CloseHandle (mapping);
+		return NULL;
+	}
+	*ret_handle = (void*)mapping;
+	return ptr;
+}
+
+int
+mono_file_unmap (void *addr, void *handle)
+{
+	UnmapViewOfFile (addr);
+	CloseHandle ((HANDLE)handle);
+	return 0;
+}
+#endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
+
+int
+mono_mprotect (void *addr, size_t length, int flags)
+{
+	DWORD oldprot;
+	int prot = mono_mmap_win_prot_from_flags (flags);
+
+	if (flags & MONO_MMAP_DISCARD) {
+		VirtualFree (addr, length, MEM_DECOMMIT);
+		VirtualAlloc (addr, length, MEM_COMMIT, prot);
+		return 0;
+	}
+	return VirtualProtect (addr, length, prot, &oldprot) == 0;
+}
+
+void*
+mono_shared_area (void)
+{
+	if (!malloced_shared_area)
+		malloced_shared_area = malloc_shared_area (0);
+	/* get the pid here */
+	return malloced_shared_area;
+}
+
+void
+mono_shared_area_remove (void)
+{
+	if (malloced_shared_area)
+		g_free (malloced_shared_area);
+	malloced_shared_area = NULL;
+}
+
+void*
+mono_shared_area_for_pid (void *pid)
+{
+	return NULL;
+}
+
+void
+mono_shared_area_unload (void *area)
+{
+}
+
+int
+mono_shared_area_instances (void **array, int count)
+{
+	return 0;
+}

--- a/mono/utils/mono-mmap-windows.h
+++ b/mono/utils/mono-mmap-windows.h
@@ -1,0 +1,14 @@
+#ifndef __MONO_UTILS_MMAP_WINDOWS_H__
+#define __MONO_UTILS_MMAP_WINDOWS_H__
+
+#include <config.h>
+#include <glib.h>
+
+#ifdef HOST_WIN32
+#include "mono/utils/mono-mmap.h"
+#include "mono/utils/mono-mmap-internals.h"
+
+int
+mono_mmap_win_prot_from_flags (int flags);
+#endif /* HOST_WIN32 */
+#endif /* __MONO_UTILS_MMAP_WINDOWS_H__ */

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -85,177 +85,8 @@ aligned_address (char *mem, size_t size, size_t alignment)
 }
 
 #ifdef HOST_WIN32
-
-int
-mono_pagesize (void)
-{
-	SYSTEM_INFO info;
-	static int saved_pagesize = 0;
-	if (saved_pagesize)
-		return saved_pagesize;
-	GetSystemInfo (&info);
-	saved_pagesize = info.dwPageSize;
-	return saved_pagesize;
-}
-
-static int
-prot_from_flags (int flags)
-{
-	int prot = flags & (MONO_MMAP_READ|MONO_MMAP_WRITE|MONO_MMAP_EXEC);
-	switch (prot) {
-	case 0: prot = PAGE_NOACCESS; break;
-	case MONO_MMAP_READ: prot = PAGE_READONLY; break;
-	case MONO_MMAP_READ|MONO_MMAP_EXEC: prot = PAGE_EXECUTE_READ; break;
-	case MONO_MMAP_READ|MONO_MMAP_WRITE: prot = PAGE_READWRITE; break;
-	case MONO_MMAP_READ|MONO_MMAP_WRITE|MONO_MMAP_EXEC: prot = PAGE_EXECUTE_READWRITE; break;
-	case MONO_MMAP_WRITE: prot = PAGE_READWRITE; break;
-	case MONO_MMAP_WRITE|MONO_MMAP_EXEC: prot = PAGE_EXECUTE_READWRITE; break;
-	case MONO_MMAP_EXEC: prot = PAGE_EXECUTE; break;
-	default:
-		g_assert_not_reached ();
-	}
-	return prot;
-}
-
-void*
-mono_valloc (void *addr, size_t length, int flags)
-{
-	void *ptr;
-	int mflags = MEM_RESERVE|MEM_COMMIT;
-	int prot = prot_from_flags (flags);
-	/* translate the flags */
-
-	ptr = VirtualAlloc (addr, length, mflags, prot);
-	return ptr;
-}
-
-void*
-mono_valloc_aligned (size_t length, size_t alignment, int flags)
-{
-	int prot = prot_from_flags (flags);
-	char *mem = VirtualAlloc (NULL, length + alignment, MEM_RESERVE, prot);
-	char *aligned;
-
-	if (!mem)
-		return NULL;
-
-	aligned = aligned_address (mem, length, alignment);
-
-	aligned = VirtualAlloc (aligned, length, MEM_COMMIT, prot);
-	g_assert (aligned);
-
-	return aligned;
-}
-
+//Windows specific implementaiton in mono-mmap-windows.c
 #define HAVE_VALLOC_ALIGNED
-
-int
-mono_vfree (void *addr, size_t length)
-{
-	MEMORY_BASIC_INFORMATION mbi;
-	SIZE_T query_result = VirtualQuery (addr, &mbi, sizeof (mbi));
-	BOOL res;
-
-	g_assert (query_result);
-
-	res = VirtualFree (mbi.AllocationBase, 0, MEM_RELEASE);
-
-	g_assert (res);
-
-	return 0;
-}
-
-void*
-mono_file_map (size_t length, int flags, int fd, guint64 offset, void **ret_handle)
-{
-	void *ptr;
-	int mflags = 0;
-	HANDLE file, mapping;
-	int prot = prot_from_flags (flags);
-	/* translate the flags */
-	/*if (flags & MONO_MMAP_PRIVATE)
-		mflags |= MAP_PRIVATE;
-	if (flags & MONO_MMAP_SHARED)
-		mflags |= MAP_SHARED;
-	if (flags & MONO_MMAP_ANON)
-		mflags |= MAP_ANONYMOUS;
-	if (flags & MONO_MMAP_FIXED)
-		mflags |= MAP_FIXED;
-	if (flags & MONO_MMAP_32BIT)
-		mflags |= MAP_32BIT;*/
-
-	mflags = FILE_MAP_READ;
-	if (flags & MONO_MMAP_WRITE)
-		mflags = FILE_MAP_COPY;
-
-	file = (HANDLE) _get_osfhandle (fd);
-	mapping = CreateFileMapping (file, NULL, prot, 0, 0, NULL);
-	if (mapping == NULL)
-		return NULL;
-	ptr = MapViewOfFile (mapping, mflags, 0, offset, length);
-	if (ptr == NULL) {
-		CloseHandle (mapping);
-		return NULL;
-	}
-	*ret_handle = (void*)mapping;
-	return ptr;
-}
-
-int
-mono_file_unmap (void *addr, void *handle)
-{
-	UnmapViewOfFile (addr);
-	CloseHandle ((HANDLE)handle);
-	return 0;
-}
-
-int
-mono_mprotect (void *addr, size_t length, int flags)
-{
-	DWORD oldprot;
-	int prot = prot_from_flags (flags);
-
-	if (flags & MONO_MMAP_DISCARD) {
-		VirtualFree (addr, length, MEM_DECOMMIT);
-		VirtualAlloc (addr, length, MEM_COMMIT, prot);
-		return 0;
-	}
-	return VirtualProtect (addr, length, prot, &oldprot) == 0;
-}
-
-void*
-mono_shared_area (void)
-{
-	if (!malloced_shared_area)
-		malloced_shared_area = malloc_shared_area (0);
-	/* get the pid here */
-	return malloced_shared_area;
-}
-
-void
-mono_shared_area_remove (void)
-{
-	if (malloced_shared_area)
-		g_free (malloced_shared_area);
-	malloced_shared_area = NULL;
-}
-
-void*
-mono_shared_area_for_pid (void *pid)
-{
-	return NULL;
-}
-
-void
-mono_shared_area_unload (void *area)
-{
-}
-
-int
-mono_shared_area_instances (void **array, int count)
-{
-	return 0;
-}
 
 #else
 #if defined(HAVE_MMAP)
@@ -276,6 +107,12 @@ mono_pagesize (void)
 		return saved_pagesize;
 	saved_pagesize = getpagesize ();
 	return saved_pagesize;
+}
+
+int
+mono_valloc_granule (void)
+{
+	return mono_pagesize ();
 }
 
 static int
@@ -492,6 +329,12 @@ int
 mono_pagesize (void)
 {
 	return 4096;
+}
+
+int
+mono_valloc_granule (void)
+{
+	return mono_pagesize ();
 }
 
 void*

--- a/mono/utils/mono-mmap.h
+++ b/mono/utils/mono-mmap.h
@@ -31,6 +31,7 @@ MONO_API int          mono_file_map_fd    (MonoFileMap *fmap);
 MONO_API int          mono_file_map_close (MonoFileMap *fmap);
 
 MONO_API int   mono_pagesize   (void);
+MONO_API int   mono_valloc_granule(void);
 MONO_API void* mono_valloc     (void *addr, size_t length, int flags);
 MONO_API void* mono_valloc_aligned (size_t length, size_t alignment, int flags);
 MONO_API int   mono_vfree      (void *addr, size_t length);

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -47,6 +47,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-log-common.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-math.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-md5.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-mmap-windows.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-mmap.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-networkinterfaces.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-rand.c" />


### PR DESCRIPTION
Backport the windows mmap support already in Mono 5.0 (2017_01) to 4.8.0 for users in unity-2017.1
(also fixes issue where the mmap support keeps a file handle open)