### PR TITLE
Unity 2017 02 staging changes

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilderAccess.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilderAccess.cs
@@ -35,6 +35,7 @@ namespace System.Reflection.Emit
 	[ComVisible (true)]
 	[Serializable]
 	[Flags]
+	#region Sync with sre-internals.h
 	public enum AssemblyBuilderAccess {
 		Run = 1,
 		Save = 2,
@@ -42,4 +43,5 @@ namespace System.Reflection.Emit
 		ReflectionOnly = 6,
 		RunAndCollect = 9
   }
+	#endregion
 }

--- a/mcs/class/corlib/Test/System.Reflection.Emit/AssemblyBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/AssemblyBuilderTest.cs
@@ -1839,5 +1839,68 @@ public class AssemblyBuilderTest
 		} catch (NotSupportedException e) {
 		}
      }
+
+	class AssemblyBuilderResolver {
+		private Assembly mock;
+		private ResolveEventHandler d;
+		private string theName;
+
+		public AssemblyBuilderResolver (string theName) {
+			mock = CreateMock (theName);
+			d = new ResolveEventHandler (HandleResolveEvent);
+			this.theName = theName;
+		}
+
+		public void StartHandling () {
+			AppDomain.CurrentDomain.AssemblyResolve += d;
+		}
+
+		public void StopHandling () {
+			AppDomain.CurrentDomain.AssemblyResolve -= d;
+		}
+
+		public Assembly HandleResolveEvent (Object sender, ResolveEventArgs args) {
+			if (args.Name.StartsWith (theName))
+				return mock;
+			else
+				return null;
+		}
+
+		private static Assembly CreateMock (string name) {
+			var an = new AssemblyName (name);
+			var ab = AssemblyBuilder.DefineDynamicAssembly (an, AssemblyBuilderAccess.ReflectionOnly);
+			var mb = ab.DefineDynamicModule (an.Name);
+
+			// Just make some content for the assembly
+			var tb = mb.DefineType ("Foo", TypeAttributes.Public);
+			tb.DefineDefaultConstructor (MethodAttributes.Public);
+
+			tb.CreateType ();
+
+			return ab;
+		}
+	}
+
+	[Test]
+	public void ResolveEventHandlerReflectionOnlyError ()
+	{
+		// Regression test for 57850.
+
+		// If a ResolveEventHandler returns a reflection-only
+		// AssemblyBuilder, we should throw a FileNotFoundException.
+		var s = "ResolveEventHandlerReflectionOnlyErrorAssembly";
+		var h = new AssemblyBuilderResolver (s);
+		Assert.Throws<FileNotFoundException>(() => {
+				h.StartHandling ();
+				var aName = new AssemblyName (s);
+				try {
+					AppDomain.CurrentDomain.Load (aName);
+				} finally {
+					h.StopHandling ();
+				}
+			});
+	}
+
+
 }
 }

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1120,7 +1120,7 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 	mono_error_init (error);
 
 	if (mono_runtime_get_no_exec ())
-		return ret;
+		goto leave;
 
 	g_assert (domain != NULL && !MONO_HANDLE_IS_NULL (fname));
 
@@ -1131,14 +1131,23 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 	MonoReflectionAssemblyHandle requesting_handle;
 	if (requesting) {
 		requesting_handle = mono_assembly_get_object_handle (domain, requesting, error);
-		return_val_if_nok (error, ret);
+		if (!is_ok (error))
+			goto leave;
 	}
 	params [0] = MONO_HANDLE_RAW (fname);
 	params[1] = requesting ? MONO_HANDLE_RAW (requesting_handle) : NULL;
 	params [2] = &isrefonly;
 	MonoReflectionAssemblyHandle result = MONO_HANDLE_NEW (MonoReflectionAssembly, mono_runtime_invoke_checked (method, domain->domain, params, error));
 	ret = !MONO_HANDLE_IS_NULL (result) ? MONO_HANDLE_GETVAL (result, assembly) : NULL;
-	return ret;
+
+	if (ret && !refonly && ret->ref_only) {
+		/* .NET Framework throws System.IO.FileNotFoundException in this case */
+		mono_error_set_file_not_found (error, "AssemblyResolveEvent handlers cannot return Assemblies loaded for reflection only");
+		ret = NULL;
+		goto leave;
+	}
+leave:
+	HANDLE_FUNCTION_RETURN_VAL (ret);
 }
 
 MonoAssembly *

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1112,6 +1112,7 @@ leave:
 MonoAssembly*
 mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoAssembly *ret = NULL;
 	MonoMethod *method;
 	MonoBoolean isrefonly;

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1861,6 +1861,9 @@ mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssembly
 	 */
 
 	image = assembly->image;
+	/* Dynamic images would need to go through the AssemblyBuilder's
+	 * CustomAttributeBuilder array.  Going through the tables below
+	 * definitely won't work. */
 	g_assert (!image_is_dynamic (image));
 	idx = 1; /* there is only one assembly */
 	idx <<= MONO_CUSTOM_ATTR_BITS;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4249,6 +4249,9 @@ mono_marshal_get_runtime_invoke (MonoMethod *method, gboolean virtual_)
 	if (virtual_)
 		need_direct_wrapper = TRUE;
 
+	if (method->dynamic)
+		need_direct_wrapper = TRUE;
+
 	/* 
 	 * Use a separate cache indexed by methods to speed things up and to avoid the
 	 * boundless mempool growth caused by the signature_dup stuff below.
@@ -4345,7 +4348,7 @@ mono_marshal_get_runtime_invoke (MonoMethod *method, gboolean virtual_)
 	csig->call_convention = MONO_CALL_C;
 #endif
 
-	name = mono_signature_to_name (callsig, virtual_ ? "runtime_invoke_virtual" : "runtime_invoke");
+	name = mono_signature_to_name (callsig, virtual_ ? "runtime_invoke_virtual" : (need_direct_wrapper ? "runtime_invoke_direct" : "runtime_invoke"));
 	mb = mono_mb_new (target_klass, name,  MONO_WRAPPER_RUNTIME_INVOKE);
 	g_free (name);
 

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -7,6 +7,15 @@
 
 #include <mono/metadata/object-internals.h>
 
+/* Keep in sync with System.Reflection.Emit.AssemblyBuilderAccess */
+enum MonoAssemblyBuilderAccess {
+	MonoAssemblyBuilderAccess_Run = 1,                /* 0b0001 */
+	MonoAssemblyBuilderAccess_Save = 2,               /* 0b0010 */
+	MonoAssemblyBuilderAccess_RunAndSave = 3,         /* Run | Save */
+	MonoAssemblyBuilderAccess_ReflectionOnly = 6,     /* Refonly | Save */
+	MonoAssemblyBuilderAccess_RunAndCollect = 9,      /* Collect | Run */
+};
+
 typedef struct _ArrayMethod ArrayMethod;
 
 typedef struct {

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1202,6 +1202,25 @@ mono_image_create_token (MonoDynamicImage *assembly, MonoObjectHandle obj,
 
 #ifndef DISABLE_REFLECTION_EMIT
 
+static gboolean
+assemblybuilderaccess_can_refonlyload (guint32 access)
+{
+	return (access & 0x4) != 0;
+}
+
+static gboolean
+assemblybuilderaccess_can_run (guint32 access)
+{
+	return (access & MonoAssemblyBuilderAccess_Run) != 0;
+}
+
+static gboolean
+assemblybuilderaccess_can_save (guint32 access)
+{
+	return (access & MonoAssemblyBuilderAccess_Save) != 0;
+}
+
+
 /*
  * mono_reflection_dynimage_basic_init:
  * @assembly: an assembly builder object
@@ -1258,8 +1277,9 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 			assembly->assembly.aname.revision = 0;
         }
 
-	assembly->run = assemblyb->access != 2;
-	assembly->save = assemblyb->access != 1;
+	assembly->assembly.ref_only = assemblybuilderaccess_can_refonlyload (assemblyb->access);
+	assembly->run = assemblybuilderaccess_can_run (assemblyb->access);
+	assembly->save = assemblybuilderaccess_can_save (assemblyb->access);
 	assembly->domain = domain;
 
 	char *assembly_name = mono_string_to_utf8_checked (assemblyb->name, &error);

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -345,6 +345,14 @@ MonoMethod* mono_unity_method_alloc0(MonoClass* klass)
 	return mono_image_alloc0(klass->image, sizeof(MonoMethod));
 }
 
+MonoMethod* mono_unity_method_delegate_invoke_wrapper(MonoClass* klass)
+{
+	MonoMethod* method = (MonoMethod*)mono_image_alloc0(klass->image, sizeof(MonoMethod));
+	MonoMethod *invoke = mono_get_delegate_invoke (klass);
+	method->signature = mono_metadata_signature_dup_full (klass->image, mono_method_signature (invoke));
+	return method;
+}
+
 gboolean mono_unity_method_is_static(MonoMethod *method)
 {
 	return method->flags & METHOD_ATTRIBUTE_STATIC;

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -78,6 +78,7 @@ gboolean mono_class_is_blittable(MonoClass *klass);
 MonoMethod* mono_unity_method_get_generic_definition(MonoMethod* method);
 MonoReflectionMethod* mono_unity_method_get_object(MonoMethod *method);
 MonoMethod* mono_unity_method_alloc0(MonoClass* klass);
+MonoMethod* mono_unity_method_delegate_invoke_wrapper(MonoClass* klass);
 gboolean mono_unity_method_is_static(MonoMethod *method);
 MonoClass* mono_unity_method_get_class(const MonoMethod *method);
 

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -1386,7 +1386,7 @@ mono_file_remap_path(const char** path)
 	return TRUE;
 }
 
-void
+MONO_API void
 mono_unity_register_path_remapper(RemapPathFunction func)
 {
 	g_RemapPathFunc = func;

--- a/mono/tests/assemblyresolve_event5.cs
+++ b/mono/tests/assemblyresolve_event5.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+
+public class TestAssemblyResolveEvent {
+	public static int Main (String[] args) {
+		// Regression test for https://bugzilla.xamarin.com/show_bug.cgi?id=57851
+
+		// If the custom attributes of an assembly trigger a
+		// ResolveEventHandler, and that handler returns an
+		// AssemblyBuilder, don't crash.
+		var h = new MockResolver ("assemblyresolve_event5_label");
+		var aName = new AssemblyName ("assemblyresolve_event5_helper");
+		var a = AppDomain.CurrentDomain.Load (aName);
+		var t = a.GetType ("MyClass");
+		h.StartHandling ();
+		var cas = t.GetCustomAttributes (true);
+		h.StopHandling ();
+		return 0;
+	}
+}
+
+
+public class MockResolver {
+	private Assembly mock;
+	private ResolveEventHandler d;
+	private string theName;
+	
+	public MockResolver (string theName) {
+		mock = CreateMock (theName);
+		d = new ResolveEventHandler (HandleResolveEvent);
+		this.theName = theName;
+	}
+
+	public void StartHandling () {
+		AppDomain.CurrentDomain.AssemblyResolve += d;
+	}
+
+	public void StopHandling () {
+		AppDomain.CurrentDomain.AssemblyResolve -= d;
+	}
+
+	public Assembly HandleResolveEvent (Object sender, ResolveEventArgs args) {
+		Console.Error.WriteLine ("handling load of {0}", args.Name);
+		if (args.Name.StartsWith (theName))
+			return mock;
+		else
+			return null;
+	}
+
+	private static Assembly CreateMock (string s) {
+		var an = new AssemblyName (s);
+		var ab = AssemblyBuilder.DefineDynamicAssembly (an, AssemblyBuilderAccess.Run);
+		var mb = ab.DefineDynamicModule (an.Name);
+
+		var tb = mb.DefineType ("Foo", TypeAttributes.Public);
+		tb.DefineDefaultConstructor (MethodAttributes.Public);
+		tb.CreateType ();
+
+		return ab;
+	}
+}

--- a/mono/tests/assemblyresolve_event5_helper.cs
+++ b/mono/tests/assemblyresolve_event5_helper.cs
@@ -1,0 +1,10 @@
+using System;
+
+public class SimpleTypedAttribute : Attribute {
+	public SimpleTypedAttribute (Type t) { }
+}
+
+[SimpleTypedAttribute(typeof(Foo))] /* Foo defined in the assemblyresolve_event5_label assembly */
+public class MyClass {
+	public MyClass () { }
+}

--- a/mono/tests/assemblyresolve_event5_label.cs
+++ b/mono/tests/assemblyresolve_event5_label.cs
@@ -1,0 +1,5 @@
+using System;
+
+public class Foo {
+	public Foo () { }
+}

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -120,6 +120,9 @@ void
 mono_error_set_invalid_operation (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
+mono_error_set_file_not_found (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
+
+void
 mono_error_set_exception_instance (MonoError *error, MonoException *exc);
 
 void

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -459,6 +459,20 @@ mono_error_set_invalid_operation (MonoError *oerror, const char *msg_format, ...
 	va_end (args);
 }
 
+/**
+ * mono_error_set_file_not_found:
+ *
+ * System.IO.FileNotFoundException
+ */
+void
+mono_error_set_file_not_found (MonoError *oerror, const char *msg_format, ...)
+{
+	va_list args;
+	va_start (args, msg_format);
+	mono_error_set_generic_errorv (oerror, "System.IO", "FileNotFoundException", msg_format, args);
+	va_end (args);
+}
+
 void
 mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...)
 {

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -41,6 +41,12 @@
     <MONO_C_RUNTIME Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</MONO_C_RUNTIME>
     <MONO_C_RUNTIME Condition="'$(Configuration)'!='Debug'">MultiThreadedDLL</MONO_C_RUNTIME>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Label="MonoSGEN" Condition="$(MONO_TARGET_GC)=='sgen'">
     <SGEN_DEFINES>HAVE_SGEN_GC;HAVE_MOVING_COLLECTOR;HAVE_WRITE_BARRIERS</SGEN_DEFINES>
     <GC_DEFINES>$(SGEN_DEFINES)</GC_DEFINES>


### PR DESCRIPTION
- Bug fix from upstream for case 920772
- Two other bug fixes for case 911456 and case 920085
- Export mono_unity_register_path_remapper
- Disable incremental linking in Release builds on Windows to fix stack traces
- Add mono_unity_method_delegate_invoke_wrapper for il2cpp on mono invoking native method with delegate wrapper

