### PR TITLE
MonoBleedingEdge fixes for 2017.1

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -437,6 +437,10 @@ boehm_thread_detach (MonoThreadInfo *info)
 	 * does not hold any locks while unregister does.
 	 */
 	mono_handle_stack_free (info->handle_stack);
+
+#if HAVE_BDWGC_GC
+	GC_unregister_my_thread ();
+#endif
 }
 
 static void
@@ -448,10 +452,6 @@ boehm_thread_unregister (MonoThreadInfo *p)
 
 	if (p->runtime_thread)
 		mono_threads_add_joinable_thread ((gpointer)tid);
-
-#if HAVE_BDWGC_GC
-	GC_unregister_my_thread ();
-#endif
 }
 
 gboolean

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7255,6 +7255,8 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		clear_suspended_objs ();
 		break;
 	case CMD_VM_DISPOSE:
+		suspend_vm ();
+		wait_for_suspend ();
 		/* Clear all event requests */
 		mono_loader_lock ();
 		while (event_requests->len > 0) {


### PR DESCRIPTION
case 958346 - Fix hang on exit
case 951901 - Fix crash in debugger when trying to stop while a single step operation is in progress