### PR TITLE
Don't use the Apple TLS provider.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -172,11 +172,13 @@ namespace Mono.Net.Security
 					defaultProvider = btlsProvider;
 				}
 			
+#if !UNITY
 				if (Platform.IsMacOS) {
 					var appleProvider = "Mono.AppleTls.AppleTlsProvider";
 					providerRegistration.Add ("apple", appleProvider);
 					defaultProvider = appleProvider;
 				}
+#endif
 
 				if (defaultProvider == null)
 					defaultProvider = legacyProvider;


### PR DESCRIPTION
* This is not working on iOS with IL2CPP.
* For now, use the default TLS provider like Mono 4.8 (and Unity 2017.1) did.
* The Unity TLS provider work is in progress and should replace this.

Here is what the code shipping with Unity 2017.1 looks like: https://github.com/Unity-Technologies/mono/blob/unity-2017.1-mbe/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs#L159-L175

This fixes part of Unity case 938287.