### PR TITLE
Mono Fixes for 2017.2

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -419,6 +419,15 @@ typedef union {
 		x86_regp_emit ((inst), (reg) & 0x7, (regp) & 0x7);	\
 	} while (0)
 
+#define amd64_movdqu_reg_membase(inst,reg,basereg,disp)	\
+	do {	\
+		*(inst)++ = (unsigned char)0xf3;	\
+		amd64_emit_rex(inst, 0, (reg), 0, (basereg)); \
+		*(inst)++ = (unsigned char)0x0f;	\
+		*(inst)++ = (unsigned char)0x6f;	\
+		x86_membase_emit ((inst), (reg) & 0x7, (basereg) & 0x7, (disp));	\
+	} while (0)
+
 #define amd64_movsd_reg_membase(inst,reg,basereg,disp)	\
 	do {	\
 		*(inst)++ = (unsigned char)0xf2;	\
@@ -434,6 +443,15 @@ typedef union {
 		amd64_emit_rex(inst, 0, (reg), 0, (basereg)); \
 		*(inst)++ = (unsigned char)0x0f;	\
 		*(inst)++ = (unsigned char)0x10;	\
+		x86_membase_emit ((inst), (reg) & 0x7, (basereg) & 0x7, (disp));	\
+	} while (0)
+
+#define amd64_movdqu_membase_reg(inst,basereg,disp,reg)	\
+	do {	\
+		*(inst)++ = (unsigned char)0xf3;	\
+		amd64_emit_rex(inst, 0, (reg), 0, (basereg)); \
+		*(inst)++ = (unsigned char)0x0f;	\
+		*(inst)++ = (unsigned char)0x7f;	\
 		x86_membase_emit ((inst), (reg) & 0x7, (basereg) & 0x7, (disp));	\
 	} while (0)
 

--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -1706,7 +1706,10 @@ gpointer OpenProcess (guint32 req_access G_GNUC_UNUSED, gboolean inherit G_GNUC_
 				      GUINT_TO_POINTER (pid), NULL, TRUE);
 	if (handle == 0) {
 #if defined(__OpenBSD__) || defined(PLATFORM_MACOSX)
-		if ((kill(pid, 0) == 0) || (errno == EPERM)) {
+		/* pid == 0 and pid == -1 have special meaning for kill()
+		 * so they should not be treated as valid process ids 
+		 */
+		if (pid > 0 && ((kill(pid, 0) == 0) || (errno == EPERM))) {
 #else
 		gchar *dir = g_strdup_printf ("/proc/%d", pid);
 		if (!access (dir, F_OK)) {

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -569,7 +569,7 @@ dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned cha
 		size_t len2;
 		char *blob2 = NULL;
 
-		if (!method->klass->image->dynamic) {
+		if (!method->klass->image->dynamic && !method->dynamic) {
 			token = read32 (ip);
 			blob = mono_metadata_user_string (method->klass->image, mono_metadata_token_index (token));
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5686,6 +5686,12 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionType *type, Mon
 			mono_raise_exception (mono_get_exception_argument ("method", " Cannot bind to the target method because its signature differs from that of the delegate type"));
 	}
 
+	if (method->klass->is_generic)
+	{
+		mono_set_pending_exception(mono_get_exception_argument("method", " Cannot bind to the target method because the type is not inflated"));
+		return NULL;
+	}
+
 	delegate = mono_object_new (mono_object_domain (type), delegate_class);
 
 	if (method->dynamic) {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4504,7 +4504,10 @@ ss_create (MonoInternalThread *thread, StepSize size, StepDepth depth, EventRequ
 		if (frame->il_offset != -1) {
 			/* FIXME: Sort the table and use a binary search */
 			sp = find_seq_point (frame->domain, frame->method, frame->il_offset, &info);
-			if (!sp) return ERR_NOT_IMPLEMENTED; // This can happen with exceptions when stepping
+			if (!sp) {
+				ss_destroy (ss_req);
+				return ERR_NOT_IMPLEMENTED; // This can happen with exceptions when stepping
+			}
 			method = frame->method;
 		}
 	}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5502,6 +5502,8 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		resume_vm ();
 		break;
 	case CMD_VM_DISPOSE:
+		suspend_vm ();
+		wait_for_suspend ();
 		/* Clear all event requests */
 		mono_loader_lock ();
 		while (event_requests->len > 0) {

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -417,10 +417,10 @@ mono_arch_create_trampoline_code_full (MonoTrampolineType tramp_type, guint32 *c
 			g_assert (r11_save_code == after_r11_save_code);
 		}
 	}
-	offset += 8 * 8;
+	offset += 8 * 16;
 	saved_fpregs_offset = - offset;
 	for (i = 0; i < 8; ++i)
-		amd64_movsd_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * 8), i);
+		amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * 16), i);
 
 	if (tramp_type != MONO_TRAMPOLINE_GENERIC_CLASS_INIT &&
 			tramp_type != MONO_TRAMPOLINE_MONITOR_ENTER &&
@@ -573,7 +573,7 @@ mono_arch_create_trampoline_code_full (MonoTrampolineType tramp_type, guint32 *c
 			amd64_mov_reg_membase (code, i, AMD64_RBP, saved_regs_offset + (i * 8), 8);
 
 	for (i = 0; i < 8; ++i)
-		amd64_movsd_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * 8));
+		amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * 16));
 
 	/* Restore stack */
 	amd64_leave (code);


### PR DESCRIPTION
case 763091 - Fix crash if delegate is created on un-inflated generic type
case 951901 - Fix crash in debugger when trying to stop while a single step operation is in progress
case 952069 - Save/resume entire 128-bits of xmm argument registers
case 949127 - Fix alignment of 64-bit types on iOS