### PR TITLE
[Dont Merge Yet] Revert "Remove the Mono build dependency on IL2CPP"

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -166,6 +166,7 @@ if ($android || $iphone || $iphoneCross || $iphoneSimulator || $tizen || $tizenE
 
 # Do any settings agnostic per-platform stuff
 my $externalBuildDeps = "";
+my $externalBuildDepsIl2Cpp = "$monoroot/../../il2cpp/build";
 
 if ($buildDeps ne "" && not $forceDefaultBuildDeps)
 {
@@ -289,6 +290,18 @@ if ($build)
 
 			# Only clean up if the dir exists.   Otherwise abs_path will return empty string
 			$externalBuildDeps = abs_path($externalBuildDeps) if (-d $externalBuildDeps);
+		}
+
+		if (!(-d "$externalBuildDepsIl2Cpp"))
+		{
+			my $il2cpp_repo = "https://bitbucket.org/Unity-Technologies/il2cpp";
+            print(">>> Cloning $il2cpp_repo at $externalBuildDepsIl2Cpp\n");
+            $checkoutResult = system("hg", "clone", $il2cpp_repo, "$externalBuildDepsIl2Cpp");
+
+            if ($checkoutOnTheFly && $checkoutResult ne 0)
+            {
+                die("failed to checkout IL2CPP for the mono build dependencies\n");
+            }
 		}
 
 		if (-d "$existingExternalMono")

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -65,6 +65,7 @@ print(">>> Build Scripts Revision = $buildScriptsRevision\n");
 
 # Do any settings agnostic per-platform stuff
 my $externalBuildDeps = "";
+my $externalBuildDepsIl2Cpp = "$monoroot/../../il2cpp/build";
 
 if ($buildDeps ne "" && not $forceDefaultBuildDeps)
 {
@@ -110,6 +111,18 @@ if ($build)
 				die("failed to checkout mono build dependencies\n");
 			}
 		}
+
+        if (!(-d "$externalBuildDepsIl2Cpp"))
+        {
+            my $il2cpp_repo = "https://bitbucket.org/Unity-Technologies/il2cpp";
+            print(">>> Cloning $il2cpp_repo at $externalBuildDepsIl2Cpp\n");
+            $checkoutResult = system("hg", "clone", $il2cpp_repo, "$externalBuildDepsIl2Cpp");
+
+            if ($checkoutOnTheFly && $checkoutResult ne 0)
+            {
+                die("failed to checkout IL2CPP for the mono build dependencies\n");
+            }
+        }
 
 		if (-d "$existingExternalMono")
 		{

--- a/external/buildscripts/build_win_wrapper.pl
+++ b/external/buildscripts/build_win_wrapper.pl
@@ -66,6 +66,7 @@ GetOptions(
 );
 
 my $externalBuildDeps = "";
+my $externalBuildDepsIl2Cpp = "$monoroot/../../il2cpp/build";
 
 if ($buildDeps ne "")
 {
@@ -96,6 +97,18 @@ else
 			die("failed to checkout mono build dependencies\n");
 		}
 	}
+
+    if (!(-d "$externalBuildDepsIl2Cpp"))
+    {
+        my $il2cpp_repo = "https://bitbucket.org/Unity-Technologies/il2cpp";
+        print(">>> Cloning $il2cpp_repo at $externalBuildDepsIl2Cpp\n");
+        $checkoutResult = system("hg", "clone", $il2cpp_repo, "$externalBuildDepsIl2Cpp");
+
+        if ($checkoutOnTheFly && $checkoutResult ne 0)
+        {
+            die("failed to checkout IL2CPP for the mono build dependencies\n");
+        }
+    }
 }
 
 print(">>> externalBuildDeps = $externalBuildDeps\n");


### PR DESCRIPTION
This reverts commit 5c2be733b4509bda35b9323054d5f6c5812f2278.

We need the dependency on il2cpp for sharing the PAL layer

Will merge after katana config is updated