### PR TITLE
Increase the code size for deep profiling again

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -5661,7 +5661,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	gboolean args_clobbered = FALSE;
 	gboolean trace = FALSE;
 
-	cfg->code_size =  MAX (((MonoMethodNormal *)method)->header->code_size * 4, 14000);
+	cfg->code_size =  MAX (((MonoMethodNormal *)method)->header->code_size * 4, 20000);
 
 	code = cfg->native_code = g_malloc (cfg->code_size);
 


### PR DESCRIPTION
We continue to get bug reports with larger and larger code sizes. Let's
make it much bigger this time in hopes of catching more cases.