### PR TITLE
[Backport] Don't allocate when sorting a list

### DIFF
--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -1909,6 +1909,17 @@ namespace System
 			SortImpl<T> (array, array.Length, comparison);
 		}
 
+		internal static void Sort<T> (T [] array, int length, Comparison<T> comparison)
+		{
+			if (array == null)
+				throw new ArgumentNullException ("array");
+
+			if (comparison == null)
+				throw new ArgumentNullException ("comparison");
+
+			SortImpl<T> (array, length, comparison);
+		}
+
 		// used by List<T>.Sort (Comparison <T>)
 		internal static void SortImpl<T> (T [] array, int length, Comparison<T> comparison)
 		{

--- a/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs
+++ b/mcs/class/referencesource/mscorlib/system/collections/generic/list.cs
@@ -995,8 +995,7 @@ namespace System.Collections.Generic {
             Contract.EndContractBlock();
 
             if( _size > 0) {
-                IComparer<T> comparer = new Array.FunctorComparer<T>(comparison);
-                Array.Sort(_items, 0, _size, comparer);
+                Array.Sort(_items, _size, comparison);
             }
         }
 


### PR DESCRIPTION
graft change that stopped sorting a list from allocating memory when using a system.comparison object