### PR TITLE
Fix missing header files in targets

### DIFF
--- a/msvc/eglib-common.targets
+++ b/msvc/eglib-common.targets
@@ -28,5 +28,8 @@
     <ClInclude Include="$(MonoSourceLocation)\eglib\src\glib.h" />
     <ClInclude Include="$(MonoSourceLocation)\eglib\src\gmodule.h" />
     <ClInclude Include="$(MonoSourceLocation)\eglib\src\sort.frag.h" />
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\eglib-remap.h" />
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\eglib-config.hw" />
+    <ClInclude Include="$(MonoSourceLocation)\eglib\src\unicode-data.h" />
   </ItemGroup>
 </Project>

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -97,7 +97,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\abi-details.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\appdomain.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\assembly-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\assembly.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\attach.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\cil-coff.h" />
@@ -106,6 +108,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\class.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\cominterop.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\console-io.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\coree-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\coree.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\culture-info-tables.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\culture-info.h" />
@@ -113,6 +116,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\debug-helpers.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\debug-mono-ppdb.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\debug-mono-symfile.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\decimal-ms.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\domain-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\dynamic-image-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\dynamic-stream-internals.h" />
@@ -126,12 +130,15 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\seq-points-data.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-bridge-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-client-mono.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-dynarray.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\sgen\gc-internal-agnostic.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-def.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\image-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\image.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\loader.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\locales.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\lock-tracer.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mempool-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mempool.h" />
@@ -145,6 +152,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-debug-debugger.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-debug.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-endian.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-gc.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-hash.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-mlist.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-perfcounters-def.h" />
@@ -153,6 +161,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\normalization-tables.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\number-formatter.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\object-internals.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\object-offsets.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\object.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\opcodes.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\profiler-private.h" />
@@ -174,9 +183,13 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\tabledefs.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threadpool.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threadpool-io.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threadpool-io-epoll.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threadpool-io-kqueue.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threadpool-io-poll.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threadpool-worker.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threads.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\threads-types.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\tokentype.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\verify-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\verify.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\unity-utils.h" />

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -98,6 +98,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\os-event-win32.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\checked-build.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\dlmalloc.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\dtrace.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\freebsd-dwarf.h" />
@@ -135,6 +136,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-math.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-membar.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-memory-model.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-mmap-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-mmap.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-networkinterfaces.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-once.h" />
@@ -153,7 +155,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-api.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-coop.h" />
-    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-posix-signals.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-threads-debug.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-time.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-tls.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-uri.h" />
@@ -163,10 +165,10 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\valgrind.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\atomic.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-hwcap.h" />
-    <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-hwcap-x86.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\bsearch.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\memfuncs.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\parse.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\os-event.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\w32api.h" />
   </ItemGroup>  
 </Project>

--- a/msvc/libmonoutils-unity.targets
+++ b/msvc/libmonoutils-unity.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\unity-rand.c" /> 
-    <ClCompile Include="$(MonoSourceLocation)\mono\utils\unity-time.c" /> 
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\unity-rand.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\unity-time.c" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds headers that are missing in the targets files so that we can parse them to get the files we need to build mono