### PR TITLE
Out-of-process inspection of details needed for Mono callstack generation

### DIFF
--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -207,6 +207,8 @@ jit_info_table_chunk_index (MonoJitInfoTableChunk *chunk, MonoThreadHazardPointe
 	return left;
 }
 
+/* When changing this method, make sure to also update oop_jit_info_table_find
+   in mono/metadata/oop.c. */
 static MonoJitInfo*
 jit_info_table_find (MonoJitInfoTable *table, MonoThreadHazardPointers *hp, gint8 *addr)
 {

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -403,13 +403,21 @@ mono_unity_oop_get_stack_frame_details(
                 className,
                 classNameLen,
                 read_pointer(OFFSET_MEMBER(MonoClass, klass, name)));
-
-            frameDetails->classNameLen = sprintf_s(
-                frameDetails->className,
-                frameDetails->classNameLen,
-                "%s.%s",
-                nsName,
-                className);
+            
+            if (*nsName) {
+                frameDetails->classNameLen = sprintf_s(
+                    frameDetails->className,
+                    frameDetails->classNameLen,
+                    "%s.%s",
+                    nsName,
+                    className);
+            } else {
+                frameDetails->classNameLen = sprintf_s(
+                    frameDetails->className,
+                    frameDetails->classNameLen,
+                    "%s",
+                    className);
+            }
         }
 
         frameDetails->assemblyNameLen = read_nt_string(

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -148,6 +148,12 @@ mono_unity_oop_init(
     g_oop.userData = userdata;
 }
 
+MONO_API void
+mono_unity_oop_shutdown(void)
+{
+    memset(&g_oop, 0, sizeof(g_oop));
+}
+
 #ifdef _M_X64
 gboolean TryAcquireSpinWait(PSRWLOCK lock, unsigned int spinWait)
 {

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -300,6 +300,7 @@ oop_jit_info_table_chunk_index(
     return left;
 }
 
+/* This method is an out-of-process version of jit_info_table_find. */
 static const MonoJitInfo*
 oop_jit_info_table_find(
     const MonoDomain *domain,

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -70,10 +70,7 @@ static OutOfProcessMono g_oop = { NULL, NULL };
 void read_exception(const void* address, gsize size)
 {
     g_assert(g_oop.readException);
-    if (g_oop.readException)
-        g_oop.readException(address, size, g_oop.userData);
-    else
-        eg_unreachable();
+    g_oop.readException(address, size, g_oop.userData);
 }
 
 gsize read_memory(void* buffer, const void* address, gsize size)

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -413,6 +413,9 @@ mono_unity_oop_get_stack_frame_details(
             frameDetails->assemblyNameLen,
             read_pointer(OFFSET_MEMBER(MonoImage, image, assembly_name)));
 
+        free(className);
+        free(nsName);
+
         return TRUE;
     }
 

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -1,0 +1,221 @@
+/*
+ * oop.c: These functions allow us to access the MonoDomain internals for purposes of post-mortem
+ * inspection by another process. All data is immutable: these calls are guaranteed to have no 
+ * side-effects. These routines are not thread safe. This does not work with AOT modules.
+ *
+ * Author:
+ *	Pete Lewis <pete.lewis@unity3d.com>
+ *
+ * Copyright 2017 Unity Technologies (http://www.unity3d.com)
+ * Copyright 2001-2003 Ximian, Inc (http://www.ximian.com)
+ * Copyright 2004-2009 Novell, Inc (http://www.novell.com)
+ */
+
+#include <config.h>
+#include <glib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-logger.h>
+#include <mono/utils/mono-membar.h>
+#include <mono/utils/mono-counters.h>
+#include <mono/metadata/object.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/domain-internals.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/exception.h>
+#include <mono/metadata/metadata-internals.h>
+#include <mono/metadata/gc-internals.h>
+#include <mono/metadata/appdomain.h>
+#include <mono/metadata/mono-debug-debugger.h>
+#include <mono/metadata/mono-config.h>
+#include <mono/metadata/threads-types.h>
+#include <metadata/threads.h>
+#include <metadata/profiler-private.h>
+#include <mono/metadata/coree.h>
+
+G_BEGIN_DECLS
+typedef int(*MonoReadMemoryCallback)(void* userData, const void* address, void* buffer, size_t size);
+
+typedef struct _MonoStackFrameDetails
+{
+    char* methodName;
+    char* signature;
+    char* assemblyName;
+    char* sourceFile;
+    int lineNo;
+} MonoStackFrameDetails;
+
+struct _MonoOutOfProcessParameters
+{
+    MonoReadMemoryCallback readMemoryCallback;
+    void* userData;
+};
+
+typedef struct _MonoOutOfProcessParameters MonoOutOfProcessParameters;
+
+G_END_DECLS
+
+typedef const void * gooppointer;
+
+gooppointer oop_fetch_ptr(
+    const MonoOutOfProcessParameters* oopCfg,
+    gooppointer ptr)
+{
+    gpointer out = NULL;
+    if (!oopCfg->readMemoryCallback(oopCfg->userData, ptr, &out, sizeof(out)))
+        return NULL;
+    return out;
+}
+
+#define oop_copy(oopCfg, storage, address) (oopCfg->readMemoryCallback(oopCfg->userData, address, &storage, sizeof(storage)))
+#define oop_member_address(type, base, member) ((const gint8*)base + offsetof(type, member))
+
+MonoBoolean oop_copy_jit_info_table(
+    const MonoOutOfProcessParameters* oopCfg,
+    const MonoDomain* domain,
+    MonoJitInfoTable* table)
+{
+    gooppointer srcTable = oop_fetch_ptr(oopCfg, oop_member_address(MonoDomain, domain, jit_info_table));
+    return oopCfg->readMemoryCallback(oopCfg->userData, srcTable, table, sizeof(MonoJitInfoTable));
+}
+
+static int oop_jit_info_table_index(
+    const MonoOutOfProcessParameters* oopCfg,
+    const MonoJitInfoTableChunk** chunks, // non-local
+    int num_chunks,
+    const gint8* addr)
+{
+    MonoJitInfoTableChunk chunk;
+
+    int left = 0, right = num_chunks;
+
+    g_assert(left < right);
+
+    do {
+        int pos = (left + right) / 2;
+        oop_copy(oopCfg, chunk, oop_fetch_ptr(oopCfg, chunks + pos));
+
+        if (addr < chunk.last_code_end)
+            right = pos;
+        else
+            left = pos + 1;
+    } while (left < right);
+    g_assert(left == right);
+
+    if (left >= num_chunks)
+        return num_chunks - 1;
+    return left;
+}
+
+static int
+oop_jit_info_table_chunk_index(
+    const MonoOutOfProcessParameters* oopCfg,
+    const MonoJitInfo** chunk_data,
+    int num_elements,
+    const gint8 *addr)
+{
+    MonoJitInfo ji;
+    int left = 0, right = num_elements;
+
+    while (left < right) {
+        int pos = (left + right) / 2;
+        gint8 *code_end;
+
+        oop_copy(oopCfg, ji, oop_fetch_ptr(oopCfg, chunk_data + pos));
+        code_end = (gint8*)ji.code_start + ji.code_size;
+
+        if (addr < code_end)
+            right = pos;
+        else
+            left = pos + 1;
+    }
+    g_assert(left == right);
+
+    return left;
+}
+
+static const MonoJitInfo*
+oop_jit_info_table_find(
+    const MonoOutOfProcessParameters* oopCfg,
+    const MonoDomain *domain,
+    const char *addr)
+{
+    MonoJitInfoTable table;
+    MonoJitInfoTableChunk chunk;
+    MonoJitInfo jiLocal;
+    const MonoJitInfo * jiPtr;
+    int chunk_pos, pos;
+    
+    // Copy the domain's jit_info_table.
+    if (!oop_copy_jit_info_table(oopCfg, domain, &table))
+        return 0;
+
+    chunk_pos = oop_jit_info_table_index(oopCfg, table.chunks, table.num_chunks, (const gint8*)addr);
+    g_assert(chunk_pos < table.num_chunks);
+
+    oop_copy(oopCfg, chunk, oop_fetch_ptr(oopCfg, table.chunks + chunk_pos));
+    pos = oop_jit_info_table_chunk_index(oopCfg, (const MonoJitInfo**) chunk.data, chunk.num_elements, addr);
+
+    /* We now have a position that's very close to that of the
+    first element whose end address is higher than the one
+    we're looking for.  If we don't have the exact position,
+    then we have a position below that one, so we'll just
+    search upward until we find our element. */
+    do {
+        oop_copy(oopCfg, chunk, oop_fetch_ptr(oopCfg, table.chunks + chunk_pos));
+
+        while (pos < chunk.num_elements) {
+            jiPtr = (const MonoJitInfo*)oop_fetch_ptr(oopCfg, chunk.data + pos);
+            oop_copy(oopCfg, jiLocal, jiPtr);
+
+            ++pos;
+
+            if (jiLocal.d.method == NULL) {
+                continue;
+            }
+            if ((gint8*)addr >= (gint8*)jiLocal.code_start
+                && (gint8*)addr < (gint8*)jiLocal.code_start + jiLocal.code_size) {
+                return jiPtr;
+            }
+
+            /* If we find a non-tombstone element which is already
+            beyond what we're looking for, we have to end the
+            search. */
+            if ((gint8*)addr < (gint8*)jiLocal.code_start)
+                goto not_found;
+        }
+
+        ++chunk_pos;
+        pos = 0;
+    } while (chunk_pos < table.num_chunks);
+
+not_found:
+    return NULL;
+}
+
+
+int
+mono_oop_get_stack_frame_details(
+    const MonoDomain* domain,
+    const void* frameAddress,
+    MonoReadMemoryCallback readMemoryCallback,
+    void* userData,
+    MonoStackFrameDetails* frameDetails)
+{
+    const MonoJitInfo* ji;
+
+    MonoOutOfProcessParameters oopCfg;
+    oopCfg.readMemoryCallback = readMemoryCallback;
+    oopCfg.userData = userData;
+
+    ji = oop_jit_info_table_find(&oopCfg, domain, (const char*) frameAddress);
+    if (ji)
+    {
+        return 1;
+    }
+
+    return 0;
+}

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -47,13 +47,10 @@ typedef struct _MonoStackFrameDetails
 {
     char* methodName;
     size_t methodNameLen;
-    char* signature;
-    size_t signatureLen;
+    char* className;
+    size_t classNameLen;
     char* assemblyName;
     size_t assemblyNameLen;
-    char* sourceFile;
-    size_t sourceFileLen;
-    int lineNo;
 } MonoStackFrameDetails;
 
 typedef gboolean(*ReadMemoryCallback)(void* buffer, gsize* read, const void* address, gsize size, void* userdata);
@@ -385,26 +382,15 @@ mono_unity_oop_get_stack_frame_details(
             frameDetails->methodNameLen,
             read_pointer(OFFSET_MEMBER(MonoMethod, method, name)));
 
+        frameDetails->classNameLen = read_nt_string(
+            frameDetails->className,
+            frameDetails->classNameLen,
+            read_pointer(OFFSET_MEMBER(MonoClass, klass, name)));
+
         frameDetails->assemblyNameLen = read_nt_string(
             frameDetails->assemblyName,
             frameDetails->assemblyNameLen,
             read_pointer(OFFSET_MEMBER(MonoImage, image, assembly_name)));
-
-        /*
-        const char* signature = mono_method_full_name(ji->method, true);
-        g_free((void*)signature);
-
-        //TODO: On 64bits couldn't the subtraction below overflow the conversion?
-        guint32 offset = (guint32)((UIntPtr)frameAddress - (UIntPtr)ji->code_start);
-        MonoDebugSourceLocation* sourceLocation = mono_debug_lookup_source_location(ji->method, offset, monoDomain);
-
-        if (sourceLocation)
-        {
-            stackFrame.sourceFile = sourceLocation->source_file;
-            stackFrame.lineNumber = sourceLocation->row;
-            g_free(sourceLocation);
-        }
-        */
 
         return TRUE;
     }

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -69,10 +69,11 @@ static OutOfProcessMono g_oop = { NULL, NULL };
 
 void read_exception(const void* address, gsize size)
 {
+    g_assert(g_oop.readException);
     if (g_oop.readException)
         g_oop.readException(address, size, g_oop.userData);
     else
-        abort();
+        eg_unreachable();
 }
 
 gsize read_memory(void* buffer, const void* address, gsize size)

--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -359,14 +359,13 @@ oop_jit_info_table_find(
             beyond what we're looking for, we have to end the
             search. */
             if ((gint8*)addr < (gint8*)ji.code_start)
-                goto not_found;
+                return NULL;
         }
 
         ++chunk_pos;
         pos = 0;
     } while (chunk_pos < num_chunks);
 
-not_found:
     return NULL;
 }
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1151,11 +1151,11 @@ mono_arch_unwindinfo_add_alloc_stack (PUNWIND_INFO unwindinfo, MonoUnwindOp *unw
 static gboolean g_dyn_func_table_inited;
 
 // Dynamic function table used when registering unwind info for OS unwind support.
-static GList *g_dynamic_function_table_begin;
-static GList *g_dynamic_function_table_end;
+GList *g_dynamic_function_table_begin;
+GList *g_dynamic_function_table_end;
 
 // SRW lock (lightweight read/writer lock) protecting dynamic function table.
-static SRWLOCK g_dynamic_function_table_lock = SRWLOCK_INIT;
+SRWLOCK g_dynamic_function_table_lock = SRWLOCK_INIT;
 
 // Module handle used when explicit loading ntdll.
 static HMODULE g_ntdll;

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -52,6 +52,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\null-gc.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\number-ms.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\object.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\oop.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\opcodes.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\profiler.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\property-bag.c" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -154,6 +154,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\object.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\oop.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\opcodes.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -29,10 +29,7 @@
     <None Include="..\mono\metadata\Makefile.am" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\mono\metadata\unity-memory-info.c" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\mono\metadata\unity-memory-info.h" />
+    <ClCompile Include="..\mono\metadata\oop.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C36612BD-22D3-4B95-85E2-7FDC4FC5D739}</ProjectGuid>

--- a/msvc/libmonoruntime.vcxproj
+++ b/msvc/libmonoruntime.vcxproj
@@ -29,7 +29,10 @@
     <None Include="..\mono\metadata\Makefile.am" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\mono\metadata\oop.c" />
+    <ClCompile Include="..\mono\metadata\unity-memory-info.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\mono\metadata\unity-memory-info.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C36612BD-22D3-4B95-85E2-7FDC4FC5D739}</ProjectGuid>

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -987,3 +987,6 @@ mono_unity_capture_memory_snapshot
 mono_unity_free_captured_memory_snapshot
 mono_unity_thread_fast_attach
 mono_unity_thread_fast_detach
+
+; Out-of-process inspection
+mono_oop_get_stack_frame_details

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -992,6 +992,7 @@ mono_unity_thread_fast_detach
 mono_unity_oop_init
 mono_unity_oop_iterate_dynamic_function_access_tables64
 mono_unity_oop_get_dynamic_function_access_table64
+mono_unity_oop_get_stack_frame_details
 
 ; Accessors for FATs in X64
 mono_unity_lock_dynamic_function_access_tables64

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -990,6 +990,7 @@ mono_unity_thread_fast_detach
 
 ; Out-of-process inspection
 mono_unity_oop_init
+mono_unity_oop_shutdown
 mono_unity_oop_iterate_dynamic_function_access_tables64
 mono_unity_oop_get_dynamic_function_access_table64
 mono_unity_oop_get_stack_frame_details

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -989,4 +989,10 @@ mono_unity_thread_fast_attach
 mono_unity_thread_fast_detach
 
 ; Out-of-process inspection
-mono_oop_get_stack_frame_details
+mono_unity_oop_init
+mono_unity_oop_iterate_dynamic_function_access_tables64
+mono_unity_oop_get_dynamic_function_access_table64
+
+; Accessors for FATs in X64
+mono_unity_lock_dynamic_function_access_tables64
+mono_unity_unlock_dynamic_function_access_tables64


### PR DESCRIPTION
This exposes the necessary details for symbolicating managed callstacks out-of-process. For x64, this also exposes the Function Access Tables maintained by Mono for purposes of stack unwinding out-of-process.

New APIs:
+mono_unity_oop_init // Sets up out-of-process callbacks
+mono_unity_oop_iterate_dynamic_function_access_tables64 // Iterates over the FATs (x64 only)
+mono_unity_oop_get_dynamic_function_access_table64 // Iterates over the FATs (x64 only)
+mono_unity_oop_get_stack_frame_details // Given an address, return stack frame human-readable name
+mono_unity_lock_dynamic_function_access_tables64* // Locks the FATs to prevent corruption by other threads (x64 only)
+mono_unity_unlock_dynamic_function_access_tables64* // Unlocks the FATs (x64 only)

(* These don't obey the oop_ naming convention as they can't be called from external processes. The crashing process must call lock() before allowing any external process to inspect the FATs.)

To Do/Known Issues:

* oop_init stores callbacks as globals, which isn't great, but made the code so much simpler. Feedback appreciated.
* Expose a few more details from get_stack_frame_details: return type, parameters, whatever we can.
* Testing generated names for nested classes, generics, etc.
* Comments, docs.