### PR TITLE
Handle a directory length smaller than the buffer

### DIFF
--- a/mono/metadata/w32file-unity.c
+++ b/mono/metadata/w32file-unity.c
@@ -496,6 +496,8 @@ gboolean mono_w32file_delete(const gunichar2 *name)
 guint32
 mono_w32file_get_cwd (guint32 length, gunichar2 *buffer)
 {
+	/* length is the number of characters in buffer, including the null terminator */
+	/* count is the number of characters in the current directory, including the null terminator */
 	gunichar2 *utf16_path;
 	glong count;
 	uintptr_t bytes;
@@ -505,11 +507,15 @@ mono_w32file_get_cwd (guint32 length, gunichar2 *buffer)
 	mono_w32error_set_last (error);
 	utf16_path = mono_unicode_from_external(palPath, &bytes);
 	count = (bytes / 2) + 1;
-	memcpy(buffer, utf16_path, length);
+
+	if (count <= length) {
+		/* Add the terminator */
+		memset (buffer, '\0', bytes+2);
+		memcpy (buffer, utf16_path, bytes);
+	}
+
 	g_free(utf16_path);
 	g_free(palPath);
-
-
 
 	return count;
 }


### PR DESCRIPTION
This fixes a crash when the length of the directory is less than the length of the input buffer.

* We were copying the entire length of the input buffer, which means we read beyond the path.
* The memory after the valid length of the path might not be readable, hence a possible crash.
* The fix steals a bit of code from the w32file-unix.c file, where the implement is similar to ours.