### PR TITLE
Two fixes

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -453,10 +453,6 @@ boehm_thread_unregister (MonoThreadInfo *p)
 
 	if (p->runtime_thread)
 		mono_threads_add_joinable_thread ((gpointer)tid);
-
-#if HAVE_BDWGC_GC
-	GC_unregister_my_thread ();
-#endif
 }
 
 static gpointer
@@ -474,14 +470,18 @@ boehm_thread_detach (MonoThreadInfo *p)
 	if (mono_thread_internal_current_is_attached ())
 		mono_thread_detach_internal (mono_thread_internal_current ());
 
-
 	GC_call_with_alloc_lock (remove_handle_stack, p->handle_stack);
+
 	/* Free in detach rather than unregister since 
 	 * Boehm handle stack uses GC memory and acquires
 	 * GC lock to free it. The detach callback 
 	 * does not hold any locks while unregister does.
 	 */
 	mono_handle_stack_free (p->handle_stack);
+
+#if HAVE_BDWGC_GC
+	GC_unregister_my_thread ();
+#endif
 }
 
 gboolean

--- a/mono/metadata/w32socket-internals.h
+++ b/mono/metadata/w32socket-internals.h
@@ -68,6 +68,13 @@ mono_w32socket_cleanup (void);
 SOCKET
 mono_w32socket_accept (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking);
 
+#ifndef HOST_WIN32
+
+SOCKET
+mono_w32socket_accept_internal (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking);
+
+#endif
+
 int
 mono_w32socket_connect (SOCKET s, const struct sockaddr *name, int namelen, gboolean blocking);
 

--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -132,12 +132,19 @@ static gboolean alertable_socket_wait (SOCKET sock, int event_bit)
 		blocking ? "blocking" : "non-blocking", sock, ret, _saved_error)); \
 	WSASetLastError (_saved_error);
 
+SOCKET mono_w32socket_accept_internal (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking)
+{
+	SOCKET newsock = INVALID_SOCKET;
+	ALERTABLE_SOCKET_CALL (FD_ACCEPT_BIT, blocking, TRUE, newsock, accept, s, addr, addrlen);
+	return newsock;
+}
+
 SOCKET mono_w32socket_accept (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking)
 {
 	MonoInternalThread *curthread = mono_thread_internal_current ();
 	SOCKET newsock = INVALID_SOCKET;
 	curthread->interrupt_on_stop = (gpointer)TRUE;
-	ALERTABLE_SOCKET_CALL (FD_ACCEPT_BIT, blocking, TRUE, newsock, accept, s, addr, addrlen);
+	newsock = mono_w32socket_accept_internal (s, addr, addrlen, blocking);
 	curthread->interrupt_on_stop = (gpointer)FALSE;
 	return newsock;
 }

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1193,7 +1193,7 @@ socket_transport_accept (int socket_fd)
 {
 	MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
-	conn_fd = mono_w32socket_accept (socket_fd, NULL, NULL, TRUE);
+	conn_fd = mono_w32socket_accept_internal (socket_fd, NULL, NULL, TRUE);
 	if (conn_fd != -1)
 		mono_w32socket_set_blocking (conn_fd, TRUE);
 #else


### PR DESCRIPTION
Fix jam debugging by using new `mono_w32socket_accept_internal` method that doesn't assume thread is attached to runtime as debugger socket connect thread is not.

Fix deadlock on thread detach between GC and thread info locks. Move call to `GC_unregister_my_thread` inside the thread info callback that allows locks.