### PR TITLE
IL2CPP debugger unit tests

### DIFF
--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -67,7 +67,8 @@
 #define VM_OBJECT_GET_DOMAIN(object) il2cpp_mono_domain_get()
 #define VM_OBJECT_GET_CLASS(object) il2cpp_object_get_class(object)
 #define VM_OBJECT_GET_TYPE(object) il2cpp_mono_object_get_type(object)
-#define VM_GENERIC_CLASS_GET_INST(klass) il2cpp_generic_class_get_inst(klass)
+#define VM_GENERIC_CLASS_GET_INST(gklass) il2cpp_generic_class_get_inst(gklass)
+#define VM_GENERIC_CLASS_GET_CONTAINER_CLASS(gklass) il2cpp_generic_class_get_container_class(gklass)
 #define VM_GENERIC_CONTAINER_GET_TYPE_ARGC(container) il2cpp_generic_container_get_type_argc(container)
 #define VM_GENERIC_INST_TYPE_ARGC(inst) il2cpp_generic_inst_type_argc(inst)
 #define VM_GENERIC_INST_TYPE_ARG(inst, i) il2cpp_generic_inst_type_arg(inst, i)
@@ -141,7 +142,8 @@
 #define VM_OBJECT_GET_CLASS(object) ((MonoObject*)object)->vtable->klass
 #define VM_OBJECT_GET_TYPE(object) ((MonoReflectionType*)object->vtable->type)->type
 #define VM_GENERIC_CONTAINER_GET_TYPE_ARGC(container) container->type_argc
-#define VM_GENERIC_CLASS_GET_INST(klass) (klass)->context.class_inst
+#define VM_GENERIC_CLASS_GET_INST(gklass) (gklass)->context.class_inst
+#define VM_GENERIC_CLASS_GET_CONTAINER_CLASS(gklass) (gklass)->container_class
 #define VM_GENERIC_INST_TYPE_ARGC(inst) (inst)->type_argc
 #define VM_GENERIC_INST_TYPE_ARG(inst, i) (inst)->type_argv[i]
 #define VM_DEFAULTS_OBJECT_CLASS mono_defaults.object_class
@@ -655,5 +657,6 @@ uint32_t il2cpp_internal_thread_get_state(Il2CppMonoInternalThread* thread);
 il2cpp_internal_thread_get_threadpool_thread(Il2CppMonoInternalThread* thread);
 Il2CppMonoMethod* il2cpp_method_get_generic_definition(Il2CppMonoMethodInflated *imethod);
 Il2CppMonoGenericInst* il2cpp_method_get_generic_class_inst(Il2CppMonoMethodInflated *imethod);
+Il2CppMonoClass* il2cpp_generic_class_get_container_class(Il2CppMonoGenericClass *gclass);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -12,6 +12,7 @@
 #include "vm/Domain.h"
 #include "vm/Field.h"
 #include "vm/GenericContainer.h"
+#include "vm/GenericClass.h"
 #include "vm/Image.h"
 #include "vm/Method.h"
 #include "vm/Object.h"
@@ -873,6 +874,10 @@ Il2CppMonoString* il2cpp_mono_ldstr_checked(Il2CppMonoDomain* domain, Il2CppMono
 Il2CppMonoObject* il2cpp_mono_runtime_try_invoke(Il2CppMonoMethod* method, void* obj, void** params, Il2CppMonoObject** exc, MonoError* error)
 {
 	mono_error_init(error);
+
+	if (((MethodInfo*)method)->declaring_type->valuetype)
+		obj = static_cast<Il2CppObject*>(obj) - 1;
+
 	return (Il2CppMonoObject*)il2cpp::vm::Runtime::Invoke((MethodInfo*)method, obj, params, (Il2CppException**)exc);
 }
 
@@ -975,7 +980,7 @@ Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_method_checked(Il2CppMon
 
 Il2CppMonoCustomAttrInfo* il2cpp_mono_custom_attrs_from_class_checked(Il2CppMonoClass* klass, MonoError* error)
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
+	mono_error_init(error);
 	return NULL;
 }
 
@@ -1715,6 +1720,10 @@ Il2CppMonoGenericInst* il2cpp_method_get_generic_class_inst(Il2CppMonoMethodInfl
 	return (Il2CppMonoGenericInst*)method->genericMethod->context.class_inst;
 }
 
+Il2CppMonoClass* il2cpp_generic_class_get_container_class(Il2CppMonoGenericClass *gclass)
+{
+	return (Il2CppMonoClass*)il2cpp::vm::GenericClass::GetTypeDefinition((Il2CppGenericClass*)gclass);
+}
 
 }
 


### PR DESCRIPTION
* Adding a simplification to mono_domain_get_assemblies_iter in debugger-agent.c that was previously
suggested but didn't make it into the PR.
* Fixing MOD_KIND_SOURCE_FILE_ONLY event request filter in debugger agent.  Switched
to using the new type->source-files map to greatly improve the speed of looking for
a source file in all of the loaded types, converting string to lower case for
case insensitive comparison, fixed the test to search for the correct path.
* Removing mono_object_box calls from do_invoke_method in debugger agent. Replacing
this with a pointer manipulation in il2cpp_mono_runtime_try_invoke(), the same one
that the il2cpp c-api uses for calls on value types.  This fixes the InvokeVType test.