### PR TITLE
Add stub functions for the Unity platform

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -926,13 +926,23 @@ mono_gc_suspend_finalizers (void)
 int
 mono_gc_get_suspend_signal (void)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+#else
 	return GC_get_suspend_signal ();
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 
 int
 mono_gc_get_restart_signal (void)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+#else
 	return GC_get_thr_restart_signal ();
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 
 #if defined(USE_COMPILER_TLS) && defined(__linux__) && (defined(__i386__) || defined(__x86_64__)) && !defined(HAVE_BDWGC_GC)
@@ -1500,9 +1510,14 @@ mono_gc_register_for_finalization (MonoObject *obj, void *user_data)
 int
 mono_gc_pthread_create (pthread_t *new_thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+#else
 	/* it is being replaced by GC_pthread_create on some
 	 * platforms, see libgc/include/gc_pthread_redirects.h */
 	return pthread_create (new_thread, attr, start_routine, arg);
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 #endif
 

--- a/mono/metadata/console-unity.c
+++ b/mono/metadata/console-unity.c
@@ -1,0 +1,53 @@
+#include <mono/metadata/console-io.h>
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_console_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_console_handle_async_ops (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+MonoBoolean
+ves_icall_System_ConsoleDriver_Isatty (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_System_ConsoleDriver_SetEcho (MonoBoolean want_echo)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_System_ConsoleDriver_SetBreak (MonoBoolean want_break)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gint32
+ves_icall_System_ConsoleDriver_InternalKeyAvailable (gint32 timeout)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardown, MonoArray **control_chars, int **size)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
+

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6426,6 +6426,10 @@ ves_icall_System_Environment_get_UserName (void)
 static MonoString *
 mono_icall_get_machine_name (void)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+#else
 #if !defined(DISABLE_SOCKETS)
 	MonoString *result;
 	char *buf;
@@ -6448,6 +6452,7 @@ mono_icall_get_machine_name (void)
 #else
 	return mono_string_new (mono_domain_get (), "mono");
 #endif
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 #endif /* !HOST_WIN32 */
 
@@ -6614,7 +6619,11 @@ mono_icall_get_environment_variable_names (void)
 ICALL_EXPORT MonoArray *
 ves_icall_System_Environment_GetEnvironmentVariableNames (void)
 {
-	return mono_icall_get_environment_variable_names ();
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+#else
+	return mono_icall_get_environment_variable_names();
+#endif // PLATFORM_UNITY
 }
 
 #ifndef HOST_WIN32
@@ -6762,7 +6771,12 @@ leave:
 ICALL_EXPORT MonoArray *
 ves_icall_System_Environment_GetLogicalDrives (void)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+#else
 	return mono_icall_get_logical_drives ();
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 
 ICALL_EXPORT MonoString *

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -217,7 +217,12 @@ IsMemberOf (gid_t user, struct group *g)
 gpointer
 ves_icall_System_Security_Principal_WindowsIdentity_GetCurrentToken (void)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+#else
 	return GINT_TO_POINTER (geteuid ());
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 
 static gint32
@@ -359,6 +364,10 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (
 gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken (gpointer token)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+#else
 #ifdef HOST_WIN32
 	return (ImpersonateLoggedOnUser (token) != 0);
 #else
@@ -369,11 +378,16 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken 
 #endif
 	return geteuid () == itoken;
 #endif
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 
 gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (void)
 {
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+#else
 #ifdef HOST_WIN32
 	return (RevertToSelf () != 0);
 #else
@@ -394,6 +408,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (vo
 #endif
 	return geteuid () == suid;
 #endif
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */
 }
 #endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 

--- a/mono/metadata/w32error-unity.c
+++ b/mono/metadata/w32error-unity.c
@@ -1,0 +1,26 @@
+#include "w32error.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+guint32
+mono_w32error_get_last (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+void
+mono_w32error_set_last (guint32 error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+guint32
+mono_w32error_unix_to_win32 (guint32 error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32event-unity.c
+++ b/mono/metadata/w32event-unity.c
@@ -1,0 +1,78 @@
+#include "w32event.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_w32event_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+mono_w32event_create (gboolean manual, gboolean initial)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gboolean
+mono_w32event_close (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+mono_w32event_set (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_w32event_reset (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+ves_icall_System_Threading_Events_CreateEvent_internal (MonoBoolean manual, MonoBoolean initial, MonoString *name, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gboolean
+ves_icall_System_Threading_Events_SetEvent_internal (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+ves_icall_System_Threading_Events_CloseEvent_internal (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+ves_icall_System_Threading_Events_OpenEvent_internal (MonoString *name, gint32 rights, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoW32HandleNamespace*
+mono_w32event_get_namespace (MonoW32HandleNamedEvent *event)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32file-unity.c
+++ b/mono/metadata/w32file-unity.c
@@ -1,0 +1,282 @@
+#include "w32file.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_w32file_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_w32file_cleanup (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+mono_w32file_create(const gunichar2 *name, guint32 fileaccess, guint32 sharemode, guint32 createmode, guint32 attrs)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gboolean
+mono_w32file_close (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_delete (const gunichar2 *name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_flush (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_truncate (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+guint32
+mono_w32file_seek (gpointer handle, gint32 movedistance, gint32 *highmovedistance, guint32 method)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32file_get_type (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gboolean
+mono_w32file_get_times (gpointer handle, FILETIME *create_time, FILETIME *access_time, FILETIME *write_time)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_set_times (gpointer handle, const FILETIME *create_time, const FILETIME *access_time, const FILETIME *write_time)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_filetime_to_systemtime (const FILETIME *file_time, SYSTEMTIME *system_time)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gpointer
+mono_w32file_find_first (const gunichar2 *pattern, WIN32_FIND_DATA *find_data)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gboolean
+mono_w32file_find_next (gpointer handle, WIN32_FIND_DATA *find_data)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_find_close (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_create_directory (const gunichar2 *name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_remove_directory (const gunichar2 *name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+guint32
+mono_w32file_get_attributes (const gunichar2 *name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gboolean
+mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_set_attributes (const gunichar2 *name, guint32 attrs)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+guint32
+mono_w32file_get_cwd (guint32 length, gunichar2 *buffer)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gboolean
+mono_w32file_set_cwd (const gunichar2 *path)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_create_pipe (gpointer *readpipe, gpointer *writepipe, guint32 size)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_bytes_avail, guint64 *total_number_of_bytes, guint64 *total_number_of_free_bytes)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_get_volume_information (const gunichar2 *path, gunichar2 *volumename, gint volumesize, gint *outserial, gint *maxcomp, gint *fsflags, gunichar2 *fsbuffer, gint fsbuffersize)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_move (gunichar2 *path, gunichar2 *dest, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_replace (gunichar2 *destinationFileName, gunichar2 *sourceFileName, gunichar2 *destinationBackupFileName, guint32 flags, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_copy (gunichar2 *path, gunichar2 *dest, gboolean overwrite, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_lock (gpointer handle, gint64 position, gint64 length, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_w32file_unlock (gpointer handle, gint64 position, gint64 length, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gpointer
+mono_w32file_get_console_input (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gpointer
+mono_w32file_get_console_output (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gpointer
+mono_w32file_get_console_error (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gint64
+mono_w32file_get_file_size (gpointer handle, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+guint32
+mono_w32file_get_drive_type (const gunichar2 *root_path_name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint32
+mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+guint32
+mono_w32process_get_fileversion_info_size (gunichar2 *filename, guint32 *handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+void
+mono_w32process_get_fileversion (MonoObject *filever, gunichar2 *filename, MonoError *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32mutex-unity.c
+++ b/mono/metadata/w32mutex-unity.c
@@ -1,0 +1,45 @@
+#include "w32mutex.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_w32mutex_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+ves_icall_System_Threading_Mutex_CreateMutex_internal (MonoBoolean owned, MonoString *name, MonoBoolean *created)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoBoolean
+ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gpointer
+ves_icall_System_Threading_Mutex_OpenMutex_internal (MonoString *name, gint32 rights, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoW32HandleNamespace*
+mono_w32mutex_get_namespace (MonoW32HandleNamedMutex *mutex)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+void
+mono_w32mutex_abandon (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32process-unity.c
+++ b/mono/metadata/w32process-unity.c
@@ -1,0 +1,123 @@
+#include <mono/metadata/w32process.h>
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_w32process_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_w32process_cleanup (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+ves_icall_System_Diagnostics_Process_GetProcess_internal (guint32 pid)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoBoolean
+ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStartInfo *proc_start_info, MonoW32ProcessInfo *process_info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoW32ProcessStartInfo *proc_start_info, gpointer stdin_handle,
+								 gpointer stdout_handle, gpointer stderr_handle, MonoW32ProcessInfo *process_info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoArray *
+ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_CloseProcess (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_TerminateProcess (gpointer handle, gint32 exitcode)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_GetExitCodeProcess (gpointer handle, gint32 *exitcode)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_GetProcessWorkingSetSize (gpointer handle, gsize *min, gsize *max)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_SetProcessWorkingSetSize (gpointer handle, gsize min, gsize max)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gint32
+ves_icall_Microsoft_Win32_NativeMethods_GetPriorityClass (gpointer handle)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_SetPriorityClass (gpointer handle, gint32 priorityClass)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_Microsoft_Win32_NativeMethods_GetProcessTimes (gpointer handle, gint64 *creationtime, gint64 *exittime, gint64 *kerneltime, gint64 *usertime)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gpointer
+ves_icall_Microsoft_Win32_NativeMethods_GetCurrentProcess (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoString *
+ves_icall_System_Diagnostics_Process_ProcessName_internal (gpointer process)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoArray *
+ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, gpointer process)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32semaphore-unity.c
+++ b/mono/metadata/w32semaphore-unity.c
@@ -1,0 +1,39 @@
+#include "w32semaphore.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_w32semaphore_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gpointer
+ves_icall_System_Threading_Semaphore_CreateSemaphore_internal (gint32 initialCount, gint32 maximumCount, MonoString *name, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoBoolean
+ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gpointer
+ves_icall_System_Threading_Semaphore_OpenSemaphore_internal (MonoString *name, gint32 rights, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+MonoW32HandleNamespace*
+mono_w32semaphore_get_namespace (MonoW32HandleNamedSemaphore *semaphore)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32socket-unity.c
+++ b/mono/metadata/w32socket-unity.c
@@ -1,0 +1,204 @@
+#include "w32socket.h"
+#include "w32socket-internals.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+ves_icall_System_Net_Sockets_Socket_Disconnect_internal (gsize sock, MonoBoolean reuse, gint32 *error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gboolean
+ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoString *filename, MonoArray *pre_buffer,
+	MonoArray *post_buffer, gint flags, gint32 *error, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+ves_icall_System_Net_Sockets_Socket_SupportPortReuse (MonoProtocolType proto)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+MonoBoolean
+ves_icall_System_Net_Dns_GetHostByName_internal (MonoString *host, MonoString **h_name, MonoArray **h_aliases, MonoArray **h_addr_list, gint32 hint)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+mono_w32socket_initialize (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_w32socket_cleanup (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+SOCKET mono_w32socket_accept (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return INVALID_SOCKET;
+}
+
+int mono_w32socket_connect (SOCKET s, const struct sockaddr *name, int namelen, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int mono_w32socket_recv (SOCKET s, char *buf, int len, int flags, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int mono_w32socket_recvfrom (SOCKET s, char *buf, int len, int flags, struct sockaddr *from, socklen_t *fromlen, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int mono_w32socket_recvbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCount, guint32 *lpNumberOfBytesRecvd, guint32 *lpFlags, gpointer lpOverlapped, gpointer lpCompletionRoutine, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int mono_w32socket_send (SOCKET s, char *buf, int len, int flags, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int mono_w32socket_sendto (SOCKET s, const char *buf, int len, int flags, const struct sockaddr *to, int tolen, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int mono_w32socket_sendbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCount, guint32 *lpNumberOfBytesRecvd, guint32 lpFlags, gpointer lpOverlapped, gpointer lpCompletionRoutine, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+BOOL mono_w32socket_transmit_file (SOCKET hSocket, gpointer hFile, TRANSMIT_FILE_BUFFERS *lpTransmitBuffers, guint32 dwReserved, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gint
+mono_w32socket_disconnect (SOCKET sock, gboolean reuse)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_set_blocking (SOCKET sock, gboolean blocking)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_get_available (SOCKET sock, guint64 *amount)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+void
+mono_w32socket_set_last_error (gint32 error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gint32
+mono_w32socket_get_last_error (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint32
+mono_w32socket_convert_error (gint error)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_bind (SOCKET sock, struct sockaddr *addr, socklen_t addrlen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_getpeername (SOCKET sock, struct sockaddr *name, socklen_t *namelen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_getsockname (SOCKET sock, struct sockaddr *name, socklen_t *namelen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_getsockopt (SOCKET sock, gint level, gint optname, gpointer optval, socklen_t *optlen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_setsockopt (SOCKET sock, gint level, gint optname, const gpointer optval, socklen_t optlen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_listen (SOCKET sock, gint backlog)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gint
+mono_w32socket_shutdown (SOCKET sock, gint how)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+SOCKET
+mono_w32socket_socket (int domain, int type, int protocol)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return INVALID_SOCKET;
+}
+
+gboolean
+mono_w32socket_close (SOCKET sock)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2561,6 +2561,8 @@ leave2:
 	return is_ok (error);
 }
 
+#if !defined(PLATFORM_UNITY) || !defined(UNITY_USE_PLATFORM_STUBS)
+
 MonoBoolean
 ves_icall_System_Net_Dns_GetHostByName_internal (MonoString *host, MonoString **h_name, MonoArray **h_aliases, MonoArray **h_addr_list, gint32 hint)
 {
@@ -2605,6 +2607,8 @@ ves_icall_System_Net_Dns_GetHostByName_internal (MonoString *host, MonoString **
 	}
 	return FALSE;
 }
+
+#endif // !PLATFORM_UNITY)|| !UNITY_USE_PLATFORM_STUBS
 
 MonoBoolean
 ves_icall_System_Net_Dns_GetHostByAddr_internal (MonoString *addr, MonoString **h_name, MonoArray **h_aliases, MonoArray **h_addr_list, gint32 hint)

--- a/mono/utils/mono-dl-unity.c
+++ b/mono/utils/mono-dl-unity.c
@@ -1,0 +1,75 @@
+#include <glib.h>
+#include "mono/utils/mono-dl.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+const char*
+mono_dl_get_so_prefix (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+const char**
+mono_dl_get_so_suffixes (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+void*
+mono_dl_open_file (const char *file, int flags)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+void
+mono_dl_close_handle (MonoDl *module)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void*
+mono_dl_lookup_symbol_in_process (const char *symbol_name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+void*
+mono_dl_lookup_symbol (MonoDl *module, const char *symbol_name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+int
+mono_dl_convert_flags (int flags)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+char*
+mono_dl_current_error_string (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+int
+mono_dl_get_executable_path (char *buf, int buflen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+const char*
+mono_dl_get_system_dir (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -110,7 +110,7 @@ mono_log_write_logfile (const char *log_domain, GLogLevelFlags level, mono_bool 
 		pid_t pid;
 		char logTime [80];
 
-#ifndef HOST_WIN32
+#ifdef HAVE_LOCALTIME_R
 		struct tm tod;
 		time(&t);
 		localtime_r(&t, &tod);

--- a/mono/utils/mono-log-unity.c
+++ b/mono/utils/mono-log-unity.c
@@ -1,0 +1,24 @@
+#include "mono-logger-internals.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_log_open_syslog(const char *ident, void *userData)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+
+}
+
+void
+mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, const char *message)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_log_close_syslog()
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -507,14 +507,21 @@ get_process_stat_item (int pid, int pos, int sum, MonoProcessError *error)
 #endif
 }
 
+/* The sysconf method is not defined on all platforms.
+ * For the Unity platform, we don't use this code anyway,
+ * so don't compile it.
+*/
+
 static int
 get_user_hz (void)
 {
 	static int user_hz = 0;
 	if (user_hz == 0) {
+#if !defined (PLATFORM_UNITY)
 #ifdef _SC_CLK_TCK
 		user_hz = sysconf (_SC_CLK_TCK);
 #endif
+#endif // PLATFORM_UNITY
 		if (user_hz == 0)
 			user_hz = 100;
 	}

--- a/mono/utils/mono-threads-unity.c
+++ b/mono/utils/mono-threads-unity.c
@@ -1,0 +1,171 @@
+#include <mono/utils/mono-threads.h>
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_threads_suspend_init (void)
+{
+   g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gboolean
+mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interrupt_kernel)
+{
+   g_assert(0 && "This function is not yet implemented for the Unity platform.");
+   return FALSE;
+}
+
+gboolean
+mono_threads_suspend_check_suspend_result (MonoThreadInfo *info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+mono_threads_suspend_abort_syscall (MonoThreadInfo *info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gboolean
+mono_threads_suspend_needs_abort_syscall (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_threads_suspend_begin_async_resume (MonoThreadInfo *info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+mono_threads_suspend_register (MonoThreadInfo *info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_threads_suspend_free (MonoThreadInfo *info)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_threads_suspend_init_signals (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gint
+mono_threads_suspend_search_alternative_signal (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assert_not_reached ();
+}
+
+gint
+mono_threads_suspend_get_suspend_signal (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return -1;
+}
+
+gint
+mono_threads_suspend_get_restart_signal (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return -1;
+}
+
+gint
+mono_threads_suspend_get_abort_signal (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return -1;
+}
+
+int
+mono_threads_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_data, gsize* const stack_size, MonoNativeThreadId *out_tid)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return-1;
+}
+
+
+MonoNativeThreadId
+mono_native_thread_id_get (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+gboolean
+mono_native_thread_id_equals (MonoNativeThreadId id1, MonoNativeThreadId id2)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_native_thread_create (MonoNativeThreadId *tid, gpointer func, gpointer arg)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+gboolean
+mono_native_thread_join (MonoNativeThreadId tid)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_threads_platform_init (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gboolean
+mono_threads_platform_in_critical_region (MonoNativeThreadId tid)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+gboolean
+mono_threads_platform_yield (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+void
+mono_threads_platform_exit (gsize exit_code)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+int
+mono_threads_get_max_stack_size (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+void
+mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+#endif //PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS

--- a/mono/utils/networking-unity.c
+++ b/mono/utils/networking-unity.c
@@ -1,0 +1,47 @@
+#include <mono/utils/networking.h>
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+int
+mono_get_address_info (const char *hostname, int port, int flags, MonoAddressInfo **result)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+void *
+mono_get_local_interfaces (int family, int *interface_count)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return NULL;
+}
+
+gboolean
+mono_networking_addr_to_str (MonoAddress *address, char *buffer, socklen_t buflen)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return FALSE;
+}
+
+int
+mono_networking_get_tcp_protocol (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int
+mono_networking_get_ip_protocol (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+int
+mono_networking_get_ipv6_protocol (void)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return 0;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/utils/os-event-unity.c
+++ b/mono/utils/os-event-unity.c
@@ -1,0 +1,43 @@
+#include "os-event.h"
+
+#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+
+void
+mono_os_event_init (MonoOSEvent *event, gboolean initial)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_os_event_destroy (MonoOSEvent *event)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_os_event_set (MonoOSEvent *event)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+void
+mono_os_event_reset (MonoOSEvent *event)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+}
+
+MonoOSEventWaitRet
+mono_os_event_wait_one (MonoOSEvent *event, guint32 timeout, gboolean alertable)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return MONO_OS_EVENT_WAIT_RET_TIMEOUT;
+}
+
+MonoOSEventWaitRet
+mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waitall, guint32 timeout, gboolean alertable)
+{
+	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	return MONO_OS_EVENT_WAIT_RET_TIMEOUT;
+}
+
+#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */


### PR DESCRIPTION
These stub functions allow IL2CPP on Mono to build and link on platforms where we don't have the Unity PAL completed yet. The building toolchain for a given platform needs to define `UNITY_USE_PLATFORM_STUBS` to get these stubs to be included in the build.