### PR TITLE
Allow VSTU to attach to the IL2CPP debugger

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10118,8 +10118,8 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 #endif // !IL2CPP_MONO_DEBUGGER
 		break;
 	}
-	case CMD_METHOD_GET_INFO:
-		int32_t iflags;
+	case CMD_METHOD_GET_INFO: {
+		int iflags;
 		buffer_add_int (buf, mono_method_get_flags(method, &iflags));
 		buffer_add_int (buf, iflags);
 		buffer_add_int (buf, mono_method_get_token(method));
@@ -10127,8 +10127,8 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		gboolean is_inflated = FALSE;
 		if (CHECK_PROTOCOL_VERSION (2, 12)) {
 			guint8 attrs = 0;
-			is_generic = mono_method_is_generic(method);
-			is_inflated = mono_method_is_inflated(method);
+			is_generic = VM_METHOD_IS_GENERIC(method);
+			is_inflated = VM_METHOD_IS_INFLATED(method);
 			if (is_generic)
 				attrs |= (1 << 0);
 			if (mono_method_signature (method)->generic_param_count)
@@ -10192,6 +10192,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 			}
 		}
 		break;
+	}
 	case CMD_METHOD_GET_BODY: {
 		MonoError error;
 		int i;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9364,7 +9364,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 				MonoGenericContainer *container = mono_class_get_generic_container (klass);
 				MonoClass *pklass;
 
-				count = container->type_argc;
+				count = VM_GENERIC_CONTAINER_GET_TYPE_ARGC(container);
 				buffer_add_int (buf, count);
 				for (i = 0; i < count; i++) {
 					pklass = mono_class_from_generic_parameter_internal (mono_generic_container_get_param (container, i));

--- a/mono/mini/il2cpp-c-types.h
+++ b/mono/mini/il2cpp-c-types.h
@@ -391,11 +391,13 @@ typedef gboolean (*Il2CppMonoJitStackWalk) (Il2CppMonoStackFrameInfo *frame, Mon
 typedef void (*Il2CppMonoDomainFunc) (Il2CppMonoDomain *domain, void* user_data);
 
 typedef void (*emit_assembly_load_callback)(void*, void*);
+typedef void(*emit_type_load_callback)(void*, void*, void*);
 
 void il2cpp_set_thread_state_background(Il2CppMonoThread* thread);
 void* il2cpp_domain_get_agent_info(Il2CppMonoAppDomain* domain);
 void il2cpp_domain_set_agent_info(Il2CppMonoAppDomain* domain, void* agentInfo);
 void il2cpp_send_assemblies_for_domain (Il2CppMonoAppDomain *domain, void *user_data, emit_assembly_load_callback callback);
+void il2cpp_send_types_for_domain(Il2CppMonoAppDomain *domain, emit_type_load_callback callback);
 void il2cpp_start_debugger_thread();
 uintptr_t il2cpp_get_thread_id(Il2CppMonoThread* thread);
 void* il2cpp_gc_alloc_fixed(size_t size);

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -21,15 +21,6 @@
 #define VM_ASSEMBLY_FREE_NAME(name) g_free(name)
 #define VM_ASSEMBLY_IS_DYNAMIC(assembly) FALSE
 #define VM_ASSEMBLY_GET_IMAGE(assembly) il2cpp_mono_assembly_get_image(assembly)
-#define VM_ASSEMBLY_NAME_GET_NAME(assembly) il2cpp_assembly_name_name(assembly)
-#define VM_ASSEMBLY_NAME_GET_MAJOR(assembly) il2cpp_assembly_name_major(assembly)
-#define VM_ASSEMBLY_NAME_GET_MINOR(assembly) il2cpp_assembly_name_minor(assembly)
-#define VM_ASSEMBLY_NAME_GET_BUILD(assembly) il2cpp_assembly_name_build(assembly)
-#define VM_ASSEMBLY_NAME_GET_REVISION(assembly) il2cpp_assembly_name_revision(assembly)
-#define VM_ASSEMBLY_NAME_GET_CULTURE(assembly) il2cpp_assembly_name_culture(assembly)
-#define VM_ASSEMBLY_NAME_GET_PUBLIC_KEY_TOKEN(assembly, i) il2cpp_assembly_name_public_key_token(assembly, i)
-#define VM_ASSEMBLY_NAME_GET_PUBLIC_KEY_TOKEN_STRING(assembly) il2cpp_assembly_name_public_key_token_string(assembly)
-#define VM_ASSEMBLY_NAME_GET_FLAGS(assembly) il2cpp_assembly_name_flags(assembly)
 #define VM_CLASS_GET_TYPE(klass) il2cpp_class_get_type(klass)
 #define VM_CLASS_GET_THIS_ARG(klass) il2cpp_class_this_arg(klass)
 #define VM_CLASS_GET_ELEMENT_CLASS(klass) il2cpp_class_get_element_class(klass)
@@ -70,15 +61,6 @@
 #define VM_ASSEMBLY_FREE_NAME(name)
 #define VM_ASSEMBLY_IS_DYNAMIC(assembly) assembly->image->dynamic
 #define VM_ASSEMBLY_GET_IMAGE(assembly) assembly->image
-#define VM_ASSEMBLY_NAME_GET_NAME(assembly) (assembly)->aname.name
-#define VM_ASSEMBLY_NAME_GET_MAJOR(assembly) (assembly)->aname.major
-#define VM_ASSEMBLY_NAME_GET_MINOR(assembly) (assembly)->aname.minor
-#define VM_ASSEMBLY_NAME_GET_BUILD(assembly) (assembly)->aname.build
-#define VM_ASSEMBLY_NAME_GET_REVISION(assembly) (assembly)->aname.revision
-#define VM_ASSEMBLY_NAME_GET_CULTURE(assembly) (assembly)->aname.culture
-#define VM_ASSEMBLY_NAME_GET_PUBLIC_KEY_TOKEN(assembly, i) (assembly)->aname.public_key_token[i]
-#define VM_ASSEMBLY_NAME_GET_PUBLIC_KEY_TOKEN_STRING(assembly) (char*)(assembly)->aname.public_key_token
-#define VM_ASSEMBLY_NAME_GET_FLAGS(assembly) (assembly)->aname.flags
 #define VM_CLASS_GET_TYPE(klass) &(klass)->byval_arg
 #define VM_CLASS_GET_THIS_ARG(klass) &(klass)->this_arg
 #define VM_CLASS_GET_PARENT(klass) (klass)->parent
@@ -365,6 +347,10 @@
 #define mono_class_get_type_token il2cpp_class_get_type_token
 #define mono_type_is_byref il2cpp_type_is_byref
 #define mono_class_is_enum il2cpp_class_is_enum
+#define mono_method_get_flags il2cpp_method_get_flags
+#define mono_method_get_token il2cpp_method_get_token
+#define mono_method_is_generic il2cpp_method_is_generic
+#define mono_method_is_inflated il2cpp_method_is_inflated
 
 Il2CppMonoMethod* il2cpp_mono_image_get_entry_point (Il2CppMonoImage *image);
 const char* il2cpp_mono_image_get_filename (Il2CppMonoImage *image);
@@ -556,6 +542,7 @@ Il2CppMonoException* il2cpp_mono_error_convert_to_exception (MonoError *target_e
 const char* il2cpp_mono_error_get_message (MonoError *oerror);
 void il2cpp_mono_error_assert_ok_pos (MonoError *error, const char* filename, int lineno);
 Il2CppSequencePointC* il2cpp_get_sequence_points(void* *iter);
+Il2CppSequencePointC* il2cpp_get_method_sequence_points(Il2CppMonoMethod* method, void* *iter);
 Il2CppMonoGenericInst* il2cpp_generic_class_get_inst(Il2CppMonoGenericClass *monoGenClass);
 guint il2cpp_generic_inst_type_argc(Il2CppMonoGenericInst *monoInst);
 Il2CppMonoType* il2cpp_generic_inst_type_arg(Il2CppMonoGenericInst *monoInst, int i);
@@ -565,15 +552,6 @@ Il2CppMonoClass* il2cpp_defaults_object_class();
 guint8 il2cpp_array_rank(Il2CppMonoArray *monoArr);
 mono_array_size_t il2cpp_array_bound_length(Il2CppMonoArray *monoArr, int i);
 mono_array_lower_bound_t il2cpp_array_bound_lower_bound(Il2CppMonoArray *monoArr, int i);
-const char* il2cpp_assembly_name_name(Il2CppMonoAssembly *monoAssembly);
-uint16_t il2cpp_assembly_name_major(Il2CppMonoAssembly *monoAssembly);
-uint16_t il2cpp_assembly_name_minor(Il2CppMonoAssembly *monoAssembly);
-uint16_t il2cpp_assembly_name_build(Il2CppMonoAssembly *monoAssembly);
-uint16_t il2cpp_assembly_name_revision(Il2CppMonoAssembly *monoAssembly);
-const char* il2cpp_assembly_name_culture(Il2CppMonoAssembly *monoAssembly);
-mono_byte il2cpp_assembly_name_public_key_token(Il2CppMonoAssembly *monoAssembly, int i);
-const char* il2cpp_assembly_name_public_key_token_string(Il2CppMonoAssembly *monoAssembly);
-uint32_t il2cpp_assembly_name_flags(Il2CppMonoAssembly *monoAssembly);
 const char* il2cpp_image_name(Il2CppMonoImage *monoImage);
 Il2CppMonoAssembly* il2cpp_image_assembly(Il2CppMonoImage *monoImage);
 guint8* il2cpp_field_get_address(Il2CppMonoObject *obj, Il2CppMonoClassField *monoField);

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -39,6 +39,7 @@
 #define VM_OBJECT_GET_CLASS(object) il2cpp_object_get_class(object)
 #define VM_OBJECT_GET_TYPE(object) il2cpp_mono_object_get_type(object)
 #define VM_GENERIC_CLASS_GET_INST(klass) il2cpp_generic_class_get_inst(klass)
+#define VM_GENERIC_CONTAINER_GET_TYPE_ARGC(container) il2cpp_generic_container_get_type_argc(container)
 #define VM_GENERIC_INST_TYPE_ARGC(inst) il2cpp_generic_inst_type_argc(inst)
 #define VM_GENERIC_INST_TYPE_ARG(inst, i) il2cpp_generic_inst_type_arg(inst, i)
 #define VM_DEFAULTS_OBJECT_CLASS il2cpp_defaults_object_class()
@@ -79,6 +80,7 @@
 #define VM_OBJECT_GET_DOMAIN(object) ((MonoObject*)object)->vtable->domain
 #define VM_OBJECT_GET_CLASS(object) ((MonoObject*)object)->vtable->klass
 #define VM_OBJECT_GET_TYPE(object) ((MonoReflectionType*)object->vtable->type)->type
+#define VM_GENERIC_CONTAINER_GET_TYPE_ARGC(container) container->type_argc
 #define VM_GENERIC_CLASS_GET_INST(klass) (klass)->context.class_inst
 #define VM_GENERIC_INST_TYPE_ARGC(inst) (inst)->type_argc
 #define VM_GENERIC_INST_TYPE_ARG(inst, i) (inst)->type_argv[i]
@@ -562,5 +564,6 @@ guint8* il2cpp_field_get_address(Il2CppMonoObject *obj, Il2CppMonoClassField *mo
 Il2CppMonoType* il2cpp_mono_object_get_type(Il2CppMonoObject* object);
 Il2CppMonoClass* il2cpp_defaults_exception_class();
 Il2CppMonoImage* il2cpp_defaults_corlib_image();
+int il2cpp_generic_container_get_type_argc(Il2CppMonoGenericClass* container);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -28,6 +28,8 @@
 #define VM_CLASS_GET_IMAGE(klass) il2cpp_class_get_image(klass)
 #define VM_METHOD_GET_WRAPPER_TYPE(method) FALSE
 #define VM_METHOD_GET_DECLARING_TYPE(method) il2cpp_method_get_declaring_type(method)
+#define VM_METHOD_IS_GENERIC(method) il2cpp_method_is_generic(method)
+#define VM_METHOD_IS_INFLATED(method) il2cpp_method_is_inflated(method)
 #define VM_FIELD_GET_NAME(field) il2cpp_mono_field_get_name(field)
 #define VM_FIELD_GET_PARENT(field) il2cpp_field_get_parent(field)
 #define VM_FIELD_GET_TYPE(field) il2cpp_field_get_type(field)
@@ -67,6 +69,8 @@
 #define VM_CLASS_GET_IMAGE(klass) (klass)->image
 #define VM_METHOD_GET_WRAPPER_TYPE(method) method->wrapper_type
 #define VM_METHOD_GET_DECLARING_TYPE(method) (method)->klass
+#define VM_METHOD_IS_GENERIC(method) method->is_generic
+#define VM_METHOD_IS_INFLATED(method) method->is_inflated
 #define VM_FIELD_GET_NAME(field) field->name
 #define VM_FIELD_GET_PARENT(field) (field)->parent
 #define VM_FIELD_GET_TYPE(field) (field)->type

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -10,6 +10,7 @@
 #include "vm/Class.h"
 #include "vm/Domain.h"
 #include "vm/Field.h"
+#include "vm/GenericContainer.h"
 #include "vm/Image.h"
 #include "vm/Method.h"
 #include "vm/Object.h"
@@ -609,8 +610,7 @@ gboolean il2cpp_mono_class_is_nullable(Il2CppMonoClass* klass)
 
 Il2CppMonoGenericContainer* il2cpp_mono_class_get_generic_container(Il2CppMonoClass* klass)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+    return (Il2CppMonoGenericContainer*)il2cpp::vm::Class::GetGenericContainer((Il2CppClass*)klass);
 }
 
 void il2cpp_mono_class_setup_interfaces(Il2CppMonoClass* klass, MonoError* error)
@@ -632,8 +632,7 @@ gpointer il2cpp_mono_ldtoken_checked(Il2CppMonoImage* image, guint32 token, Il2C
 
 Il2CppMonoClass* il2cpp_mono_class_from_generic_parameter_internal(Il2CppMonoGenericParam* param)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	return (Il2CppMonoClass*)il2cpp::vm::Class::FromGenericParameter((Il2CppGenericParameter*)param);
 }
 
 Il2CppMonoClass* il2cpp_mono_class_load_from_name(Il2CppMonoImage* image, const char* name_space, const char* name)
@@ -1089,8 +1088,7 @@ gboolean il2cpp_mono_class_has_parent (Il2CppMonoClass *klass, Il2CppMonoClass *
 
 Il2CppMonoGenericParam* il2cpp_mono_generic_container_get_param (Il2CppMonoGenericContainer *gc, int i)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	return (Il2CppMonoGenericParam*)il2cpp::vm::GenericContainer::GetGenericParameter((Il2CppGenericContainer*)gc, i);
 }
 
 gboolean il2cpp_mono_find_seq_point (Il2CppMonoDomain *domain, Il2CppMonoMethod *method, gint32 il_offset, MonoSeqPointInfo **info, SeqPoint *seq_point)
@@ -1360,6 +1358,11 @@ Il2CppMonoClass* il2cpp_defaults_exception_class()
 Il2CppMonoImage* il2cpp_defaults_corlib_image()
 {
 	return (Il2CppMonoImage*)il2cpp_defaults.corlib;
+}
+
+int il2cpp_generic_container_get_type_argc(Il2CppMonoGenericClass* container)
+{
+	return ((Il2CppGenericContainer*)container)->type_argc;
 }
 
 }

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -385,7 +385,6 @@ Il2CppMonoMethod* il2cpp_mono_jit_info_get_method(MonoJitInfo* ji)
 
 MonoDebugMethodInfo* il2cpp_mono_debug_lookup_method(Il2CppMonoMethod* method)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
 	return NULL;
 }
 
@@ -666,7 +665,6 @@ void il2cpp_mono_thread_internal_reset_abort(Il2CppMonoInternalThread* thread)
 
 gunichar2* il2cpp_mono_thread_get_name(Il2CppMonoInternalThread* this_obj, guint32* name_len)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
 	return NULL;
 }
 
@@ -860,8 +858,7 @@ Il2CppMonoReflectionAssemblyHandle il2cpp_mono_assembly_get_object_handle(Il2Cpp
 
 Il2CppMonoReflectionType* il2cpp_mono_type_get_object_checked(Il2CppMonoDomain* domain, Il2CppMonoType* type, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	return (Il2CppMonoReflectionType*)il2cpp::vm::Reflection::GetTypeObject((const Il2CppType*)type);
 }
 
 void il2cpp_mono_network_init()
@@ -1196,9 +1193,20 @@ void il2cpp_domain_set_agent_info(Il2CppMonoAppDomain* domain, void* agentInfo)
 void il2cpp_send_assemblies_for_domain (Il2CppMonoAppDomain *domain, void *user_data, emit_assembly_load_callback callback)
 {
 	il2cpp::vm::AssemblyVector* assemblies = il2cpp::vm::Assembly::GetAllAssemblies();
-	for (il2cpp::vm::AssemblyVector::iterator it = assemblies->begin(); it != assemblies->end(); it++)
+	for (il2cpp::vm::AssemblyVector::iterator assembly = assemblies->begin(); assembly != assemblies->end(); ++assembly)
+		callback((void*)*assembly, NULL);
+}
+
+void il2cpp_send_types_for_domain(Il2CppMonoAppDomain *domain, emit_type_load_callback callback)
+{
+	il2cpp::vm::AssemblyVector* assemblies = il2cpp::vm::Assembly::GetAllAssemblies();
+	for (il2cpp::vm::AssemblyVector::iterator assembly = assemblies->begin(); assembly != assemblies->end(); ++assembly)
 	{
-		callback((void*)*it, NULL);
+		Il2CppImage* image = il2cpp::vm::Assembly::GetImage(*assembly);
+		il2cpp::vm::TypeVector types;
+		il2cpp::vm::Image::GetTypes(image, true, &types);
+		for (il2cpp::vm::TypeVector::iterator type = types.begin(); type != types.end(); ++type)
+			callback(NULL, (void*)*type, NULL);
 	}
 }
 
@@ -1241,6 +1249,11 @@ int il2cpp_mono_type_get_attrs(Il2CppMonoType* type)
 Il2CppSequencePointC* il2cpp_get_sequence_points(void* *iter)
 {
 	return (Il2CppSequencePointC*)il2cpp::utils::Debugger::GetSequencePoints(iter);
+}
+
+Il2CppSequencePointC* il2cpp_get_method_sequence_points(Il2CppMonoMethod* method, void* *iter)
+{
+    return (Il2CppSequencePointC*)il2cpp::utils::Debugger::GetSequencePoints((const MethodInfo*)method, iter);
 }
 
 gboolean il2cpp_mono_methods_match(Il2CppMonoMethod* left, Il2CppMonoMethod* right)
@@ -1314,60 +1327,6 @@ mono_array_lower_bound_t il2cpp_array_bound_lower_bound(Il2CppMonoArray *monoArr
 {
 	Il2CppArray *arr = (Il2CppArray*)monoArr;
 	return arr->bounds[i].lower_bound;
-}
-
-const char* il2cpp_assembly_name_name(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return il2cpp::vm::MetadataCache::GetStringFromIndex(assembly->aname.nameIndex);
-}
-
-uint16_t il2cpp_assembly_name_major(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return assembly->aname.major;
-}
-
-uint16_t il2cpp_assembly_name_minor(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return assembly->aname.minor;
-}
-
-uint16_t il2cpp_assembly_name_build(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return assembly->aname.build;
-}
-
-uint16_t il2cpp_assembly_name_revision(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return assembly->aname.revision;
-}
-
-const char* il2cpp_assembly_name_culture(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return il2cpp::vm::MetadataCache::GetStringFromIndex(assembly->aname.cultureIndex);
-}
-
-mono_byte il2cpp_assembly_name_public_key_token(Il2CppMonoAssembly *monoAssembly, int i)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return assembly->aname.publicKeyToken[i];
-}
-
-const char* il2cpp_assembly_name_public_key_token_string(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return il2cpp::vm::MetadataCache::GetStringFromIndex(assembly->aname.publicKeyIndex);
-}
-
-uint32_t il2cpp_assembly_name_flags(Il2CppMonoAssembly *monoAssembly)
-{
-	Il2CppAssembly *assembly = (Il2CppAssembly*)monoAssembly;
-	return assembly->aname.flags;
 }
 
 const char* il2cpp_image_name(Il2CppMonoImage *monoImage)


### PR DESCRIPTION
These changes help the VSTU interaction with the IL2CPP debugger, but
breakpoints and single stepping are still not working, even with these
changes. We need to implement more of the IL2CPP stub methods to make
the VSTU debugger work at an alpha level.

* Send type source file debug information from the debugger agent
  * Use the existing GetSequencePointsAndSourceFilesUniqueSequencePoints method
  * Make this method much faster by building a hash table of method to list of sequence points
  * Without this change, sending all of the debug information for all took minutes
* Use the existing code in libil2cpp to get the assembly name
  * A previous commit to libil2cpp fixed the assembly name generation, adding the "Culture" entry properly
  * This change reverts the Mono branch of the assembly name code to its previous state
  * It removes the now-unused IL2CPP stubs
* Implement the CMD_METHOD_GET_INFO message
* Send all of the types for the domain to the client