### PR TITLE
IL2CPP Debugger generic fixes

### DIFF
--- a/mono/mini/il2cpp-c-types.h
+++ b/mono/mini/il2cpp-c-types.h
@@ -352,7 +352,7 @@ typedef struct
 {
 	const Il2CppMethodExecutionContextInfoC* const executionContextInfos;
 	const uint32_t executionContextInfoCount;
-	const Il2CppMonoMethod** method;
+	const Il2CppMonoMethod* method;
 	const char* const sourceFile;
 	const uint8_t sourceFileHash[16];
 	const int32_t lineStart, lineEnd;

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -1380,9 +1380,9 @@ gboolean il2cpp_mono_methods_match(Il2CppMonoMethod* left, Il2CppMonoMethod* rig
 		return TRUE;
 	if (rightMethod == NULL || leftMethod == NULL)
 		return FALSE;
-	if (rightMethod->is_inflated && rightMethod->genericMethod->methodDefinition == leftMethod)
+	if (rightMethod->is_inflated && !rightMethod->is_generic && rightMethod->genericMethod->methodDefinition == leftMethod)
 		return TRUE;
-	if (leftMethod->is_inflated && leftMethod->genericMethod->methodDefinition == rightMethod)
+	if (leftMethod->is_inflated && !leftMethod->is_generic && leftMethod->genericMethod->methodDefinition == rightMethod)
 		return TRUE;
     if (leftMethod->is_generic && rightMethod->is_inflated && rightMethod->methodPointer &&
         leftMethod->declaring_type == rightMethod->declaring_type &&
@@ -1393,8 +1393,8 @@ gboolean il2cpp_mono_methods_match(Il2CppMonoMethod* left, Il2CppMonoMethod* rig
 
         for(int i = 0;i < leftMethod->parameters_count;++i)
         {
-            if (leftMethod->parameters[i].parameter_type != rightMethod->parameters[i].parameter_type)
-                return FALSE;
+			if ((leftMethod->parameters[i].parameter_type->type != IL2CPP_TYPE_MVAR) && (leftMethod->parameters[i].parameter_type->type != IL2CPP_TYPE_VAR) && (leftMethod->parameters[i].parameter_type != rightMethod->parameters[i].parameter_type))
+				return FALSE;
         }
 
         return TRUE;


### PR DESCRIPTION
* Making the method pointer in SequencePoint struct a simple pointer instead of
a pointer-to-pointer.  We were using a pointer-to-pointer because the pointers
weren't updated at the time we initialized the sequence points, but now we need the
ability to replace those pointers when a shared generic is called.  Fixed the debugger
initialization sequence to allow for this.
* Improved il2cpp_mono_methods_match.  Allowing generic parameters on the left side
to match any type on the right side.  Now that sequence points are the same for all
generic methods this should work in the context of finding sequence points. Also
checking for is_generic to be false and is_inflated to be true before accessing the
genericMethod->methodDefinition field.