### PR TITLE
Make mono_class_from_name work with Type Forwarders on Mono AOT

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -6615,10 +6615,13 @@ mono_class_from_name (MonoImage *image, const char* name_space, const char *name
 		if (res) {
 			if (!class)
 				class = search_modules (image, name_space, name);
-			if (nested)
-				return class ? return_nested_in (class, nested) : NULL;
-			else
-				return class;
+			if (class)
+			{
+				if (nested)
+					return class ? return_nested_in (class, nested) : NULL;
+				else
+					return class;
+			}
 		}
 	}
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -6618,7 +6618,7 @@ mono_class_from_name (MonoImage *image, const char* name_space, const char *name
 			if (class)
 			{
 				if (nested)
-					return class ? return_nested_in (class, nested) : NULL;
+					return return_nested_in (class, nested);
 				else
 					return class;
 			}


### PR DESCRIPTION
This fixes mono_class_from_name to resolve classes forwarded to other assemblies in Mono AOT.

Mono AOT installs a get_class_from_name callback for mono_class_from_name to use to find a class in an assembly. However, when that returns null, it will exit the function, bypassing the logic in mono_class_from_name which would resolve forwarded types. This change makes the function not return when get_class_from_name returns null, but instead run the rest of mono_class_from_name.

This seems to work well, and makes my code using forwarders pass runtime tests on Mono AOT platforms. However, I am not very knowledgeable of this code, and not sure if there might be unintended side effects?