### PR TITLE
Remove il2cpp dependency

### DIFF
--- a/eglib/src/Makefile.am
+++ b/eglib/src/Makefile.am
@@ -1,4 +1,4 @@
-noinst_LTLIBRARIES = libeglib.la libeglib-unity.la
+noinst_LTLIBRARIES = libeglib.la
 
 AM_CFLAGS = $(WERROR_CFLAGS)
 
@@ -10,10 +10,6 @@ win_files  = \
 unix_files = \
 	gdate-unix.c  gdir-unix.c  gfile-unix.c  gmisc-unix.c	\
 	gmodule-unix.c gtimer-unix.c gfile-posix.c
-
-unity_files = \
-	gdate-unity.c gdir-unity.c gfile-unity.c gmisc-unity.c \
-	gpath-unity.c
 
 common_files = \
 	eglib-remap.h	\
@@ -54,12 +50,7 @@ libeglib_la_SOURCES = \
 	$(common_files) \
 	$(os_files)
 
-libeglib_unity_la_SOURCES = \
-	$(common_files) \
-	$(unity_files)
-
 libeglib_la_CFLAGS = -g -Wall -D_FORTIFY_SOURCE=2
-libeglib_unity_la_CFLAGS = $(libeglib_la_CFLAGS) -DPLATFORM_UNITY -I../../../../il2cpp/build/libil2cpp/os/c-api
 
 AM_CPPFLAGS = -I$(srcdir)
 

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -166,7 +166,6 @@ if ($android || $iphone || $iphoneCross || $iphoneSimulator || $tizen || $tizenE
 
 # Do any settings agnostic per-platform stuff
 my $externalBuildDeps = "";
-my $externalBuildDepsIl2Cpp = "$monoroot/../../il2cpp/build";
 
 if ($buildDeps ne "" && not $forceDefaultBuildDeps)
 {
@@ -290,18 +289,6 @@ if ($build)
 
 			# Only clean up if the dir exists.   Otherwise abs_path will return empty string
 			$externalBuildDeps = abs_path($externalBuildDeps) if (-d $externalBuildDeps);
-		}
-
-		if (!(-d "$externalBuildDepsIl2Cpp"))
-		{
-			my $il2cpp_repo = "https://bitbucket.org/Unity-Technologies/il2cpp";
-            print(">>> Cloning $il2cpp_repo at $externalBuildDepsIl2Cpp\n");
-            $checkoutResult = system("hg", "clone", $il2cpp_repo, "$externalBuildDepsIl2Cpp");
-
-            if ($checkoutOnTheFly && $checkoutResult ne 0)
-            {
-                die("failed to checkout IL2CPP for the mono build dependencies\n");
-            }
 		}
 
 		if (-d "$existingExternalMono")

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -65,7 +65,6 @@ print(">>> Build Scripts Revision = $buildScriptsRevision\n");
 
 # Do any settings agnostic per-platform stuff
 my $externalBuildDeps = "";
-my $externalBuildDepsIl2Cpp = "$monoroot/../../il2cpp/build";
 
 if ($buildDeps ne "" && not $forceDefaultBuildDeps)
 {
@@ -111,18 +110,6 @@ if ($build)
 				die("failed to checkout mono build dependencies\n");
 			}
 		}
-
-        if (!(-d "$externalBuildDepsIl2Cpp"))
-        {
-            my $il2cpp_repo = "https://bitbucket.org/Unity-Technologies/il2cpp";
-            print(">>> Cloning $il2cpp_repo at $externalBuildDepsIl2Cpp\n");
-            $checkoutResult = system("hg", "clone", $il2cpp_repo, "$externalBuildDepsIl2Cpp");
-
-            if ($checkoutOnTheFly && $checkoutResult ne 0)
-            {
-                die("failed to checkout IL2CPP for the mono build dependencies\n");
-            }
-        }
 
 		if (-d "$existingExternalMono")
 		{

--- a/external/buildscripts/build_win_wrapper.pl
+++ b/external/buildscripts/build_win_wrapper.pl
@@ -66,7 +66,6 @@ GetOptions(
 );
 
 my $externalBuildDeps = "";
-my $externalBuildDepsIl2Cpp = "$monoroot/../../il2cpp/build";
 
 if ($buildDeps ne "")
 {
@@ -97,18 +96,6 @@ else
 			die("failed to checkout mono build dependencies\n");
 		}
 	}
-
-    if (!(-d "$externalBuildDepsIl2Cpp"))
-    {
-        my $il2cpp_repo = "https://bitbucket.org/Unity-Technologies/il2cpp";
-        print(">>> Cloning $il2cpp_repo at $externalBuildDepsIl2Cpp\n");
-        $checkoutResult = system("hg", "clone", $il2cpp_repo, "$externalBuildDepsIl2Cpp");
-
-        if ($checkoutOnTheFly && $checkoutResult ne 0)
-        {
-            die("failed to checkout IL2CPP for the mono build dependencies\n");
-        }
-    }
 }
 
 print(">>> externalBuildDeps = $externalBuildDeps\n");


### PR DESCRIPTION
We don't need to check out IL2CPP any more when we build Mono, so remove the code which does that on user machines. I'll make the change on the build farm separately.