### PR TITLE
Unity 2017 02 staging disable com

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -852,6 +852,7 @@ with_unityaot_default=no
 
 with_bitcode_default=no
 with_cooperative_gc_default=no
+mono_feature_disable_com=yes
 
 INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=8000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4000
 

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -253,6 +253,7 @@ if ($build)
 	push @configureparams, "--disable-btls";  #this removes the dependency on cmake to build btls for now
 	push @configureparams, "--with-mcs-docs=no";
 	push @configureparams, "--prefix=$monoprefix";
+	push @configureparams, "--mono_feature_disable_com=yes";
 
 	if(!($disableMcs))
 	{

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -253,7 +253,6 @@ if ($build)
 	push @configureparams, "--disable-btls";  #this removes the dependency on cmake to build btls for now
 	push @configureparams, "--with-mcs-docs=no";
 	push @configureparams, "--prefix=$monoprefix";
-	push @configureparams, "--mono_feature_disable_com=yes";
 
 	if(!($disableMcs))
 	{

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -7831,7 +7831,8 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 #ifndef DISABLE_COM
 		return mono_cominterop_get_native_wrapper (method);
 #else
-		g_assert_not_reached ();
+		//In the case COM is disabled, returning the method will trigger a MissingMethodException
+		return method;
 #endif
 	}
 

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -120,7 +120,7 @@
     <ClCompile>
       <DllExportPreprocessorDefinitions>MONO_DLL_EXPORT</DllExportPreprocessorDefinitions>
       <DllImportPreprocessorDefinitions>MONO_DLL_IMPORT</DllImportPreprocessorDefinitions>
-      <PreprocessorDefinitions>__default_codegen__;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;$(MONO_GC_DEFINES);WIN32_THREADS;WINVER=0x0600;_WIN32_WINNT=0x0600;_WIN32_IE=0x0501;_UNICODE;UNICODE;FD_SETSIZE=1024;%(PreprocessorDefinitions);</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__default_codegen__;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;$(MONO_GC_DEFINES);WIN32_THREADS;WINVER=0x0600;_WIN32_WINNT=0x0600;_WIN32_IE=0x0501;_UNICODE;UNICODE;FD_SETSIZE=1024;%(PreprocessorDefinitions);DISABLE_COM;</PreprocessorDefinitions>
       <DisableSpecificWarnings>4273;4005</DisableSpecificWarnings>
       <RuntimeLibrary>$(MONO_C_RUNTIME)</RuntimeLibrary>
     </ClCompile>


### PR DESCRIPTION
- Disable's COM on all profiles including JIT
- Returns method instead of asserting (like AOT path) to result in MissingMethodException instead of crashing the editor