### PR TITLE
5.6 Backports

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4143,6 +4143,8 @@ mono_marshal_get_runtime_invoke (MonoMethod *method, gboolean virtual)
 
 	if (virtual)
 		need_direct_wrapper = TRUE;
+	if (method->dynamic)
+		need_direct_wrapper = TRUE;
 
 	/* 
 	 * Use a separate cache indexed by methods to speed things up and to avoid the


### PR DESCRIPTION
[runtime] Make runtime invoke wrappers for dynamic methods non-shareable, so they can be freed when the dynamic method is freed. (case 920085)