### PR TITLE
Fix for https://fogbugz.unity3d.com/f/cases/922668/  

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5215,8 +5215,9 @@ mono_object_new_checked (MonoDomain *domain, MonoClass *klass, MonoError *error)
 
 	MonoVTable *vtable;
 
-	vtable = mono_class_vtable (domain, klass);
-	g_assert (vtable); /* FIXME don't swallow the error */
+	vtable = mono_class_vtable_full (domain, klass, error);
+    if (!vtable)
+        return NULL;
 
 	MonoObject *o = mono_object_new_specific_checked (vtable, error);
 	return o;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5216,8 +5216,8 @@ mono_object_new_checked (MonoDomain *domain, MonoClass *klass, MonoError *error)
 	MonoVTable *vtable;
 
 	vtable = mono_class_vtable_full (domain, klass, error);
-    if (!vtable)
-        return NULL;
+	if (!vtable)
+		return NULL;
 
 	MonoObject *o = mono_object_new_specific_checked (vtable, error);
 	return o;


### PR DESCRIPTION
 No longer asserting when vtable is null in mono_object_new_checked, which crashes the Unity editor.  Instead, propagating error to caller.