### PR TITLE
use thread specific get value function to fix getting thread local statics

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9538,7 +9538,11 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 			if (!(VM_TYPE_GET_ATTRS(VM_FIELD_GET_TYPE(f)) & FIELD_ATTRIBUTE_STATIC))
 				return ERR_INVALID_FIELDID;
-#ifndef IL2CPP_MONO_DEBUGGER
+
+#ifdef IL2CPP_MONO_DEBUGGER
+			if (!thread && VM_FIELD_GET_OFFSET(f) == THREAD_STATIC_FIELD_OFFSET)
+				return ERR_INVALID_FIELDID;
+#else
 			special_static_type = mono_class_field_get_special_static_type (f);
 			if (special_static_type != SPECIAL_STATIC_NONE) {
 				if (!(thread && special_static_type == SPECIAL_STATIC_THREAD))

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -9,6 +9,9 @@
 #include <mono/sgen/sgen-conf.h>
 
 #ifdef IL2CPP_MONO_DEBUGGER
+
+#define THREAD_STATIC_FIELD_OFFSET -1
+
 #define VM_THREAD_GET(thread) thread
 #define VM_THREAD_SET_STATE_BACKGROUND(thread) il2cpp_set_thread_state_background(thread)
 #define VM_THREAD_SET_FLAG_DONT_MANAGE(thread)

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -700,7 +700,7 @@ void il2cpp_mono_field_static_get_value_checked(Il2CppMonoVTable* vt, Il2CppMono
 void il2cpp_mono_field_static_get_value_for_thread(Il2CppMonoInternalThread* thread, Il2CppMonoVTable* vt, Il2CppMonoClassField* field, void* value, MonoError* error)
 {
 	mono_error_init(error);
-	il2cpp::vm::Field::StaticGetValue((FieldInfo*)field, value);
+	il2cpp::vm::Field::StaticGetValueForThread((FieldInfo*)field, value, (Il2CppThread*)thread);
 }
 
 Il2CppMonoObject* il2cpp_mono_field_get_value_object_checked(Il2CppMonoDomain* domain, Il2CppMonoClassField* field, Il2CppMonoObject* obj, MonoError* error)


### PR DESCRIPTION
Use newly implemented StaticGetValueForThread in order to retrieve thread local static values correctly