### PR TITLE
Handle the empty file inode on macOS and FAT32

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -2107,6 +2107,22 @@ static mode_t convert_perms(guint32 sharemode)
 }
 #endif
 
+static gboolean already_shared(gboolean file_alread_shared, ino_t inode)
+{
+#if PLATFORM_MACOSX
+	/* On macOS and FAT32 partitions, we will sometimes get this inode value
+	 * for more than one file. It means the file is empty (FILENO_EMPTY is
+	 * defined in an internal header).  When this happens, the hash table of
+	 * file shares becomes corrupt, since more then one file has the same
+	 * inode. Instead, let's assume it is always fine to share empty files.
+	 * (Unity case 950616).
+	 */
+	return file_alread_shared && inode != 999999999;
+#else
+	return file_alread_shared;
+#endif
+}
+
 static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 				   guint32 fileaccess,
 				   FileShare **share_info)
@@ -2116,7 +2132,7 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 
 	file_already_shared = file_share_get (statbuf->st_dev, statbuf->st_ino, sharemode, fileaccess, &file_existing_share, &file_existing_access, share_info);
 	
-	if (file_already_shared) {
+	if (already_shared (file_already_shared, statbuf->st_ino)) {
 		/* The reference to this share info was incremented
 		 * when we looked it up, so be careful to put it back
 		 * if we conclude we can't use this file.


### PR DESCRIPTION
On macOS and FAT32 partitions, we will sometimes get this inode value
for more than one file. It means the file is empty.  When this happens,
the hash table of file shares becomes corrupt, since more than one file
has the same inode. Instead, let's assume it is always fine to share
empty files. (Unity case 950616).

Release notes: Prevent a sharing violation when the UnityLinker writes files on a FAT32 partition on macOS.