### PR TITLE
Unity 5.6 - Mono Backports

### DIFF
--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -569,7 +569,7 @@ dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned cha
 		size_t len2;
 		char *blob2 = NULL;
 
-		if (!method->klass->image->dynamic) {
+		if (!method->klass->image->dynamic && !method->dynamic) {
 			token = read32 (ip);
 			blob = mono_metadata_user_string (method->klass->image, mono_metadata_token_index (token));
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5686,6 +5686,12 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionType *type, Mon
 			mono_raise_exception (mono_get_exception_argument ("method", " Cannot bind to the target method because its signature differs from that of the delegate type"));
 	}
 
+	if (method->klass->is_generic)
+	{
+		mono_set_pending_exception(mono_get_exception_argument("method", " Cannot bind to the target method because the type is not inflated"));
+		return NULL;
+	}
+
 	delegate = mono_object_new (mono_object_domain (type), delegate_class);
 
 	if (method->dynamic) {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4504,7 +4504,10 @@ ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, EventRequ
 		if (frame->il_offset != -1) {
 			/* FIXME: Sort the table and use a binary search */
 			sp = find_seq_point (frame->domain, frame->method, frame->il_offset, &info);
-			if (!sp) return ERR_NOT_IMPLEMENTED; // This can happen with exceptions when stepping
+			if (!sp) {
+				ss_destroy (ss_req);
+				return ERR_NOT_IMPLEMENTED; // This can happen with exceptions when stepping
+			}
 			method = frame->method;
 		}
 	}

--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -2587,5 +2587,24 @@ class Tests {
 		catch {}
 		return (int)value;
 	}
+
+	class A {
+		public object AnObj;
+	}
+
+	public static void DoSomething (ref object o) {
+	}
+
+	public static int test_0_ldflda_null () {
+		A a = null;
+
+		try {
+			DoSomething (ref a.AnObj);
+		} catch (NullReferenceException) {
+			return 0;
+		}
+
+		return 1;
+	}
 }
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8382,9 +8382,12 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					sp [0] = ins;
 				}
 
-				MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg);
-
 				if (*ip == CEE_LDFLDA) {
+					if (sp[0]->type == STACK_OBJ) {
+						MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, sp[0]->dreg, 0);
+						MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+					}
+
 					dreg = alloc_preg (cfg);
 
 					EMIT_NEW_BIALU_IMM (cfg, ins, OP_PADD_IMM, dreg, sp [0]->dreg, foffset);
@@ -8393,6 +8396,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					*sp++ = ins;
 				} else {
 					MonoInst *load;
+
+					MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg);
 
 					EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, load, field->type, sp [0]->dreg, foffset);
 					load->flags |= ins_flag;


### PR DESCRIPTION
case 942459 - Fix crash when invalid IL code was encountered
case 918046 - Fix crash when Ldflda opcode is used and null check is missing
case 763091 - Fix crash if delegate is created on un-inflated generic type