### PR TITLE
Implement the assembly object command for IL2CPP

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8782,6 +8782,14 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 static ErrorCode
 get_assembly_object_command (MonoDomain *domain, MonoAssembly *ass, Buffer *buf, MonoError *error)
 {
+#ifdef IL2CPP_MONO_DEBUGGER
+	MonoReflectionAssemblyHandle o = il2cpp_mono_assembly_get_object_handle(domain, ass, error);
+	if (o == NULL) {
+		return ERR_INVALID_OBJECT;
+	}
+	buffer_add_objid(buf, (MonoObject*)o);
+	return ERR_NONE;
+#else
 	HANDLE_FUNCTION_ENTER();
 	ErrorCode err = ERR_NONE;
 	mono_error_init (error);
@@ -8793,6 +8801,7 @@ get_assembly_object_command (MonoDomain *domain, MonoAssembly *ass, Buffer *buf,
 	buffer_add_objid (buf, MONO_HANDLE_RAW (MONO_HANDLE_CAST (MonoObject, o)));
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (err);
+#endif
 }
 
 

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -14,6 +14,7 @@
 #include "vm/Method.h"
 #include "vm/Object.h"
 #include "vm/Profiler.h"
+#include "vm/Reflection.h"
 #include "vm/Runtime.h"
 #include "vm/String.h"
 #include "vm/Thread.h"
@@ -866,8 +867,7 @@ Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_field_checked(Il2CppMono
 
 Il2CppMonoReflectionAssemblyHandle il2cpp_mono_assembly_get_object_handle(Il2CppMonoDomain* domain, Il2CppMonoAssembly* assembly, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return 0;
+	return (Il2CppMonoReflectionAssemblyHandle)il2cpp::vm::Reflection::GetAssemblyObject((const Il2CppAssembly *)assembly);
 }
 
 Il2CppMonoReflectionType* il2cpp_mono_type_get_object_checked(Il2CppMonoDomain* domain, Il2CppMonoType* type, MonoError* error)


### PR DESCRIPTION
VSTU uses this event, so we need to implement it to move forward with VSTU support.