### PR TITLE
Use the proper size for the bytes pointer

### DIFF
--- a/mono/metadata/w32file-unity.c
+++ b/mono/metadata/w32file-unity.c
@@ -500,7 +500,7 @@ mono_w32file_get_cwd (guint32 length, gunichar2 *buffer)
 	/* count is the number of characters in the current directory, including the null terminator */
 	gunichar2 *utf16_path;
 	glong count;
-	uintptr_t bytes;
+	glong bytes;
 	int error = 0;
 
 	const char* palPath = UnityPalDirectoryGetCurrent(&error);

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3757,7 +3757,7 @@ mono_w32file_get_cwd (guint32 length, gunichar2 *buffer)
 {
 	gunichar2 *utf16_path;
 	glong count;
-	gsize bytes;
+	glong bytes;
 
 #ifdef __native_client__
 	gchar *path = g_get_current_dir ();

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1143,7 +1143,7 @@ guint32
 mono_w32process_module_get_filename (gpointer process, gpointer module, gunichar2 *basename, guint32 size)
 {
 	gint pid, len;
-	gsize bytes;
+	glong bytes;
 	gchar *path;
 	gunichar2 *proc_path;
 
@@ -1815,7 +1815,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	 */
 	if (is_managed_binary (prog)) {
 		gunichar2 *newapp, *newcmd;
-		gsize bytes_ignored;
+		glong bytes_ignored;
 
 		newapp = mono_unicode_from_external (cli_launcher ? cli_launcher : "mono", &bytes_ignored);
 		if (newapp) {

--- a/mono/utils/strenc.c
+++ b/mono/utils/strenc.c
@@ -41,7 +41,7 @@ static const char trailingBytesForUTF8[256] = {
  * of bytes in the returned string, not including the terminator.
  */
 gunichar2 *
-mono_unicode_from_external (const gchar *in, gsize *bytes)
+mono_unicode_from_external (const gchar *in, glong *bytes)
 {
 	gchar *res=NULL;
 	gchar **encodings;

--- a/mono/utils/strenc.h
+++ b/mono/utils/strenc.h
@@ -13,7 +13,7 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-extern MONO_API gunichar2 *mono_unicode_from_external (const gchar *in, gsize *bytes);
+extern MONO_API gunichar2 *mono_unicode_from_external (const gchar *in, glong *bytes);
 extern MONO_API gchar *mono_utf8_from_external (const gchar *in);
 extern MONO_API gchar *mono_unicode_to_external (const gunichar2 *uni);
 extern MONO_API gboolean mono_utf8_validate_and_len (const gchar *source, glong* oLength, const gchar** oEnd);


### PR DESCRIPTION
* In `mono_unicode_from_external`, the `bytes` pointer should be a `glong`.
* The `mono_unicode_from_external` function passes `bytes` to `g_utf8_to_utf16` and casts it as a `glong*`.
* On 64-bit builds, `sizeof(gsize) == 8` and `sizeof(glong) == 4`, so the high four bytes of the `bytes` value were not being set. * The only option for client code is to initialize the value passed to the `bytes` argument to a value of zero, which is not clearly necessary.
* Instead, let's change the type of the argument to `glong`, so that we pass something which won't end up with uninitialized data.

I'm planning to PR the Mono change upstream as well.


