### PR TITLE
[Do Not Merge] Mono returns the wrong field offset for a derived type for il2cpp on mono with clang.

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -269,6 +269,7 @@ struct _MonoClass {
 	guint8     rank;          
 
 	int        instance_size; /* object instance size */
+	int        actual_instance_size;
 
 	guint inited          : 1;
 


### PR DESCRIPTION
How do we clean this up? This should only be done on osx right? should we limit this to only il2cpp on mono as well?