### PR TITLE
Unity Trunk - Fast Thread Attach/Detach

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -81,6 +81,9 @@ struct _ProfilerDesc {
 	MonoProfileThreadFunc   thread_start;
 	MonoProfileThreadFunc   thread_end;
 
+	MonoProfileThreadFunc   thread_fast_attach;
+	MonoProfileThreadFunc   thread_fast_detach;
+
 	MonoProfileCoverageFilterFunc coverage_filter_cb;
 
 	MonoProfileFunc shutdown_callback;
@@ -235,6 +238,15 @@ mono_profiler_install_thread (MonoProfileThreadFunc start, MonoProfileThreadFunc
 		return;
 	prof_list->thread_start = start;
 	prof_list->thread_end = end;
+}
+
+void
+mono_profiler_install_thread_fast_attach_detach (MonoProfileThreadFunc fast_attach, MonoProfileThreadFunc fast_detach)
+{
+	if (!prof_list)
+		return;
+	prof_list->thread_fast_attach = fast_attach;
+	prof_list->thread_fast_detach = fast_detach;
 }
 
 void 
@@ -539,6 +551,26 @@ mono_profiler_thread_end (gsize tid)
 	for (prof = prof_list; prof; prof = prof->next) {
 		if ((prof->events & MONO_PROFILE_THREADS) && prof->thread_end)
 			prof->thread_end (prof->profiler, tid);
+	}
+}
+
+void
+mono_profiler_thread_fast_attach (gsize tid)
+{
+	ProfilerDesc *prof;
+	for (prof = prof_list; prof; prof = prof->next) {
+		if ((prof->events & MONO_PROFILE_THREADS) && prof->thread_fast_attach)
+			prof->thread_fast_attach (prof->profiler, tid);
+	}
+}
+
+void
+mono_profiler_thread_fast_detach(gsize tid)
+{
+	ProfilerDesc *prof;
+	for (prof = prof_list; prof; prof = prof->next) {
+		if ((prof->events & MONO_PROFILE_THREADS) && prof->thread_fast_detach)
+			prof->thread_fast_detach (prof->profiler, tid);
 	}
 }
 

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -148,6 +148,7 @@ void mono_profiler_install_method_free (MonoProfileMethodFunc callback);
 void mono_profiler_install_method_invoke (MonoProfileMethodFunc start, MonoProfileMethodFunc end);
 void mono_profiler_install_enter_leave (MonoProfileMethodFunc enter, MonoProfileMethodFunc fleave);
 void mono_profiler_install_thread      (MonoProfileThreadFunc start, MonoProfileThreadFunc end);
+void mono_profiler_install_thread_fast_attach_detach (MonoProfileThreadFunc fast_attach, MonoProfileThreadFunc fast_detach);
 void mono_profiler_install_transition  (MonoProfileMethodResult callback);
 void mono_profiler_install_allocation  (MonoProfileAllocFunc callback);
 void mono_profiler_install_monitor     (MonoProfileMonitorFunc callback);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -193,7 +193,7 @@ typedef struct {
 	MonoContext handler_ctx;
 	/* Whenever thread_stop () was called for this thread */
 	gboolean terminated;
-	/* Whenever thread_stop () was called for this thread */
+	/* If thread should be suspended and processed. FALSE is fast detach has been called */
 	gboolean attached;
 
 	/* Number of thread interruptions not yet processed */

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -835,3 +835,5 @@ mono_unity_class_get_generic_parameter_count
 mono_unity_set_data_dir
 mono_unity_get_data_dir
 mono_unity_class_get
+mono_unity_thread_fast_attach
+mono_unity_thread_fast_detach


### PR DESCRIPTION
Expose mono_unity_thread_fast_attach and mono_unity_thread_fast_detach for quick entering and exiting threads into a Unity child domain in the Editor (case 918651)