### PR TITLE
Unity 2017.1 MBE Fixes

### DIFF
--- a/mcs/errors/cs1621-2.cs
+++ b/mcs/errors/cs1621-2.cs
@@ -1,0 +1,21 @@
+// CS1621: The yield statement cannot be used inside anonymous method blocks
+// Line: 12
+
+using System;
+using System.Collections;
+
+public class Test
+{
+	public IEnumerator Foo ()
+	{
+		Call (() => {
+			yield break;
+		});
+
+		yield break;
+	}
+
+	void Call (Action a)
+	{
+	}
+}

--- a/mcs/mcs/iterators.cs
+++ b/mcs/mcs/iterators.cs
@@ -161,7 +161,6 @@ namespace Mono.CSharp
 
 		protected override void CloneTo (CloneContext clonectx, Statement target)
 		{
-			throw new NotSupportedException ();
 		}
 
 		protected override bool DoResolve (BlockContext bc)

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2020,6 +2020,9 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomain *ad,
 		return NULL; 
 	}
 
+	/* Clear the reference added by mono_image_open_from_data_full */
+	mono_image_close (image);
+
 	refass = mono_assembly_get_object_checked (domain, ass, &error);
 	if (!refass)
 		mono_error_set_pending_exception (&error);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -275,7 +275,9 @@ mono_gc_base_init (void)
 	mono_os_mutex_init_recursive (&handle_section);
 
 	mono_thread_info_attach (&dummy);
-#if !HAVE_BDWGC_GC
+#ifdef HAVE_BDWGC_GC
+	GC_set_on_event (on_gc_notification);
+#else
 	GC_set_on_collection_event (on_gc_notification);
 #endif
 	GC_on_heap_resize = on_gc_heap_resize;


### PR DESCRIPTION
Case 931981 - Report GC pause time correctly in profiler
Case 634364 - Fix internal compiler error due to yield in a lambda statement
Case 935845 - Avoid allocating GC memory when calling List.Sort with Comparer`1