### PR TITLE
PMIP My Callstack Support

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -540,7 +540,9 @@ common_sources = \
 	llvm-runtime.h	\
 	type-checking.c \
 	lldb.h			\
-	lldb.c
+	lldb.c			\
+	pmip_my_callstack.h	\
+	pmip_my_callstack.c
 
 test_sources = 			\
 	basic-calls.cs 		\

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -81,6 +81,7 @@
 #include "mini-llvm.h"
 #include "debugger-agent.h"
 #include "lldb.h"
+#include "pmip_my_callstack.h"
 
 #ifdef MONO_ARCH_LLVM_SUPPORTED
 #ifdef ENABLE_LLVM
@@ -578,6 +579,7 @@ mono_tramp_info_register (MonoTrampInfo *info, MonoDomain *domain)
 
 	mono_save_trampoline_xdebug_info (info);
 	mono_lldb_save_trampoline_info (info);
+	mono_pmip_my_callstack_save_trampoline_info (info);
 
 #ifdef MONO_ARCH_HAVE_UNWIND_TABLE
 	mono_arch_unwindinfo_install_tramp_unwind_info (info->unwind_ops, info->code, info->code_size);
@@ -3698,6 +3700,10 @@ mini_init (const char *filename, const char *runtime_version)
 
 	if (mini_get_debug_options ()->lldb || g_hasenv ("MONO_LLDB")) {
 		mono_lldb_init ("");
+		mono_dont_free_domains = TRUE;
+	}
+	if (g_hasenv ("MONO_PMIP")) {
+		mono_pmip_my_callstack_init ("");
 		mono_dont_free_domains = TRUE;
 	}
 

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -19,6 +19,7 @@
 
 #include "mini.h"
 #include "lldb.h"
+#include "pmip_my_callstack.h"
 
 /*
  * Address of the trampoline code.  This is used by the debugger to check
@@ -1445,6 +1446,7 @@ mono_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_type, M
 	else
 		code = mono_arch_create_specific_trampoline (arg1, tramp_type, domain, &len);
 	mono_lldb_save_specific_trampoline_info (arg1, tramp_type, domain, code, len);
+	mono_pmip_my_callstack_save_specific_trampoline_info (arg1, tramp_type, domain, code, len);
 	if (code_len)
 		*code_len = len;
 	return code;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -77,6 +77,7 @@
 #include "llvm-runtime.h"
 #include "mini-llvm.h"
 #include "lldb.h"
+#include "pmip_my_callstack.h"
 
 MonoTraceSpec *mono_jit_trace_calls;
 MonoMethodDesc *mono_inject_async_exc_method;
@@ -3890,6 +3891,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	if (!cfg->compile_aot) {
 		mono_save_xdebug_info (cfg);
 		mono_lldb_save_method_info (cfg);
+		mono_pmip_my_callstack_save_method_info (cfg);
 	}
 
 	if (cfg->verbose_level >= 2) {

--- a/mono/mini/pmip_my_callstack.c
+++ b/mono/mini/pmip_my_callstack.c
@@ -36,7 +36,7 @@ pmip_pretty(MonoMethod* method)
 	return formattedPMIP;
 }
 
-#if !defined(DISABLE_JIT)
+#if !defined(DISABLE_JIT) && defined(HOST_WIN32)
 
 static gboolean enabled;
 static mono_mutex_t mutex;

--- a/mono/mini/pmip_my_callstack.c
+++ b/mono/mini/pmip_my_callstack.c
@@ -108,7 +108,7 @@ mono_pmip_my_callstack_save_specific_trampoline_info (gpointer arg1, MonoTrampol
 void
 mono_pmip_my_callstack_init (const char *options)
 {
-	g_error ("pmip support is only available with the jit enabled");
+	g_error ("Only Available On Windows With Jit Enabled");
 }
 
 void

--- a/mono/mini/pmip_my_callstack.c
+++ b/mono/mini/pmip_my_callstack.c
@@ -1,0 +1,134 @@
+#include "pmip_my_callstack.h"
+#include "mono/metadata/mono-debug.h"
+
+static char *
+pmip_pretty(MonoMethod* method)
+{
+	char *lineNumber;
+	char* filePath;
+	char* methodName;
+	char* assemblyName;
+	char* formattedPMIP;
+	MonoDebugSourceLocation* debugSourceLocation;
+	MonoDebugMethodInfo* debugMethodInfo;
+	MonoDomain *domain;
+
+	domain = mono_domain_get();
+	if (!domain)
+		domain = mono_get_root_domain();
+
+	methodName = mono_method_full_name(method, TRUE);
+
+	debugSourceLocation = mono_debug_lookup_source_location(method, 0, domain);
+	debugMethodInfo = mono_debug_lookup_method(method);
+
+	assemblyName = method->klass->image->module_name;
+	lineNumber = debugSourceLocation ? g_strdup_printf("%d", debugSourceLocation->row) : g_strdup("<UNKNOWN>");
+	filePath = debugSourceLocation ? g_strdup(debugSourceLocation->source_file) : g_strdup("<UNKNOWN>");
+
+	formattedPMIP = g_strdup_printf("[%s] %s Line %s File %s", assemblyName, methodName, lineNumber, filePath);
+
+	mono_debug_free_source_location(debugSourceLocation);
+	g_free(methodName);
+	g_free(lineNumber);
+	g_free(filePath);
+
+	return formattedPMIP;
+}
+
+#if !defined(DISABLE_JIT)
+
+static gboolean enabled;
+static mono_mutex_t mutex;
+static FILE* fd;
+
+#define pmip_my_callstack_lock() mono_os_mutex_lock (&mutex)
+#define pmip_my_callstack_unlock() mono_os_mutex_unlock (&mutex)
+
+void
+mono_pmip_my_callstack_init (const char *options)
+{
+	char* file_name = g_strdup_printf("pmip.%d", GetCurrentProcessId());
+	char* path = g_build_filename(g_get_tmp_dir(), file_name, NULL);
+
+	mono_os_mutex_init_recursive(&mutex);
+
+	fd = _fsopen(path, "w", _SH_DENYNO);
+
+	g_free(file_name);
+	g_free(path);
+
+	if (fd)
+		enabled = TRUE;
+}
+
+void
+mono_pmip_my_callstack_save_method_info (MonoCompile *cfg)
+{
+	char* pretty_name;
+
+	if (!enabled)
+		return;
+
+	pretty_name = pmip_pretty(cfg->method);
+
+	pmip_my_callstack_lock ();
+	fprintf(fd, "%p;%p;%s\n", cfg->native_code, ((char*)cfg->native_code) + cfg->code_size, pretty_name);
+	fflush (fd);
+	pmip_my_callstack_unlock ();
+
+	g_free(pretty_name);
+}
+
+void
+mono_pmip_my_callstack_remove_method (MonoDomain *domain, MonoMethod *method, MonoJitDynamicMethodInfo *info)
+{
+}
+
+void
+mono_pmip_my_callstack_save_trampoline_info (MonoTrampInfo *info)
+{
+	if (!enabled)
+		return;
+
+	pmip_my_callstack_lock ();
+	fprintf (fd, "%p;%p;%s\n", info->code, ((char*)info->code) + info->code_size, info->name ? info->name : "");
+	fflush (fd);
+	pmip_my_callstack_unlock ();
+}
+
+void
+mono_pmip_my_callstack_save_specific_trampoline_info (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, gpointer code, guint32 code_len)
+{
+
+}
+
+#else
+
+void
+mono_pmip_my_callstack_init (const char *options)
+{
+	g_error ("pmip support is only available with the jit enabled");
+}
+
+void
+mono_pmip_my_callstack_save_method_info (MonoCompile *cfg)
+{
+}
+
+void
+mono_pmip_my_callstack_save_trampoline_info (MonoTrampInfo *info)
+{
+}
+
+void
+mono_pmip_my_callstack_remove_method (MonoDomain *domain, MonoMethod *method, MonoJitDynamicMethodInfo *info)
+{
+}
+
+void
+mono_pmip_my_callstack_save_specific_trampoline_info (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, gpointer code, guint32 code_len)
+{
+}
+
+#endif

--- a/mono/mini/pmip_my_callstack.h
+++ b/mono/mini/pmip_my_callstack.h
@@ -1,0 +1,17 @@
+#ifndef __MONO_PMIP_MY_CALLSTACK_H__
+#define __MONO_PMIP_MY_CALLSTACK_H__
+
+#include "config.h"
+#include "mini.h"
+
+void mono_pmip_my_callstack_init (const char *options);
+
+void mono_pmip_my_callstack_save_method_info (MonoCompile *cfg);
+
+void mono_pmip_my_callstack_save_trampoline_info (MonoTrampInfo *info);
+
+void mono_pmip_my_callstack_remove_method (MonoDomain *domain, MonoMethod *method, MonoJitDynamicMethodInfo *info);
+
+void mono_pmip_my_callstack_save_specific_trampoline_info (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, gpointer code, guint32 code_len);
+
+#endif

--- a/msvc/libmono-static.vcxproj
+++ b/msvc/libmono-static.vcxproj
@@ -67,6 +67,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="..\mono\mini\mini.h" />
+    <ClInclude Include="..\mono\mini\pmip_my_callstack.h" />
     <ClInclude Include="..\mono\mini\seq-points.h" />
     <ClInclude Include="..\mono\mini\version.h" />
     <ClInclude Include="..\mono\mini\optflags-def.h" />
@@ -74,6 +75,7 @@
     <ClCompile Include="..\mono\mini\cfgdump.c" />
     <ClInclude Include="..\mono\mini\jit-icalls.h " />
     <ClCompile Include="..\mono\mini\jit-icalls.c " />
+    <ClCompile Include="..\mono\mini\pmip_my_callstack.c" />
     <ClCompile Include="..\mono\mini\seq-points.c" />
     <ClCompile Include="..\mono\mini\trace.c" />
     <ClInclude Include="..\mono\mini\trace.h" />

--- a/msvc/libmono-static.vcxproj.filters
+++ b/msvc/libmono-static.vcxproj.filters
@@ -237,6 +237,9 @@
     <ClInclude Include="..\mono\mini\mini-windows.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\mono\mini\pmip_my_callstack.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">


### PR DESCRIPTION
Support for PmipMyCallstack visual studio plugin

When environment MONO_PMIP is set, we write jit information to a file. This file is then read by the visual studio plugin and used to display stacktrace information