### PR TITLE
NULL terminate in the assemblies in the debugger

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5725,7 +5725,7 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				int n = decode_int (p, &p, end);
 				int j;
 
-				req->modifiers [i].data.assemblies = g_new0 (MonoAssembly*, n);
+				req->modifiers [i].data.assemblies = g_new0 (MonoAssembly*, n + 1);
 				for (j = 0; j < n; ++j) {
 					req->modifiers [i].data.assemblies [j] = decode_assemblyid (p, &p, end, &domain, &err);
 					if (err) {


### PR DESCRIPTION
When a MOD_KIND_ASSEMBLY_ONLY event is processed, the debugger agent
assumes the list of assemblies is NULL terminated. However, the event
processing code was not leaving a NULL terminator.

Allocate one additional entry, and leave it empty (the g_new0 call zeros
memory already). This same change was made in upstream Mono.

This corrects a number of intermittent crashes in Unity when the
debugger is attached, including case 914171.