### PR TITLE
Fix ARM alignment issues

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3893,15 +3893,15 @@ mono_type_size (MonoType *t, int *align)
 		return 4;
 	case MONO_TYPE_I8:
 	case MONO_TYPE_U8:
-#if defined(TARGET_ARM)                                                                                                                                                                                                                                               
-                *align = 4;                                                                                                                                                                                                                                            
+#if defined(PLATFORM_IPHONE_XCOMP)
+		*align = 4;
 #else
 		*align = __alignof__(gint64);
 #endif
 		return 8;		
 	case MONO_TYPE_R8:
-#if defined(TARGET_ARM)                                                                                                                                                                                                                                               
-                *align = 4;                                                                                                                                                                                                                                            
+#if defined(PLATFORM_IPHONE_XCOMP)
+		*align = 4;
 #else
 		*align = __alignof__(double);
 #endif


### PR DESCRIPTION
Only force 4 byte for double/int64_t on iOS cross compiles (case 898636)