### PR TITLE
Mono Fixes for 5.6

### DIFF
--- a/mono/io-layer/processes.c
+++ b/mono/io-layer/processes.c
@@ -1706,7 +1706,10 @@ gpointer OpenProcess (guint32 req_access G_GNUC_UNUSED, gboolean inherit G_GNUC_
 				      GUINT_TO_POINTER (pid), NULL, TRUE);
 	if (handle == 0) {
 #if defined(__OpenBSD__) || defined(PLATFORM_MACOSX)
-		if ((kill(pid, 0) == 0) || (errno == EPERM)) {
+		/* pid == 0 and pid == -1 have special meaning for kill()
+		 * so they should not be treated as valid process ids 
+		 */
+		if (pid > 0 && ((kill(pid, 0) == 0) || (errno == EPERM))) {
 #else
 		gchar *dir = g_strdup_printf ("/proc/%d", pid);
 		if (!access (dir, F_OK)) {

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3849,6 +3849,11 @@ mono_backtrace (int limit)
 #define __alignof__(type) G_STRUCT_OFFSET(struct { char c; type x; }, x)
 #endif
 
+/* __alignof__ returns the preferred alignment of values not the actual alignment used by
+    the compiler so is wrong e.g. for iOS where doubles are aligned on a 4 byte boundary
+    but __alignof__ returns 8. Using G_STRUCT_OFFSET works better */
+#define ALIGNMENT_OF(type) G_STRUCT_OFFSET(struct { char c; type x; }, x)
+
 /*
  * mono_type_size:
  * @t: the type to return the size of
@@ -3896,14 +3901,14 @@ mono_type_size (MonoType *t, int *align)
 #if defined(PLATFORM_IPHONE_XCOMP)
 		*align = 4;
 #else
-		*align = __alignof__(gint64);
+        *align = ALIGNMENT_OF(gint64);
 #endif
 		return 8;		
 	case MONO_TYPE_R8:
 #if defined(PLATFORM_IPHONE_XCOMP)
 		*align = 4;
 #else
-		*align = __alignof__(double);
+        *align = ALIGNMENT_OF(double);
 #endif
 		return 8;		
 	case MONO_TYPE_I:

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5502,6 +5502,8 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		resume_vm ();
 		break;
 	case CMD_VM_DISPOSE:
+		suspend_vm ();
+		wait_for_suspend ();
 		/* Clear all event requests */
 		mono_loader_lock ();
 		while (event_requests->len > 0) {


### PR DESCRIPTION
case 951901 - Fix crash in debugger when trying to stop while a single step operation is in progress
case 949127 - Fix alignment of 64-bit types on iOS