### PR TITLE
[mcs] Don't do constraints on fabricated generic methods. Fixes #47672

### DIFF
--- a/mcs/mcs/method.cs
+++ b/mcs/mcs/method.cs
@@ -731,7 +731,12 @@ namespace Mono.CSharp {
 				}
 			}
 
-			if (type_expr != null)
+			//
+			// Optimization but it also covers cases where we cannot check
+			// constraints because method is captured into generated class
+			// and type parameters context is now different
+			//
+			if (type_expr != null && !IsCompilerGenerated)
 				ConstraintChecker.Check (this, member_type, type_expr.Location);
 
 			base.Emit ();

--- a/mcs/tests/gtest-642.cs
+++ b/mcs/tests/gtest-642.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+	static void Main ()
+	{
+	}
+
+	public static void Transform<V> (Area<V> area, Func<V, V> transform)
+		where V : IA<V>
+	{
+		Test (GetIB<V> (), t => Transform2 (null, transform));
+	}
+
+	static IB<W> GetIB<W> ()
+		where W : IA<W>
+	{
+		return null;
+	}
+
+	static void Test<T> (T values, Func<T, T> func)
+	{
+	}
+
+	public static IB<U> Transform2<U> (
+		IB<U> b,
+		Func<U, U> transform) where U : IA<U>
+	{
+		return null;
+	}
+}
+
+
+public class Area<TVector>
+	where TVector : IA<TVector>
+{
+	public IB<TVector> GetSegments ()
+	{
+		return null;
+	}
+}
+
+public interface IB<TB>
+	where TB : IA<TB>
+{
+}
+
+public interface IA<T>
+{
+}


### PR DESCRIPTION
I neglected to cherry pick the second Mono C# compiler fix we needed to fully correct case 847798. This is it. It is already in 5.5 and 2017.1.