### PR TITLE
2017.2 MBE Backports

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1187,6 +1187,8 @@ socket_transport_accept (int socket_fd)
 	MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
 	conn_fd = mono_w32socket_accept (socket_fd, NULL, NULL, TRUE);
+	if (conn_fd != -1)
+		mono_w32socket_set_blocking (conn_fd, TRUE);
 #else
 	conn_fd = accept (socket_fd, NULL, NULL);
 #endif
@@ -1394,7 +1396,8 @@ socket_transport_close1 (void)
 	/* Also shut down the connection listener so that we can exit normally */
 #ifdef HOST_WIN32
 	MonoThreadInfo* info = mono_thread_info_lookup (debugger_thread_id);
-	mono_threads_suspend_abort_syscall (info);
+	if (info)
+		mono_threads_suspend_abort_syscall (info);
 	/* SD_RECEIVE doesn't break the recv in the debugger thread */
 	shutdown (conn_fd, SD_BOTH);
 	shutdown (listen_fd, SD_BOTH);


### PR DESCRIPTION
Ensure socket is blocking when using the win32 helper methods that make it non-blocking. Check for NULL when shutting down debugger thread (case 930244)