### PR TITLE
Mono Fixes

### DIFF
--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -569,7 +569,7 @@ dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned cha
 		size_t len2;
 		char *blob2 = NULL;
 
-		if (!method->klass->image->dynamic) {
+		if (!method->klass->image->dynamic && !method->dynamic) {
 			token = read32 (ip);
 			blob = mono_metadata_user_string (method->klass->image, mono_metadata_token_index (token));
 

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -2587,5 +2587,24 @@ class Tests {
 		catch {}
 		return (int)value;
 	}
+
+	class A {
+		public object AnObj;
+	}
+
+	public static void DoSomething (ref object o) {
+	}
+
+	public static int test_0_ldflda_null () {
+		A a = null;
+
+		try {
+			DoSomething (ref a.AnObj);
+		} catch (NullReferenceException) {
+			return 0;
+		}
+
+		return 1;
+	}
 }
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8382,9 +8382,12 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					sp [0] = ins;
 				}
 
-				MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg);
-
 				if (*ip == CEE_LDFLDA) {
+					if (sp[0]->type == STACK_OBJ) {
+						MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, sp[0]->dreg, 0);
+						MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+					}
+
 					dreg = alloc_preg (cfg);
 
 					EMIT_NEW_BIALU_IMM (cfg, ins, OP_PADD_IMM, dreg, sp [0]->dreg, foffset);
@@ -8393,6 +8396,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					*sp++ = ins;
 				} else {
 					MonoInst *load;
+
+					MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg);
 
 					EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, load, field->type, sp [0]->dreg, foffset);
 					load->flags |= ins_flag;


### PR DESCRIPTION
Case 942459 - Fixed crash when invalid IL code was encountered
Case 918046 - Fixed crash when Ldflda opcode is used and null check is missing