### PR TITLE
Fixed extremly slow flow analysis in mcs for goto heavy code, fixed duplicate unreferenced label warning

### DIFF
--- a/mcs/errors/cs0164-2.cs
+++ b/mcs/errors/cs0164-2.cs
@@ -1,0 +1,17 @@
+// CS0164: This label has not been referenced
+// Line: 13
+// Compiler options: -warnaserror -warn:2
+
+class X {
+	static void Main () {
+	}
+
+	static void foo (bool b, out int c) {
+		if (b) {
+			goto LabelA;
+		}
+		LabelA: LabelB:
+			c = 0;	// Out parameter necessary to force reevaluation of LabelA
+			return;
+	}
+}

--- a/mcs/mcs/flowanalysis.cs
+++ b/mcs/mcs/flowanalysis.cs
@@ -678,7 +678,7 @@ namespace Mono.CSharp
 				large_bits[index >> 5] |= (1 << (index & 31));
 		}
 
-		static bool IsEqual (DefiniteAssignmentBitSet a, DefiniteAssignmentBitSet b)
+		public static bool IsEqual (DefiniteAssignmentBitSet a, DefiniteAssignmentBitSet b)
 		{
 			if (a.large_bits == null)
 				return (a.bits & ~copy_on_write_flag) == (b.bits & ~copy_on_write_flag);

--- a/mcs/mcs/statement.cs
+++ b/mcs/mcs/statement.cs
@@ -271,10 +271,13 @@ namespace Mono.CSharp {
 
 			fc.BranchDefiniteAssignment (fc.DefiniteAssignmentOnTrue);
 			var labels = fc.CopyLabelStack ();
+			var assigmentBefore = new DefiniteAssignmentBitSet(fc.DefiniteAssignment);
 
 			var res = TrueStatement.FlowAnalysis (fc);
 
-			fc.SetLabelStack (labels);
+			// If walking through new labels didn't change the assignment we don't need to flush the labels.
+			if (!DefiniteAssignmentBitSet.IsEqual(fc.DefiniteAssignment, assigmentBefore))
+				fc.SetLabelStack (labels);
 
 			if (FalseStatement == null) {
 
@@ -294,7 +297,11 @@ namespace Mono.CSharp {
 				fc.DefiniteAssignment = da_false;
 
 				res = FalseStatement.FlowAnalysis (fc);
-				fc.SetLabelStack (labels);
+
+				// If walking through new labels didn't change the assignment we don't need to flush the labels.
+				if (!DefiniteAssignmentBitSet.IsEqual(fc.DefiniteAssignment, assigmentBefore))
+					fc.SetLabelStack (labels);
+
 				return res;
 			}
 
@@ -304,7 +311,9 @@ namespace Mono.CSharp {
 
 			res &= FalseStatement.FlowAnalysis (fc);
 
-			fc.SetLabelStack (labels);
+			// If walking through new labels didn't change the assignment we don't need to flush the labels.
+			if (!DefiniteAssignmentBitSet.IsEqual(fc.DefiniteAssignment, assigmentBefore))
+				fc.SetLabelStack (labels);
 
 			if (!TrueStatement.IsUnreachable) {
 				if (false_returns || FalseStatement.IsUnreachable)

--- a/mcs/mcs/statement.cs
+++ b/mcs/mcs/statement.cs
@@ -1499,6 +1499,7 @@ namespace Mono.CSharp {
 		string name;
 		bool defined;
 		bool referenced;
+		bool reportedNotReferenced;
 		Label label;
 		Block block;
 		
@@ -1549,7 +1550,8 @@ namespace Mono.CSharp {
 
 		protected override bool DoFlowAnalysis (FlowAnalysisContext fc)
 		{
-			if (!referenced) {
+			if (!referenced && !reportedNotReferenced) {
+				reportedNotReferenced = true;
 				fc.Report.Warning (164, 2, loc, "This label has not been referenced");
 			}
 


### PR DESCRIPTION
Resetting of goto label stack for flow analysis during condition if-statement is now only done if assignment bits have changed.
Before, we always reset the goto label-stack which means that goto-jumps in different branches of an if-statement need to be completely reevaluated. When compiling some suboptimal files, this unnecessary reparsing can lead to a massive performance hit - compilation in unity case #948492 took several hours.
It would be nice to have a test for this, but I haven't seen any tests in mcs that check performance. Also, this might require checking in a massive file and I have not entirely figured out the exact code structure necessary to hit such seemingly exponentially growing flow analysis times.

Also, I fixed a warning for unreferenced goto label which, with the fix above, is rather rare now. I added a test that demonstrates a case where we would have gotten the warning twice even after less aggressive label-stack flushing.


I successfully ran all tests in `mcs/error` and `mcs/tests` on a Mac with my fixes.

**Release Notes:**
Mono: Fixed compiler getting stuck in complex, goto heavy code. Fixed repeated warning for unused labels.