### PR TITLE
Memory snapshot fixes

### DIFF
--- a/libgc/misc.c
+++ b/libgc/misc.c
@@ -1270,6 +1270,18 @@ void GC_foreach_heap_section(void* user_data, GC_heap_section_proc callback)
         ptr_t sectionStart = GC_heap_sects[i].hs_start;
         ptr_t sectionEnd = sectionStart + GC_heap_sects[i].hs_bytes;
 
+        /* Merge in contiguous sections. Copied from GC_dump_regions
+
+           A free block might start in one heap section and extend
+           into the next one. Merging the section avoids crashes when 
+           trying to copy the start of section that is a free block 
+           continued from the previous section. */
+        while (i+1 < GC_n_heap_sects && GC_heap_sects[i+1].hs_start == sectionEnd)
+        {
+            ++i;
+            sectionEnd = GC_heap_sects[i].hs_start + GC_heap_sects[i].hs_bytes;
+        }
+
         while (sectionStart < sectionEnd)
         {
             struct hblk* nextFreeBlock = GetNextFreeBlock(sectionStart);

--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -70,10 +70,17 @@ static void CollectAssemblyMetaData (MonoAssembly *assembly, void *user_data)
 		ContextInsertClass(context, klass);
 	}
 
-	g_hash_table_foreach(image->array_cache, CollectHashMapListClasses, user_data);
-	g_hash_table_foreach(image->szarray_cache, CollectHashMapClass, user_data);
-	g_hash_table_foreach(image->ptr_cache, CollectHashMapClass, user_data);
-	g_hash_table_foreach(image->generic_class_cache, CollectHashMapGenericClass, user_data);
+    if(image->array_cache)
+        g_hash_table_foreach(image->array_cache, CollectHashMapListClasses, user_data);
+
+    if(image->szarray_cache)
+        g_hash_table_foreach(image->szarray_cache, CollectHashMapClass, user_data);
+
+    if(image->ptr_cache)
+        g_hash_table_foreach(image->ptr_cache, CollectHashMapClass, user_data);
+
+    if(image->generic_class_cache)
+        g_hash_table_foreach(image->generic_class_cache, CollectHashMapGenericClass, user_data);
 }
 
 static int FindClassIndex(GHashTable* hashTable, MonoClass* klass)


### PR DESCRIPTION
Fix crash when trying to copy a start of a heap section that is a free block continued from the previous heap section
Fix cosmetic issue with messages being printed about hashmap being null