### PR TITLE
Add a .editorconfig file for Mono

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# see http://editorconfig.org/ for docs on this file
+
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = false
+insert_final_newline = false
+indent_style = tab
+indent_size = 4
+
+# this VS-specific stuff is based on experiments to see how VS will modify a file after it has been manually edited.
+# the settings are meant to closely match what VS does to minimize unnecessary diffs. this duplicates some settings in *
+# but let's be explicit here to be safe (in case someone wants to copy-paste this out to another .editorconfig).
+[*.{vcxproj,vcxproj.filters,csproj,props,targets}]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8-bom
+trim_trailing_whitespace = true
+insert_final_newline = false
+[*.{sln,sln.template}]
+indent_style = tab
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false


### PR DESCRIPTION
* We're using .editorconfig in Unity now.
* Most of our editors are set up to read it.
* Add one to Mono helps local development environments to be set up properly.