### PR TITLE
Replace event, mutex, and semaphore in Mono with the Unity PAL

### DIFF
--- a/external/buildscripts/sources.txt
+++ b/external/buildscripts/sources.txt
@@ -290,8 +290,6 @@ mono/metadata/w32error-unity.c
 mono/metadata/w32error-win32.c
 mono/metadata/w32error-unix.c
 mono/metadata/w32event-unity.c
-mono/metadata/w32event-win32.c
-mono/metadata/w32event-unix.c
 mono/metadata/w32file-unity.c
 mono/metadata/w32file-win32.c
 mono/metadata/w32file-unix.c
@@ -300,8 +298,6 @@ mono/metadata/w32file.c
 mono/metadata/w32handle-namespace.c
 mono/metadata/w32handle.c
 mono/metadata/w32mutex-unity.c
-mono/metadata/w32mutex-win32.c
-mono/metadata/w32mutex-unix.c
 mono/metadata/w32process-unity.c
 mono/metadata/w32process-unix-osx.c
 mono/metadata/w32process-unix-default.c
@@ -309,8 +305,6 @@ mono/metadata/w32process-unix.c
 mono/metadata/w32process-win32.c
 mono/metadata/w32process.c
 mono/metadata/w32semaphore-unity.c
-mono/metadata/w32semaphore-win32.c
-mono/metadata/w32semaphore-unix.c
 mono/metadata/w32socket-unity.c
 mono/metadata/w32socket-unix.c
 mono/metadata/w32socket-win32.c

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -32,6 +32,10 @@
 #include <mono/utils/atomic.h>
 #include <mono/utils/w32api.h>
 
+#if defined(PLATFORM_UNITY)
+#include "Handle-c-api.h"
+#endif
+
 /*
  * Pull the list of opcodes
  */
@@ -1374,7 +1378,9 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 	 * signalled before we wait, we still succeed.
 	 */
 	MONO_ENTER_GC_SAFE;
-#ifdef HOST_WIN32
+#if defined (PLATFORM_UNITY)
+	ret = (MonoW32HandleWaitRet)UnityPalHandleWaitMs(event, ms, TRUE);
+#elif defined(HOST_WIN32)
 	ret = mono_w32handle_convert_wait_ret (WaitForSingleObjectEx (event, ms, TRUE), 1);
 #else
 	ret = mono_w32handle_wait_one (event, ms, TRUE);
@@ -1403,7 +1409,9 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 		 * while we were trying to regain the monitor lock
 		 */
 		MONO_ENTER_GC_SAFE;
-#ifdef HOST_WIN32
+#if defined(PLATFORM_UNITY)
+		ret = (MonoW32HandleWaitRet)UnityPalHandleWaitMs(event, 0, FALSE);
+#elif defined(HOST_WIN32)
 		ret = mono_w32handle_convert_wait_ret (WaitForSingleObjectEx (event, 0, FALSE), 1);
 #else
 		ret = mono_w32handle_wait_one (event, 0, FALSE);

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -46,6 +46,10 @@
 #include <mono/utils/mono-time.h>
 #include <mono/utils/refcount.h>
 
+#if defined(PLATFORM_UNITY)
+#include "Handle-c-api.h"
+#endif
+
 typedef struct {
 	MonoDomain *domain;
 	/* Number of outstanding jobs */
@@ -580,7 +584,9 @@ mono_threadpool_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObj
 		}
 		mono_monitor_exit ((MonoObject*) ares);
 		MONO_ENTER_GC_SAFE;
-#ifdef HOST_WIN32
+#if defined(PLATFORM_UNITY)
+		UnityPalHandleWait(wait_event, TRUE);
+#elif defined(HOST_WIN32)
 		WaitForSingleObjectEx (wait_event, INFINITE, TRUE);
 #else
 		mono_w32handle_wait_one (wait_event, MONO_INFINITE_WAIT, TRUE);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -65,6 +65,10 @@
 #include <errno.h>
 #endif
 
+#if defined(PLATFORM_UNITY)
+#include "Handle-c-api.h"
+#endif
+
 /*#define THREAD_DEBUG(a) do { a; } while (0)*/
 #define THREAD_DEBUG(a)
 /*#define THREAD_WAIT_DEBUG(a) do { a; } while (0)*/
@@ -1851,7 +1855,9 @@ mono_wait_uninterrupted (MonoInternalThread *thread, guint32 numhandles, gpointe
 	start = (ms == -1) ? 0 : mono_100ns_ticks ();
 	do {
 		MONO_ENTER_GC_SAFE;
-#ifdef HOST_WIN32
+#if defined(PLATFORM_UNITY)
+		ret = (MonoW32HandleWaitRet)UnityPalWaitForMultipleHandles(handles, numhandles, waitall, wait, TRUE);
+#elif defined(HOST_WIN32)
 		if (numhandles != 1)
 			ret = mono_w32handle_convert_wait_ret (WaitForMultipleObjectsEx (numhandles, handles, waitall, wait, TRUE), numhandles);
 		else
@@ -2006,7 +2012,9 @@ ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (HANDLE toSignal, H
 	mono_thread_set_state (thread, ThreadState_WaitSleepJoin);
 	
 	MONO_ENTER_GC_SAFE;
-#ifdef HOST_WIN32
+#if defined(PLATFORM_UNITY)
+	ret = (MonoW32HandleWaitRet)UnityPalHandleSignalAndWait(toSignal, toWait, ms, TRUE);
+#elif defined(HOST_WIN32)
 	ret = mono_w32handle_convert_wait_ret (SignalObjectAndWait (toSignal, toWait, ms, TRUE), 1);
 #else
 	ret = mono_w32handle_signal_and_wait (toSignal, toWait, ms, TRUE);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -66,6 +66,7 @@
 #endif
 
 #if defined(PLATFORM_UNITY)
+#include "Thread-c-api.h"
 #include "Handle-c-api.h"
 #endif
 
@@ -664,6 +665,10 @@ mono_thread_attach_internal (MonoThread *thread, gboolean force_attach, gboolean
 	g_assert (thread);
 
 	info = mono_thread_info_current ();
+
+#if defined(PLATFORM_UNITY)
+	UnityPalThreadInitialize();
+#endif
 
 	internal = thread->internal_thread;
 	internal->handle = mono_threads_open_thread_handle (info->handle);

--- a/mono/metadata/w32event-unity.c
+++ b/mono/metadata/w32event-unity.c
@@ -1,78 +1,83 @@
 #include "w32event.h"
-
-#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+#include "Handle-c-api.h"
+#include "Event-c-api.h"
+#include "Error-c-api.h"
 
 void
 mono_w32event_init (void)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
 }
 
 gpointer
 mono_w32event_create (gboolean manual, gboolean initial)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return NULL;
+	UnityPalEvent* event = UnityPalEventNew(manual, initial);
+	return UnityPalEventHandleNew(event);
 }
 
 gboolean
 mono_w32event_close (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return FALSE;
+	UnityPalHandleDestroy(handle);
+	return TRUE;
 }
 
 void
 mono_w32event_set (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	UnityPalEventSet(UnityPalEventHandleGet(handle));
 }
 
 void
 mono_w32event_reset (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	UnityPalEventReset(UnityPalEventHandleGet(handle));
 }
 
 gpointer
 ves_icall_System_Threading_Events_CreateEvent_internal (MonoBoolean manual, MonoBoolean initial, MonoString *name, gint32 *error)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return NULL;
+	if (name != NULL)
+	{
+		g_assertion_message("Named events are not supported by the Unity platform.");
+		return NULL;
+	}
+
+	UnityPalEvent* event = UnityPalEventNew(manual, initial);
+	*error = UnityPalGetLastError();
+	return UnityPalEventHandleNew(event);
 }
 
 gboolean
 ves_icall_System_Threading_Events_SetEvent_internal (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return FALSE;
+	UnityPalErrorCode result = UnityPalEventSet(UnityPalEventHandleGet(handle));
+	return UnityPalSuccess(result);
 }
 
 gboolean
 ves_icall_System_Threading_Events_ResetEvent_internal (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return FALSE;
+	UnityPalErrorCode result = UnityPalEventReset(UnityPalEventHandleGet(handle));
+	return UnityPalSuccess(result);
 }
 
 void
 ves_icall_System_Threading_Events_CloseEvent_internal (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	UnityPalHandleDestroy(handle);
 }
 
 gpointer
 ves_icall_System_Threading_Events_OpenEvent_internal (MonoString *name, gint32 rights, gint32 *error)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assertion_message("Named events are not supported by the Unity platform.");
 	return NULL;
 }
 
 MonoW32HandleNamespace*
 mono_w32event_get_namespace (MonoW32HandleNamedEvent *event)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assertion_message("Named events are not supported by the Unity platform.");
 	return NULL;
 }
-
-#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32mutex-unity.c
+++ b/mono/metadata/w32mutex-unity.c
@@ -1,45 +1,49 @@
 #include "w32mutex.h"
-
-#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+#include "Mutex-c-api.h"
 
 void
 mono_w32mutex_init (void)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
 }
 
 gpointer
 ves_icall_System_Threading_Mutex_CreateMutex_internal (MonoBoolean owned, MonoString *name, MonoBoolean *created)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return NULL;
+	UnityPalMutex* mutex = NULL;
+
+	*created = TRUE;
+
+	if (!name) {
+		mutex = UnityPalMutexNew (owned);
+	} else {
+		g_assertion_message ("Named mutexes are not supported by the Unity platform.");
+	}
+
+	return UnityPalMutexHandleNew(mutex);
 }
 
 MonoBoolean
 ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return FALSE;
+	UnityPalMutexUnlock(UnityPalMutexHandleGet(handle));
+	return TRUE;
 }
 
 gpointer
 ves_icall_System_Threading_Mutex_OpenMutex_internal (MonoString *name, gint32 rights, gint32 *error)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assertion_message ("Named mutexes are not supported by the Unity platform.");
 	return NULL;
 }
 
 MonoW32HandleNamespace*
 mono_w32mutex_get_namespace (MonoW32HandleNamedMutex *mutex)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assertion_message ("Named mutexes are not supported by the Unity platform.");
 	return NULL;
 }
 
 void
 mono_w32mutex_abandon (void)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
 }
-
-#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */

--- a/mono/metadata/w32semaphore-unity.c
+++ b/mono/metadata/w32semaphore-unity.c
@@ -1,39 +1,42 @@
 #include "w32semaphore.h"
-
-#if defined(PLATFORM_UNITY) && defined(UNITY_USE_PLATFORM_STUBS)
+#include "Semaphore-c-api.h"
+#include "Error-c-api.h"
 
 void
 mono_w32semaphore_init (void)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
 }
 
 gpointer
 ves_icall_System_Threading_Semaphore_CreateSemaphore_internal (gint32 initialCount, gint32 maximumCount, MonoString *name, gint32 *error)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return NULL;
+	if (name != NULL)
+	{
+		g_assertion_message("Named semaphores are not supported by the Unity platform.");
+		return NULL;
+	}
+
+	UnityPalSemaphore* semaphore = UnityPalSemaphoreNew(initialCount, maximumCount);
+	*error = UnityPalGetLastError();
+	return UnityPalSemaphoreHandleNew(semaphore);
 }
 
 MonoBoolean
 ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
-	return FALSE;
+	return UnityPalSemaphorePost(UnityPalSemaphoreHandleGet(handle), releaseCount, prevcount);
 }
 
 gpointer
 ves_icall_System_Threading_Semaphore_OpenSemaphore_internal (MonoString *name, gint32 rights, gint32 *error)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assertion_message("Named semaphores are not supported by the Unity platform.");
 	return NULL;
 }
 
 MonoW32HandleNamespace*
 mono_w32semaphore_get_namespace (MonoW32HandleNamedSemaphore *semaphore)
 {
-	g_assert(0 && "This function is not yet implemented for the Unity platform.");
+	g_assertion_message("Named semaphores are not supported by the Unity platform.");
 	return NULL;
 }
-
-#endif /* PLATFORM_UNITY && UNITY_USE_PLATFORM_STUBS */


### PR DESCRIPTION
This code is only used during the IL2CPP on Mono build.