### PR TITLE
Compile Mono for other platforms

### DIFF
--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -76,6 +76,8 @@ GetTokenName (uid_t uid)
 {
 	gchar *uname = NULL;
 
+#ifdef HAVE_PWD_H
+
 #ifdef HAVE_GETPWUID_R
 	struct passwd pwd;
 	size_t fbufsize;
@@ -108,8 +110,12 @@ GetTokenName (uid_t uid)
 	g_free (fbuf);
 #endif
 
+#endif /* HAVE_PWD_H */
+
 	return uname;
 }
+
+#ifdef HAVE_GRP_H
 
 static gboolean
 IsMemberInList (uid_t user, struct group *g) 
@@ -137,9 +143,15 @@ IsMemberInList (uid_t user, struct group *g)
 	return result;
 }
 
+#endif /* HAVE_GRP_H */
+
 static gboolean
 IsDefaultGroup (uid_t user, gid_t group)
 {
+	gboolean result = FALSE;
+
+#ifdef HAVE_PWD_H
+
 #ifdef HAVE_GETPWUID_R
 	struct passwd pwd;
 	size_t fbufsize;
@@ -147,7 +159,6 @@ IsDefaultGroup (uid_t user, gid_t group)
 	gint32 retval;
 #endif
 	struct passwd *p = NULL;
-	gboolean result;
 
 #ifdef HAVE_GETPWUID_R
 #ifdef _SC_GETPW_R_SIZE_MAX
@@ -173,8 +184,12 @@ IsDefaultGroup (uid_t user, gid_t group)
 	g_free (fbuf);
 #endif
 
+#endif /* HAVE_PWD_H */
+
 	return result;
 }
+
+#ifdef HAVE_GRP_H
 
 static gboolean
 IsMemberOf (gid_t user, struct group *g) 
@@ -189,6 +204,9 @@ IsMemberOf (gid_t user, struct group *g)
 	/* is the user in the group list */
 	return IsMemberInList (user, g);
 }
+
+#endif /* HAVE_GRP_H */
+
 #endif /* !HOST_WIN32 */
 
 /* ICALLS */
@@ -248,13 +266,16 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetTokenName (gpointer token
 gpointer
 ves_icall_System_Security_Principal_WindowsIdentity_GetUserToken (MonoString *username)
 {
+	gpointer token = (gpointer)-2;
+
+#ifdef HAVE_PWD_H
+
 #ifdef HAVE_GETPWNAM_R
 	struct passwd pwd;
 	size_t fbufsize;
 	gchar *fbuf;
 	gint32 retval;
 #endif
-	gpointer token = (gpointer) -2;
 	struct passwd *p;
 	gchar *utf8_name;
 	gboolean result;
@@ -285,6 +306,8 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetUserToken (MonoString *us
 	g_free (fbuf);
 #endif
 	g_free (utf8_name);
+
+#endif /* HAVE_PWD_H */
 
 	return token;
 }
@@ -382,6 +405,8 @@ ves_icall_System_Security_Principal_WindowsPrincipal_IsMemberOfGroupId (gpointer
 {
 	gboolean result = FALSE;
 
+#ifdef HAVE_GRP_H
+
 #ifdef HAVE_GETGRGID_R
 	struct group grp;
 	size_t fbufsize;
@@ -413,6 +438,8 @@ ves_icall_System_Security_Principal_WindowsPrincipal_IsMemberOfGroupId (gpointer
 	g_free (fbuf);
 #endif
 
+#endif /* HAVE_GRP_H */
+
 	return result;
 }
 
@@ -420,6 +447,9 @@ gboolean
 ves_icall_System_Security_Principal_WindowsPrincipal_IsMemberOfGroupName (gpointer user, MonoString *group)
 {
 	gboolean result = FALSE;
+
+#ifdef HAVE_GRP_H
+
 	gchar *utf8_groupname;
 
 	utf8_groupname = mono_unicode_to_external (mono_string_chars (group));
@@ -452,6 +482,8 @@ ves_icall_System_Security_Principal_WindowsPrincipal_IsMemberOfGroupName (gpoint
 #endif
 		g_free (utf8_groupname);
 	}
+
+#endif /* HAVE_GRP_H */
 
 	return result;
 }

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -3,7 +3,9 @@
 
 #include "w32process.h"
 #include "w32process-internals.h"
+#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) && defined(HOST_WIN32)
 #include "w32process-win32-internals.h"
+#endif
 #include "w32file.h"
 #include "object.h"
 #include "object-internals.h"

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2397,6 +2397,7 @@ ves_icall_System_Net_Sockets_Socket_Shutdown_internal (gsize sock, gint32 how, g
 gint
 ves_icall_System_Net_Sockets_Socket_IOControl_internal (gsize sock, gint32 code, MonoArray *input, MonoArray *output, gint32 *werror)
 {
+#if !defined(PLATFORM_UNITY)
 	glong output_bytes = 0;
 	gchar *i_buffer, *o_buffer;
 	gint i_len, o_len;
@@ -2436,6 +2437,10 @@ ves_icall_System_Net_Sockets_Socket_IOControl_internal (gsize sock, gint32 code,
 	}
 
 	return (gint)output_bytes;
+#else
+	g_assert_not_reached();
+	return 0;
+#endif
 }
 
 MonoBoolean
@@ -2612,7 +2617,9 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 	MonoAddressInfo *info = NULL;
 	MonoError error;
 	gint32 family;
+#if !defined(PLATFORM_UNITY)
 	gchar hostname [NI_MAXHOST] = { 0 };
+#endif
 	gboolean ret;
 
 	address = mono_string_to_utf8_checked (addr, &error);
@@ -2641,7 +2648,11 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 #if HAVE_SOCKADDR_IN_SIN_LEN
 		saddr.sin_len = sizeof (saddr);
 #endif
+#if !defined(PLATFORM_UNITY)
 		ret = getnameinfo ((struct sockaddr*)&saddr, sizeof (saddr), hostname, sizeof (hostname), NULL, 0, 0) == 0;
+#else
+		g_assert_not_reached();
+#endif
 		break;
 	}
 #ifdef HAVE_STRUCT_SOCKADDR_IN6
@@ -2649,7 +2660,11 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 #if HAVE_SOCKADDR_IN6_SIN_LEN
 		saddr6.sin6_len = sizeof (saddr6);
 #endif
+#if !defined(PLATFORM_UNITY)
 		ret = getnameinfo ((struct sockaddr*)&saddr6, sizeof (saddr6), hostname, sizeof (hostname), NULL, 0, 0) == 0;
+#else
+		g_assert_not_reached();
+#endif
 		break;
 	}
 #endif
@@ -2662,9 +2677,12 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 	if (!ret)
 		return FALSE;
 
+#if !defined(PLATFORM_UNITY)
 	if (mono_get_address_info (hostname, 0, hint | MONO_HINT_CANONICAL_NAME | MONO_HINT_CONFIGURED_ONLY, &info) != 0)
 		return FALSE;
-
+#else
+	g_assert_not_reached();
+#endif
 	MonoBoolean result = addrinfo_to_IPHostEntry (info, h_name, h_aliases, h_addr_list, FALSE, &error);
 	mono_error_set_pending_exception (&error);
 	return result;
@@ -2673,6 +2691,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 MonoBoolean
 ves_icall_System_Net_Dns_GetHostName_internal (MonoString **h_name)
 {
+#if !defined (PLATFORM_UNITY)
 	gchar hostname [NI_MAXHOST] = { 0 };
 	int ret;
 
@@ -2681,7 +2700,9 @@ ves_icall_System_Net_Dns_GetHostName_internal (MonoString **h_name)
 		return FALSE;
 
 	*h_name = mono_string_new (mono_domain_get (), hostname);
-
+#else
+	g_assert_not_reached();
+#endif
 	return TRUE;
 }
 

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -203,7 +203,11 @@ convert_family (MonoAddressFamily mono_family)
 	case AddressFamily_InterNetwork:
 		return AF_INET;
 	case AddressFamily_AppleTalk:
+#ifdef AF_APPLETALK
 		return AF_APPLETALK;
+#else
+		return -1;
+#endif
 	case AddressFamily_InterNetworkV6:
 		return AF_INET6;
 	case AddressFamily_DecNet:
@@ -258,8 +262,10 @@ convert_to_mono_family (guint16 af_family)
 	case AF_DECnet:
 		return AddressFamily_DecNet;
 #endif
+#ifdef AF_APPLETALK
 	case AF_APPLETALK:
 		return AddressFamily_AppleTalk;
+#endif
 	case AF_INET6:
 		return AddressFamily_InterNetworkV6;
 #ifdef AF_IRDA
@@ -289,7 +295,11 @@ convert_type (MonoSocketType mono_type)
 		return -1;
 #endif
 	case SocketType_Seqpacket:
+#ifdef SOCK_SEQPACKET
 		return SOCK_SEQPACKET;
+#else
+		return -1;
+#endif
 	case SocketType_Unknown:
 		g_warning ("System.Net.Sockets.SocketType has unsupported value 0x%x", mono_type);
 		return -1;
@@ -343,8 +353,10 @@ convert_socketflags (gint32 sflags)
 		/* Contains invalid flag values */
 		return -1;
 
+#ifdef MSG_OOB
 	if (sflags & SocketFlags_OutOfBand)
 		flags |= MSG_OOB;
+#endif
 	if (sflags & SocketFlags_Peek)
 		flags |= MSG_PEEK;
 	if (sflags & SocketFlags_DontRoute)
@@ -388,9 +400,11 @@ convert_sockopt_level_and_name (MonoSocketOptionLevel mono_level, MonoSocketOpti
 			 */
 			*system_name = SO_LINGER;
 			break;
+#ifdef SO_DEBUG
 		case SocketOptionName_Debug:
 			*system_name = SO_DEBUG;
 			break;
+#endif
 #ifdef SO_ACCEPTCONN
 		case SocketOptionName_AcceptConnection:
 			*system_name = SO_ACCEPTCONN;
@@ -402,18 +416,22 @@ convert_sockopt_level_and_name (MonoSocketOptionLevel mono_level, MonoSocketOpti
 		case SocketOptionName_KeepAlive:
 			*system_name = SO_KEEPALIVE;
 			break;
+#ifdef SO_DONTROUTE
 		case SocketOptionName_DontRoute:
 			*system_name = SO_DONTROUTE;
 			break;
+#endif
 		case SocketOptionName_Broadcast:
 			*system_name = SO_BROADCAST;
 			break;
 		case SocketOptionName_Linger:
 			*system_name = SO_LINGER;
 			break;
+#ifdef SO_OOBINLINE
 		case SocketOptionName_OutOfBandInline:
 			*system_name = SO_OOBINLINE;
 			break;
+#endif
 		case SocketOptionName_SendBuffer:
 			*system_name = SO_SNDBUF;
 			break;
@@ -471,9 +489,11 @@ convert_sockopt_level_and_name (MonoSocketOptionLevel mono_level, MonoSocketOpti
 		*system_level = mono_networking_get_ip_protocol ();
 		
 		switch (mono_name) {
+#ifdef IP_OPTIONS
 		case SocketOptionName_IPOptions:
 			*system_name = IP_OPTIONS;
 			break;
+#endif
 #ifdef IP_HDRINCL
 		case SocketOptionName_HeaderIncluded:
 			*system_name = IP_HDRINCL;

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -209,7 +209,11 @@ convert_family (MonoAddressFamily mono_family)
 		return -1;
 #endif
 	case AddressFamily_InterNetworkV6:
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 		return AF_INET6;
+#else
+		return -1;
+#endif
 	case AddressFamily_DecNet:
 #ifdef AF_DECnet
 		return AF_DECnet;
@@ -266,7 +270,9 @@ convert_to_mono_family (guint16 af_family)
 	case AF_APPLETALK:
 		return AddressFamily_AppleTalk;
 #endif
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	case AF_INET6:
+#endif
 		return AddressFamily_InterNetworkV6;
 #ifdef AF_IRDA
 	case AF_IRDA:
@@ -560,6 +566,7 @@ convert_sockopt_level_and_name (MonoSocketOptionLevel mono_level, MonoSocketOpti
 
 		switch (mono_name) {
 		case SocketOptionName_IpTimeToLive:
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 		case SocketOptionName_HopLimit:
 			*system_name = IPV6_UNICAST_HOPS;
 			break;
@@ -578,6 +585,7 @@ convert_sockopt_level_and_name (MonoSocketOptionLevel mono_level, MonoSocketOpti
 		case SocketOptionName_DropMembership:
 			*system_name = IPV6_LEAVE_GROUP;
 			break;
+#endif
 		case SocketOptionName_IPv6Only:
 #ifdef IPV6_V6ONLY
 			*system_name = IPV6_V6ONLY;
@@ -818,6 +826,7 @@ ves_icall_System_Net_Sockets_Socket_Listen_internal(gsize sock, guint32 backlog,
 		*werror = mono_w32socket_get_last_error ();
 }
 
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 // Check whether it's ::ffff::0:0.
 static gboolean
 is_ipv4_mapped_any (const struct in6_addr *addr)
@@ -836,6 +845,7 @@ is_ipv4_mapped_any (const struct in6_addr *addr)
 	}
 	return TRUE;
 }
+#endif
 
 static MonoObject*
 create_object_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 *werror, MonoError *error)
@@ -909,7 +919,9 @@ create_object_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 *werror
 		mono_field_set_value (sockaddr_obj, domain->sockaddr_data_length_field, &buffer_size);
 
 		return sockaddr_obj;
-	} else if (saddr->sa_family == AF_INET6) {
+	}
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
+	else if (saddr->sa_family == AF_INET6) {
 		struct sockaddr_in6 *sa_in = (struct sockaddr_in6 *)saddr;
 		int i;
 		int buffer_size = 28;
@@ -948,6 +960,7 @@ create_object_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 *werror
 
 		return sockaddr_obj;
 	}
+#endif
 #ifdef HAVE_SYS_UN_H
 	else if (saddr->sa_family == AF_UNIX) {
 		int i;
@@ -976,9 +989,12 @@ get_sockaddr_size (int family)
 	size = 0;
 	if (family == AF_INET) {
 		size = sizeof (struct sockaddr_in);
-	} else if (family == AF_INET6) {
+	}
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
+	else if (family == AF_INET6) {
 		size = sizeof (struct sockaddr_in6);
 	}
+#endif
 #ifdef HAVE_SYS_UN_H
 	else if (family == AF_UNIX) {
 		size = sizeof (struct sockaddr_un);
@@ -1134,7 +1150,9 @@ create_sockaddr_from_object (MonoObject *saddr_obj, socklen_t *sa_size, gint32 *
 
 		*sa_size = sizeof (struct sockaddr_in);
 		return (struct sockaddr *)sa;
-	} else if (family == AF_INET6) {
+	}
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
+	else if (family == AF_INET6) {
 		struct sockaddr_in6 *sa;
 		int i;
 		guint16 port;
@@ -1163,6 +1181,7 @@ create_sockaddr_from_object (MonoObject *saddr_obj, socklen_t *sa_size, gint32 *
 		*sa_size = sizeof (struct sockaddr_in6);
 		return (struct sockaddr *)sa;
 	}
+#endif
 #ifdef HAVE_SYS_UN_H
 	else if (family == AF_UNIX) {
 		struct sockaddr_un *sock_un;
@@ -2082,6 +2101,7 @@ ipaddress_to_struct_in_addr (MonoObject *ipaddr)
 	return inaddr;
 }
 
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 static struct in6_addr
 ipaddress_to_struct_in6_addr (MonoObject *ipaddr)
 {
@@ -2107,6 +2127,7 @@ ipaddress_to_struct_in6_addr (MonoObject *ipaddr)
 	}
 	return in6addr;
 }
+#endif
 #endif
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
@@ -2200,7 +2221,7 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 #if defined(HAVE_STRUCT_IP_MREQN) || defined(HAVE_STRUCT_IP_MREQ)
 		{
 			MonoObject *address = NULL;
-
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 			if (system_level == sol_ipv6) {
 				struct ipv6_mreq mreq6;
 
@@ -2233,7 +2254,10 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 #endif
 					
 				ret = mono_w32socket_setsockopt (sock, system_level, system_name, &mreq6, sizeof (mreq6));
-			} else if (system_level == sol_ip) {
+			
+			} else
+#endif
+			if (system_level == sol_ip) {
 #ifdef HAVE_STRUCT_IP_MREQN
 				struct ip_mreqn mreq = {{0}};
 #else
@@ -2459,7 +2483,7 @@ addrinfo_to_IPHostEntry (MonoAddressInfo *info, MonoString **h_name, MonoArray *
 					}
 				}
 			}
-
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 			if (nlocal_in6) {
 				MonoString *addr_string;
 				int i;
@@ -2474,7 +2498,7 @@ addrinfo_to_IPHostEntry (MonoAddressInfo *info, MonoString **h_name, MonoArray *
 					}
 				}
 			}
-
+#endif
 		leave:
 			g_free (local_in);
 			g_free (local_in6);
@@ -2582,7 +2606,9 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 {
 	char *address;
 	struct sockaddr_in saddr;
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	struct sockaddr_in6 saddr6;
+#endif
 	MonoAddressInfo *info = NULL;
 	MonoError error;
 	gint32 family;
@@ -2596,9 +2622,11 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 	if (inet_pton (AF_INET, address, &saddr.sin_addr ) == 1) {
 		family = AF_INET;
 		saddr.sin_family = AF_INET;
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	} else if (inet_pton (AF_INET6, address, &saddr6.sin6_addr) == 1) {
 		family = AF_INET6;
 		saddr6.sin6_family = AF_INET6;
+#endif
 	} else {
 		g_free (address);
 		return FALSE;
@@ -2616,6 +2644,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 		ret = getnameinfo ((struct sockaddr*)&saddr, sizeof (saddr), hostname, sizeof (hostname), NULL, 0, 0) == 0;
 		break;
 	}
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	case AF_INET6: {
 #if HAVE_SOCKADDR_IN6_SIN_LEN
 		saddr6.sin6_len = sizeof (saddr6);
@@ -2623,6 +2652,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 		ret = getnameinfo ((struct sockaddr*)&saddr6, sizeof (saddr6), hostname, sizeof (hostname), NULL, 0, 0) == 0;
 		break;
 	}
+#endif
 	default:
 		g_assert_not_reached ();
 	}

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2397,7 +2397,7 @@ ves_icall_System_Net_Sockets_Socket_Shutdown_internal (gsize sock, gint32 how, g
 gint
 ves_icall_System_Net_Sockets_Socket_IOControl_internal (gsize sock, gint32 code, MonoArray *input, MonoArray *output, gint32 *werror)
 {
-#if !defined(PLATFORM_UNITY)
+#if defined(FIONBIO)
 	glong output_bytes = 0;
 	gchar *i_buffer, *o_buffer;
 	gint i_len, o_len;
@@ -2617,7 +2617,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 	MonoAddressInfo *info = NULL;
 	MonoError error;
 	gint32 family;
-#if !defined(PLATFORM_UNITY)
+#if defined(NI_MAXHOST)
 	gchar hostname [NI_MAXHOST] = { 0 };
 #endif
 	gboolean ret;
@@ -2648,7 +2648,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 #if HAVE_SOCKADDR_IN_SIN_LEN
 		saddr.sin_len = sizeof (saddr);
 #endif
-#if !defined(PLATFORM_UNITY)
+#if defined(NI_MAXHOST)
 		ret = getnameinfo ((struct sockaddr*)&saddr, sizeof (saddr), hostname, sizeof (hostname), NULL, 0, 0) == 0;
 #else
 		g_assert_not_reached();
@@ -2660,7 +2660,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 #if HAVE_SOCKADDR_IN6_SIN_LEN
 		saddr6.sin6_len = sizeof (saddr6);
 #endif
-#if !defined(PLATFORM_UNITY)
+#if defined(NI_MAXHOST)
 		ret = getnameinfo ((struct sockaddr*)&saddr6, sizeof (saddr6), hostname, sizeof (hostname), NULL, 0, 0) == 0;
 #else
 		g_assert_not_reached();
@@ -2677,7 +2677,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 	if (!ret)
 		return FALSE;
 
-#if !defined(PLATFORM_UNITY)
+#if defined(NI_MAXHOST)
 	if (mono_get_address_info (hostname, 0, hint | MONO_HINT_CANONICAL_NAME | MONO_HINT_CONFIGURED_ONLY, &info) != 0)
 		return FALSE;
 #else
@@ -2691,7 +2691,7 @@ ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **
 MonoBoolean
 ves_icall_System_Net_Dns_GetHostName_internal (MonoString **h_name)
 {
-#if !defined (PLATFORM_UNITY)
+#if defined (NI_MAXHOST)
 	gchar hostname [NI_MAXHOST] = { 0 };
 	int ret;
 

--- a/mono/utils/mono-dl.c
+++ b/mono/utils/mono-dl.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <glib.h>
 
-#if !defined (HOST_WIN32) && defined (HAVE_DL_LOADER) && !defined (PLATFORM_UNITY)
+#if !defined (HOST_WIN32) && defined (HAVE_DL_LOADER)
 #include <dlfcn.h>
 #endif
 

--- a/mono/utils/mono-dl.c
+++ b/mono/utils/mono-dl.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <glib.h>
 
-#ifndef HOST_WIN32 && defined (HAVE_DL_LOADER)
+#if !defined (HOST_WIN32) && defined (HAVE_DL_LOADER) && !defined (PLATFORM_UNITY)
 #include <dlfcn.h>
 #endif
 

--- a/mono/utils/mono-membar.h
+++ b/mono/utils/mono-membar.h
@@ -60,6 +60,23 @@ static inline void mono_memory_write_barrier (void)
 {
 	mono_memory_barrier ();
 }
+#elif  defined(__x86_64__)
+#ifndef _MSC_VER
+static inline void mono_memory_barrier(void)
+{
+    __asm__ __volatile__("mfence" : : : "memory");
+}
+
+static inline void mono_memory_read_barrier(void)
+{
+    __asm__ __volatile__("lfence" : : : "memory");
+}
+
+static inline void mono_memory_write_barrier(void)
+{
+    __asm__ __volatile__("sfence" : : : "memory");
+}
+#endif // _MSC_VER
 #else
 #error "Don't know how to do memory barriers!"
 #endif

--- a/mono/utils/mono-membar.h
+++ b/mono/utils/mono-membar.h
@@ -61,7 +61,7 @@ static inline void mono_memory_write_barrier (void)
 	mono_memory_barrier ();
 }
 #elif  defined(__x86_64__)
-#ifndef _MSC_VER
+#ifdef __GNUC__
 static inline void mono_memory_barrier(void)
 {
     __asm__ __volatile__("mfence" : : : "memory");
@@ -76,7 +76,7 @@ static inline void mono_memory_write_barrier(void)
 {
     __asm__ __volatile__("sfence" : : : "memory");
 }
-#endif // _MSC_VER
+#endif // __GNUC__
 #else
 #error "Don't know how to do memory barriers!"
 #endif

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -29,7 +29,7 @@
 #ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
-#if !defined(PLATFORM_UNITY)
+#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 #endif

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -29,7 +29,9 @@
 #ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
+#if !defined(PLATFORM_UNITY)
 #include <sys/resource.h>
+#endif
 #endif
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/proc.h>

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -35,8 +35,10 @@ get_address_from_sockaddr (struct sockaddr *sa)
 	switch (sa->sa_family) {
 	case AF_INET:
 		return &((struct sockaddr_in*)sa)->sin_addr;
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	case AF_INET6:
 		return &((struct sockaddr_in6*)sa)->sin6_addr;
+#endif
 	}
 	return NULL;
 }

--- a/mono/utils/networking.c
+++ b/mono/utils/networking.c
@@ -16,8 +16,10 @@ mono_address_size_for_family (int family)
 	switch (family) {
 	case AF_INET:
 		return sizeof (struct in_addr);
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	case AF_INET6:
 		return sizeof (struct in6_addr);
+#endif
 	}
 	return 0;
 }
@@ -52,6 +54,7 @@ mono_socket_address_init (MonoSocketAddress *sa, socklen_t *len, int family, con
 #if HAVE_SOCKADDR_IN_SIN_LEN
 		sa->v4.sin_len = sizeof (*len);
 #endif
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	} else if (family == AF_INET6) {
 		*len = sizeof (struct sockaddr_in6);
 
@@ -60,6 +63,7 @@ mono_socket_address_init (MonoSocketAddress *sa, socklen_t *len, int family, con
 		sa->v6.sin6_port = htons (port);
 #if HAVE_SOCKADDR_IN6_SIN_LEN
 		sa->v6.sin6_len = sizeof (*len);
+#endif
 #endif
 	} else {
 		g_error ("Cannot handle address family %d", family);

--- a/mono/utils/networking.h
+++ b/mono/utils/networking.h
@@ -53,7 +53,9 @@ struct _MonoAddressEntry {
 	int address_len;
 	union {
 		struct in_addr v4;
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 		struct in6_addr v6;
+#endif
 	} address;
 	const char *canonical_name;
 	MonoAddressEntry *next;
@@ -66,7 +68,9 @@ typedef struct {
 
 typedef union {
 	struct sockaddr_in v4;
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 	struct sockaddr_in6 v6;
+#endif
 	struct sockaddr addr;
 } MonoSocketAddress;
 
@@ -74,7 +78,9 @@ typedef struct {
 	int family;
 	union {
 		struct in_addr v4;
+#ifdef HAVE_STRUCT_SOCKADDR_IN6
 		struct in6_addr v6;
+#endif
 	} addr;
 } MonoAddress;
 

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -8,7 +8,6 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\class.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\class-accessors.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\cominterop.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\console-win32.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\coree.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\custom-attrs.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\debug-helpers.c" />
@@ -83,17 +82,10 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\verify.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\unity-liveness.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\unity-utils.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32error-win32.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32event-win32.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32file-win32.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32file.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32handle-namespace.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32handle.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32mutex-win32.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32process-win32.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32process.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32semaphore-win32.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket-win32.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket.c" />
   </ItemGroup>
   <ItemGroup>
@@ -184,14 +176,12 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32error.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32event.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file-internals.h" />
-    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file-win32-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32handle-namespace.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32handle.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32mutex.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32process-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32process-unix-internals.h" />
-    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32process-win32-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32process.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32semaphore.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32socket.h" />

--- a/msvc/libmonoruntime-mono.targets
+++ b/msvc/libmonoruntime-mono.targets
@@ -1,5 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\console-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32error-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32event-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32file-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32mutex-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32process-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32semaphore-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket-win32.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file-win32-internals.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32process-win32-internals.h" />
   </ItemGroup>
 </Project>

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -83,7 +83,6 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\bsearch.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\memfuncs.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\parse.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\os-event-win32.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\dlmalloc.h" />

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\dlmalloc.c" />
@@ -64,18 +64,6 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-sha1.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-stdlib.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-threads-mach.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix-signals.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -153,7 +141,6 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-api.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-coop.h" />
-    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix-signals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-time.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-tls.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-uri.h" />
@@ -168,5 +155,5 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\memfuncs.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\parse.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\os-event.h" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/msvc/libmonoutils-mono.targets
+++ b/msvc/libmonoutils-mono.targets
@@ -16,6 +16,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\os-event-win32.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix-signals.h" />

--- a/msvc/libmonoutils-mono.targets
+++ b/msvc/libmonoutils-mono.targets
@@ -1,8 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-rand.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-rand-windows.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-time.c" />
+     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix-signals.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix-signals.h" />
   </ItemGroup>
 </Project>

--- a/msvc/unity.props
+++ b/msvc/unity.props
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <UnityPalSourceLocation Condition="'$(UnityPalSourceLocation)' == '' ">../../../il2cpp/build</UnityPalSourceLocation>
     <PLATFORM_UNITY_DEFINES>PLATFORM_UNITY</PLATFORM_UNITY_DEFINES>
-    <PLATFORM_UNITY_INCLUDE_DIR>../../../il2cpp/build/libil2cpp/os/c-api</PLATFORM_UNITY_INCLUDE_DIR>
+    <PLATFORM_UNITY_INCLUDE_DIR>$(UnityPalSourceLocation)/libil2cpp/os/c-api</PLATFORM_UNITY_INCLUDE_DIR>
   </PropertyGroup>
 </Project>

--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -39,12 +39,17 @@ IF EXIST %EGLIB_CONFIG_H% (
 	)
 )
 
+REM Backup existing config.h into cygconfig.h if its not already replaced.
+%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File backup-config-files.ps1 %CONFIG_H% %CYG_CONFIG_H% 2>&1
+%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File backup-config-files.ps1 %EGLIB_CONFIG_H% %EGLIB_CYG_CONFIG_H% 2>&1
+
 %windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File compare-config-files.ps1 %WIN_CONFIG_H% %CONFIG_H% %CONFIGURE_AC% 2>&1
 
 IF NOT %ERRORLEVEL% == 0 (
 	ECHO copy %WIN_CONFIG_H% %CONFIG_H%
 	copy %WIN_CONFIG_H% %CONFIG_H%
 	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "(Get-Content %CONFIG_H%) -replace '#MONO_VERSION#', (Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value | Set-Content %CONFIG_H%" 2>&1
+	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "$mono_version=[int[]](Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value.Split('.'); $corlib_counter=[int](Select-String -path %CONFIGURE_AC% -pattern 'MONO_CORLIB_COUNTER=(.*)').Matches[0].Groups[1].Value; (Get-Content %CONFIG_H%) -replace '#MONO_CORLIB_VERSION#',('1{0:00}{1:00}{2:00}{3:000}' -f $mono_version[0],$mono_version[1],$mono_version[2],$corlib_counter) | Set-Content %CONFIG_H%" 2>&1
 )
 
 %windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File compare-config-files.ps1 %EGLIB_WIN_CONFIG_H% %EGLIB_CONFIG_H% 2>&1

--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -1,20 +1,43 @@
 @ECHO off
 
+SETLOCAL
+
+IF not "%1"=="" (
+    IF not "%2"=="" (
+        SET WIN_CONFIG_H=%1
+        SET EGLIB_WIN_CONFIG_H=%2
+        SET ARGS_USED=1
+    )
+)
+
+IF "%ARGS_USED%"=="" (
+    SET WIN_CONFIG_H=..\winconfig.h
+    SET EGLIB_WIN_CONFIG_H=..\eglib\winconfig.h
+)
+
 SET CONFIG_H=..\config.h
 SET EGLIB_CONFIG_H=..\eglib\config.h
 SET CYG_CONFIG_H=..\cygconfig.h
 SET EGLIB_CYG_CONFIG_H=..\eglib\cygconfig.h
-SET WIN_CONFIG_H=..\winconfig.h
-SET EGLIB_WIN_CONFIG_H=..\eglib\winconfig.h
 SET CONFIGURE_AC=..\configure.ac
 SET VERSION_H=..\mono\mini\version.h
 
 
 ECHO Setting up Mono configuration headers...
 
-REM Backup existing config.h into cygconfig.h if its not already replaced.
-%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File backup-config-files.ps1 %CONFIG_H% %CYG_CONFIG_H% 2>&1
-%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File backup-config-files.ps1 %EGLIB_CONFIG_H% %EGLIB_CYG_CONFIG_H% 2>&1
+IF EXIST %CONFIG_H% (
+	IF NOT EXIST %CYG_CONFIG_H% (
+		ECHO copy %CONFIG_H% %CYG_CONFIG_H%
+		copy %CONFIG_H% %CYG_CONFIG_H%
+	)
+)
+
+IF EXIST %EGLIB_CONFIG_H% (
+	IF NOT EXIST %EGLIB_CYG_CONFIG_H% (
+		ECHO copy %EGLIB_CONFIG_H% %EGLIB_CYG_CONFIG_H%
+		copy %EGLIB_CONFIG_H% %EGLIB_CYG_CONFIG_H%
+	)
+)
 
 %windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File compare-config-files.ps1 %WIN_CONFIG_H% %CONFIG_H% %CONFIGURE_AC% 2>&1
 
@@ -22,7 +45,6 @@ IF NOT %ERRORLEVEL% == 0 (
 	ECHO copy %WIN_CONFIG_H% %CONFIG_H%
 	copy %WIN_CONFIG_H% %CONFIG_H%
 	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "(Get-Content %CONFIG_H%) -replace '#MONO_VERSION#', (Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value | Set-Content %CONFIG_H%" 2>&1
-	%windir%\system32\WindowsPowerShell\v1.0\powershell.exe -NonInteractive -Command "$mono_version=[int[]](Select-String -path %CONFIGURE_AC% -pattern 'AC_INIT\(mono, \[(.*)\]').Matches[0].Groups[1].Value.Split('.'); $corlib_counter=[int](Select-String -path %CONFIGURE_AC% -pattern 'MONO_CORLIB_COUNTER=(.*)').Matches[0].Groups[1].Value; (Get-Content %CONFIG_H%) -replace '#MONO_CORLIB_VERSION#',('1{0:00}{1:00}{2:00}{3:000}' -f $mono_version[0],$mono_version[1],$mono_version[2],$corlib_counter) | Set-Content %CONFIG_H%" 2>&1
 )
 
 %windir%\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -NonInteractive -File compare-config-files.ps1 %EGLIB_WIN_CONFIG_H% %EGLIB_CONFIG_H% 2>&1

--- a/support/map.c
+++ b/support/map.c
@@ -5237,7 +5237,7 @@ Mono_Posix_ToSockaddrIn (struct sockaddr_in *from, struct Mono_Posix_SockaddrIn 
 #endif /* ndef HAVE_STRUCT_SOCKADDR_IN */
 
 
-#ifdef HAVE_STRUCT_SOCKADDR_IN6
+#if defined(HAVE_STRUCT_SOCKADDR_IN6) && !defined(WINDOWS)
 int
 Mono_Posix_FromSockaddrIn6 (struct Mono_Posix_SockaddrIn6 *from, struct sockaddr_in6 *to)
 {
@@ -5259,7 +5259,7 @@ Mono_Posix_FromSockaddrIn6 (struct Mono_Posix_SockaddrIn6 *from, struct sockaddr
 #endif /* ndef HAVE_STRUCT_SOCKADDR_IN6 */
 
 
-#ifdef HAVE_STRUCT_SOCKADDR_IN6
+#if defined(HAVE_STRUCT_SOCKADDR_IN6) && !defined(WINDOWS)
 int
 Mono_Posix_ToSockaddrIn6 (struct sockaddr_in6 *from, struct Mono_Posix_SockaddrIn6 *to)
 {

--- a/winconfig.h
+++ b/winconfig.h
@@ -586,6 +586,9 @@
 /* Define to 1 if you have the <wchar.h> header file. */
 #define HAVE_WCHAR_H 1
 
+/* Define to 1 if you have IPv6 support. */
+#define HAVE_STRUCT_SOCKADDR_IN6 1
+
 /* Have a working sigaltstack */
 /* #undef HAVE_WORKING_SIGALTSTACK */
 


### PR DESCRIPTION
This pull request allows our Mono 5.0 branch to compile for some of the additional platforms Unity supports which we need for IL2CPP on Mono. Specifically, we're compiling eglib, libmonoutils, and libmonoruntime with the Unity PAL.

With these changes, the Mono build succeeds for all of the current platforms as well.