### PR TITLE
Mono Fixes for Trunk

### DIFF
--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -15,7 +15,7 @@ my $lib = "$monodistro/lib";
 my $libmono = "$lib/mono";
 my $monoprefix = "$root/tmp/monoprefix";
 my $xcodePath = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform';
-my $macversion = '10.5';
+my $macversion = '10.6';
 my $sdkversion = '10.6';
 my $externalBuildDeps = "$root/../../mono-build-deps/build";
 
@@ -74,9 +74,9 @@ if (not $skipbuild)
 
 	$ENV{'CC'} = "$sdkPath/../usr/bin/clang";
 	$ENV{'CXX'} = "$sdkPath/../usr/bin/clang++";
-	$ENV{CFLAGS}  = "$ENV{CFLAGS} -arch i386 -D_XOPEN_SOURCE";
+	$ENV{CFLAGS}  = "$ENV{CFLAGS} -arch x86_64 -D_XOPEN_SOURCE";
 	$ENV{CXXFLAGS}  = "$ENV{CXXFLAGS} $ENV{CFLAGS}";
-	$ENV{LDFLAGS}  = "$ENV{LDFLAGS} -arch i386";
+	$ENV{LDFLAGS}  = "$ENV{LDFLAGS} -arch x86_64";
 	if ($^O eq 'darwin')
 	{
 		$ENV{'MACSDKOPTIONS'} = "$ENV{CFLAGS} -mmacosx-version-min=$macversion -isysroot $sdkPath";

--- a/external/buildscripts/build_runtime_linux.pl
+++ b/external/buildscripts/build_runtime_linux.pl
@@ -81,15 +81,15 @@ if (not $skipbuild)
 
 	if ($build64)
 	{
-		$archflags = '-fPIC -ftls-model=initial-exec -mtls-dialect=gnu2';
+		$archflags .= ' -fPIC -ftls-model=initial-exec -mtls-dialect=gnu2';
 	}
 	elsif ($build_armel)
 	{
-		$archflags = '-marm -DARM_FPU_NONE';
+		$archflags .= ' -marm -DARM_FPU_NONE';
 	}
 	else # x86
 	{
-		$archflags = '-m32';
+		$archflags .= ' -m32';
 	}
 	if ($debug)
 	{

--- a/external/buildscripts/build_runtime_osx.pl
+++ b/external/buildscripts/build_runtime_osx.pl
@@ -145,15 +145,13 @@ if ($iphone_simulator || $minimal) {
 	@arches = ('i386');
 }
 
-for my $arch (@arches)
+my $arch = 'x86_64';
+
 {
 	print "Building for architecture: $arch\n";
 
-	my $macversion = '10.5';
+	my $macversion = '10.6';
 	my $sdkversion = '10.6';
-	if ($arch eq 'x86_64') {
-		$macversion = '10.6';
-	}
 
 	# Set up clang toolchain
 	$sdkPath = "$externalBuildDeps/MacBuildEnvironment/builds/MacOSX$sdkversion.sdk";
@@ -166,8 +164,8 @@ for my $arch (@arches)
 	$ENV{'CXX'} = "$sdkPath/../usr/bin/clang++";
 
 	# Make architecture-specific targets and lipo at the end
-	my $bintarget = "$root/builds/monodistribution/bin-$arch";
-	my $libtarget = "$root/builds/embedruntimes/osx-$arch";
+	my $bintarget = "$root/builds/monodistribution/bin";
+	my $libtarget = "$root/builds/embedruntimes/osx";
 	my $sdkoptions = '';
 
 	if ($minimal)
@@ -282,27 +280,4 @@ for my $arch (@arches)
 
 	system("ln","-f","$root/mono/mini/mono","$bintarget/mono") eq 0 or die("failed symlinking mono executable");
 	system("ln","-f","$root/mono/metadata/pedump","$bintarget/pedump") eq 0 or die("failed symlinking pedump executable");
-}
-
-# Create universal binaries
-mkpath ("$root/builds/embedruntimes/osx");
-for $file ('libmono.0.dylib','libmono.a','libMonoPosixHelper.dylib') {
-	system ('lipo', "$root/builds/embedruntimes/osx-i386/$file", "$root/builds/embedruntimes/osx-x86_64/$file", '-create', '-output', "$root/builds/embedruntimes/osx/$file");
-}
-system('cp', "$root/builds/embedruntimes/osx-i386/MonoBundleBinary", "$root/builds/embedruntimes/osx/MonoBundleBinary");
-
-# Create universal binaries
-mkpath ("$root/builds/embedruntimes/osx");
-for $file ('libmono.0.dylib','libmono.a','libMonoPosixHelper.dylib') {
-	system ('lipo', "$root/builds/embedruntimes/osx-i386/$file", "$root/builds/embedruntimes/osx-x86_64/$file", '-create', '-output', "$root/builds/embedruntimes/osx/$file");
-}
-system('cp', "$root/builds/embedruntimes/osx-i386/MonoBundleBinary", "$root/builds/embedruntimes/osx/MonoBundleBinary-i386");
-system('cp', "$root/builds/embedruntimes/osx-x86_64/MonoBundleBinary", "$root/builds/embedruntimes/osx/MonoBundleBinary-x86_64");
-
-if ($ENV{"UNITY_THISISABUILDMACHINE"}) {
-	# Clean up temporary arch-specific directories
-	rmtree("$root/builds/embedruntimes/osx-i386");
-	rmtree("$root/builds/embedruntimes/osx-x86_64");
-	rmtree("$root/builds/monodistribution/bin-i386");
-	rmtree("$root/builds/monodistribution/bin-x86_64");
 }


### PR DESCRIPTION
- Remove 32-bit slice on OSX
- [linux] Don't clobber shared arch compiler flags. Fixes NetworkInterface.GetAllNetworkInterfaces again