### PR TITLE
IL2CPP debugger changes

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9450,10 +9450,10 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 		while ((p = mono_class_get_properties (klass, &iter))) {
 			buffer_add_propertyid (buf, domain, p);
-			buffer_add_string (buf, p->name);
-			buffer_add_methodid (buf, domain, p->get);
-			buffer_add_methodid (buf, domain, p->set);
-			buffer_add_int (buf, p->attrs);
+			buffer_add_string (buf, VM_PROPERTY_GET_NAME(p));
+			buffer_add_methodid (buf, domain, VM_PROPERTY_GET_GET_METHOD(p));
+			buffer_add_methodid (buf, domain, VM_PROPERTY_GET_SET_METHOD(p));
+			buffer_add_int (buf, VM_PROPERTY_GET_ATTRS(p));
 			i ++;
 		}
 		g_assert (i == nprops);
@@ -10174,10 +10174,10 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 					result = method;
 				} else {
 					MonoMethodInflated *imethod = (MonoMethodInflated *)method;
-					
-					result = imethod->declaring;
-					if (imethod->context.class_inst) {
-						MonoClass *klass = ((MonoMethod *) imethod)->klass;
+
+					result = VM_INFLATED_METHOD_GET_DECLARING(imethod);
+					if (VM_INFLATED_METHOD_GET_CLASS_INST(imethod)) {
+						MonoClass *klass = VM_METHOD_GET_DECLARING_TYPE((MonoMethod *) imethod);
 						/*Generic methods gets the context of the GTD.*/
 						if (mono_class_get_context (klass)) {
 							MonoError error;
@@ -10198,11 +10198,11 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 					if (is_inflated) {
 						MonoGenericInst *inst = mono_method_get_context (method)->method_inst;
 						if (inst) {
-							count = inst->type_argc;
+							count = VM_GENERIC_INST_TYPE_ARGC(inst);
 							buffer_add_int (buf, count);
 
 							for (i = 0; i < count; i++)
-								buffer_add_typeid (buf, domain, mono_class_from_mono_type (inst->type_argv [i]));
+								buffer_add_typeid (buf, domain, mono_class_from_mono_type (VM_GENERIC_INST_TYPE_ARG(inst, i)));
 						} else {
 							buffer_add_int (buf, 0);
 						}
@@ -10380,7 +10380,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		}
 		ginst = mono_metadata_get_generic_inst (type_argc, type_argv);
 		g_free (type_argv);
-		tmp_context.class_inst = mono_class_is_ginst (method->klass) ? mono_class_get_generic_class (method->klass)->context.class_inst : NULL;
+		tmp_context.class_inst = mono_class_is_ginst (VM_METHOD_GET_DECLARING_TYPE(method)) ?  VM_GENERIC_CLASS_GET_INST(mono_class_get_generic_class (VM_METHOD_GET_DECLARING_TYPE(method))) : NULL;
 		tmp_context.method_inst = ginst;
 
 		inflated = mono_class_inflate_generic_method_checked (method, &tmp_context, &error);

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -50,6 +50,8 @@
 #define VM_METHOD_GET_NAME(method) il2cpp_method_get_name(method)
 #define VM_METHOD_IS_GENERIC(method) il2cpp_method_is_generic(method)
 #define VM_METHOD_IS_INFLATED(method) il2cpp_method_is_inflated(method)
+#define VM_INFLATED_METHOD_GET_DECLARING(imethod) il2cpp_method_get_generic_definition(imethod)
+#define VM_INFLATED_METHOD_GET_CLASS_INST(imethod) il2cpp_method_get_generic_class_inst(imethod)
 #define VM_FIELD_GET_NAME(field) il2cpp_mono_field_get_name(field)
 #define VM_FIELD_GET_PARENT(field) il2cpp_field_get_parent(field)
 #define VM_FIELD_GET_TYPE(field) il2cpp_field_get_type(field)
@@ -77,6 +79,10 @@
 #define VM_IMAGE_GET_NAME(image) il2cpp_image_name(image)
 #define VM_IMAGE_GET_MODULE_NAME(image) il2cpp_image_name(image)
 #define VM_IMAGE_GET_ASSEMBLY(image) il2cpp_image_assembly(image)
+#define VM_PROPERTY_GET_NAME(prop) il2cpp_property_get_name(prop)
+#define VM_PROPERTY_GET_GET_METHOD(prop) il2cpp_property_get_get_method(prop)
+#define VM_PROPERTY_GET_SET_METHOD(prop) il2cpp_property_get_set_method(prop)
+#define VM_PROPERTY_GET_ATTRS(prop) il2cpp_property_get_flags(prop)
 #else
 #define VM_THREAD_GET(thread) thread->internal_thread
 #define VM_THREAD_SET_STATE_BACKGROUND(thread) thread->internal_thread->state |= ThreadState_Background
@@ -115,6 +121,8 @@
 #define VM_METHOD_GET_NAME(method) (method)->name
 #define VM_METHOD_IS_GENERIC(method) method->is_generic
 #define VM_METHOD_IS_INFLATED(method) method->is_inflated
+#define VM_INFLATED_METHOD_GET_DECLARING(imethod) (imethod)->declaring
+#define VM_INFLATED_METHOD_GET_CLASS_INST(imethod) (imethod)->context.class_inst
 #define VM_FIELD_GET_NAME(field) field->name
 #define VM_FIELD_GET_PARENT(field) (field)->parent
 #define VM_FIELD_GET_TYPE(field) (field)->type
@@ -143,6 +151,10 @@
 #define VM_IMAGE_GET_NAME(image) (image)->name
 #define VM_IMAGE_GET_MODULE_NAME(image) (image)->module_name
 #define VM_IMAGE_GET_ASSEMBLY(image)  (image)->assembly
+#define VM_PROPERTY_GET_NAME(prop) (prop)->name
+#define VM_PROPERTY_GET_GET_METHOD(prop) (prop)->get
+#define VM_PROPERTY_GET_SET_METHOD(prop) (prop)->set
+#define VM_PROPERTY_GET_ATTRS(prop) (prop)->attrs
 #endif
 
 #if defined(RUNTIME_IL2CPP)
@@ -634,5 +646,7 @@ gboolean il2cpp_class_get_enumtype(Il2CppMonoClass *klass);
 Il2CppMonoClass* il2cpp_iterate_loaded_classes(void* *iter);
 Il2CppMonoAssembly* il2cpp_domain_get_assemblies_iter(Il2CppMonoAppDomain *domain, void* *iter);
 const char** il2cpp_get_source_files_for_type(Il2CppMonoClass *klass, int *count);
+Il2CppMonoMethod* il2cpp_method_get_generic_definition(Il2CppMonoMethodInflated *imethod);
+Il2CppMonoGenericInst* il2cpp_method_get_generic_class_inst(Il2CppMonoMethodInflated *imethod);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -22,6 +22,7 @@
 #include "vm/ThreadPoolMs.h"
 #include "vm/Type.h"
 #include "vm-utils/Debugger.h"
+#include "metadata/GenericMetadata.h"
 
 extern "C" {
 
@@ -94,7 +95,22 @@ Il2CppMonoMethodSignature* il2cpp_mono_method_signature (Il2CppMonoMethod *m)
 	sig->call_convention = MONO_CALL_DEFAULT;
 	sig->hasthis = il2cpp::vm::Method::IsInstance(method);
 	sig->ret = (Il2CppMonoType*)il2cpp::vm::Method::GetReturnType(method);
-	sig->generic_param_count = il2cpp::vm::Method::GetGenericParamCount(method);
+
+	sig->generic_param_count = 0;
+
+	if (method->is_generic)
+	{
+		sig->generic_param_count = il2cpp::vm::Method::GetGenericParamCount(method);
+	}
+	else if (method->is_inflated)
+	{
+		if (method->genericMethod->context.method_inst)
+			sig->generic_param_count += method->genericMethod->context.method_inst->type_argc;
+
+		if (method->genericMethod->context.class_inst)
+			sig->generic_param_count += method->genericMethod->context.class_inst->type_argc;
+	}
+
 	sig->param_count = il2cpp::vm::Method::GetParamCount(method);
 	sig->params = g_new(Il2CppMonoType*, sig->param_count);
 	for (int i = 0; i < sig->param_count; ++i)
@@ -197,8 +213,7 @@ int il2cpp_mono_class_num_methods (Il2CppMonoClass *klass)
 
 int il2cpp_mono_class_num_properties (Il2CppMonoClass *klass)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return 0;
+	return il2cpp::vm::Class::GetNumProperties((Il2CppClass*)klass);
 }
 
 Il2CppMonoClassField* il2cpp_mono_class_get_fields (Il2CppMonoClass* klass, gpointer *iter)
@@ -213,8 +228,7 @@ Il2CppMonoMethod* il2cpp_mono_class_get_methods (Il2CppMonoClass* klass, gpointe
 
 Il2CppMonoProperty* il2cpp_mono_class_get_properties (Il2CppMonoClass* klass, gpointer *iter)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	return (Il2CppMonoProperty*)il2cpp::vm::Class::GetProperties((Il2CppClass*)klass, iter);
 }
 
 const char* il2cpp_mono_field_get_name (Il2CppMonoClassField *field)
@@ -483,8 +497,7 @@ guint il2cpp_mono_aligned_addr_hash(gconstpointer ptr)
 
 Il2CppMonoGenericInst* il2cpp_mono_metadata_get_generic_inst(int type_argc, Il2CppMonoType** type_argv)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	return (Il2CppMonoGenericInst*)il2cpp::vm::MetadataCache::GetGenericInst((Il2CppType**)type_argv, type_argc);
 }
 
 Il2CppMonoMethod* il2cpp_mono_get_method_checked(Il2CppMonoImage* image, guint32 token, Il2CppMonoClass* klass, Il2CppMonoGenericContext* context, MonoError* error)
@@ -532,32 +545,39 @@ guint32 il2cpp_mono_class_field_get_special_static_type(Il2CppMonoClassField* fi
 
 Il2CppMonoGenericContext* il2cpp_mono_class_get_context(Il2CppMonoClass* klass)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	return (Il2CppMonoGenericContext*)&((Il2CppClass*)klass)->generic_class->context;
 }
 
-Il2CppMonoGenericContext* il2cpp_mono_method_get_context(Il2CppMonoMethod* method)
+Il2CppMonoGenericContext* il2cpp_mono_method_get_context(Il2CppMonoMethod* monoMethod)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	MethodInfo * method = (MethodInfo*)monoMethod;
+
+	if (!method->is_inflated || method->is_generic)
+		return NULL;
+
+	return (Il2CppMonoGenericContext*) &((MethodInfo*)method)->genericMethod->context;
 }
 
-Il2CppMonoGenericContainer* il2cpp_mono_method_get_generic_container(Il2CppMonoMethod* method)
+Il2CppMonoGenericContainer* il2cpp_mono_method_get_generic_container(Il2CppMonoMethod* monoMethod)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	MethodInfo * method = (MethodInfo*)monoMethod;
+
+	if (method->is_inflated || !method->is_generic)
+		return NULL;
+
+	return (Il2CppMonoGenericContainer*) method->genericContainer;
 }
 
 Il2CppMonoMethod* il2cpp_mono_class_inflate_generic_method_full_checked(Il2CppMonoMethod* method, Il2CppMonoClass* klass_hint, Il2CppMonoGenericContext* context, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	mono_error_init(error);
+	return (Il2CppMonoMethod*) il2cpp::metadata::GenericMetadata::Inflate((MethodInfo*)method, (Il2CppClass*)klass_hint, (Il2CppGenericContext*)context);
 }
 
 Il2CppMonoMethod* il2cpp_mono_class_inflate_generic_method_checked(Il2CppMonoMethod* method, Il2CppMonoGenericContext* context, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return NULL;
+	mono_error_init(error);
+	return (Il2CppMonoMethod*)il2cpp::metadata::GenericMetadata::Inflate((MethodInfo*)method, NULL, (Il2CppGenericContext*)context);
 }
 
 void il2cpp_mono_loader_lock()
@@ -914,8 +934,13 @@ gboolean il2cpp_mono_runtime_try_shutdown()
 
 gboolean il2cpp_mono_verifier_is_method_valid_generic_instantiation(Il2CppMonoMethod* method)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return 0;
+	if (!method)
+		return FALSE;
+
+	if (!((MethodInfo*)method)->is_generic && ((MethodInfo*)method)->is_inflated && ((MethodInfo*)method)->methodPointer)
+		return TRUE;
+
+	return FALSE;
 }
 
 Il2CppMonoType* il2cpp_mono_reflection_get_type_checked(Il2CppMonoImage* rootimage, Il2CppMonoImage* image, Il2CppMonoTypeNameParse* info, gboolean ignorecase, gboolean* type_resolve, MonoError* error)
@@ -931,7 +956,7 @@ Il2CppMonoType* il2cpp_mono_reflection_get_type_checked(Il2CppMonoImage* rootima
 
 Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_method_checked(Il2CppMonoMethod* method, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
+	mono_error_init(error);
 	return NULL;
 }
 
@@ -943,13 +968,13 @@ Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_class_checked(Il2CppMono
 
 Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_property_checked(Il2CppMonoClass* klass, Il2CppMonoProperty* property, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
+	mono_error_init(error);
 	return NULL;
 }
 
 Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_field_checked(Il2CppMonoClass* klass, Il2CppMonoClassField* field, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
+	mono_error_init(error);
 	return NULL;
 }
 
@@ -1641,6 +1666,28 @@ const char** il2cpp_get_source_files_for_type(Il2CppMonoClass *klass, int *count
 {
 	return il2cpp::utils::Debugger::GetTypeSourceFiles((Il2CppClass*)klass, *count);
 }
+
+Il2CppMonoMethod* il2cpp_method_get_generic_definition(Il2CppMonoMethodInflated *imethod)
+{
+	MethodInfo *method = (MethodInfo*)imethod;
+
+	if (!method->is_inflated || method->is_generic)
+		return NULL;
+
+	return (Il2CppMonoMethod*)((MethodInfo*)imethod)->genericMethod->methodDefinition;
+}
+
+
+Il2CppMonoGenericInst* il2cpp_method_get_generic_class_inst(Il2CppMonoMethodInflated *imethod)
+{
+	MethodInfo *method = (MethodInfo*)imethod;
+
+	if (!method->is_inflated || method->is_generic)
+		return NULL;
+
+	return (Il2CppMonoGenericInst*)method->genericMethod->context.class_inst;
+}
+
 
 }
 


### PR DESCRIPTION
* Changes to get the MethodInfo test passing (without custom method attribute support,
which is implemented much different in IL2CPP than in Mono).
* Fixing il2cpp_mono_method_signature().  We were calling vm::Method::GetGenericParamCount()
to get the generic parameter count, but this only works for uninflated generics and we
need a solution that gives the count for inflated generics as well.
* Implemented the CMD_TYPE_GET_PROPERTIES command.
* Changes for enabled tests: BreakpointAlreadyJITted, FieldInfo, StackAlloc_Breakpoints_Regress2775,
MakeGenericMethod