### PR TITLE
Mono Bleeding Edge fixes for 2017.3

### DIFF
--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -2071,5 +2071,16 @@ namespace MonoTests.System
 			var uri = new Uri ("https://_foo/bar.html");
 			Assert.AreEqual ("https", uri.Scheme);
 		}
+
+		[Test]
+		public void ImplicitUnixFileWithUnicodeGetAbsoluleUri ()
+		{
+			if (isWin32)
+				Assert.Ignore ();
+
+			string escFilePath = "/Users/Текст.txt";
+			string escUrl = new Uri (escFilePath, UriKind.Absolute).AbsoluteUri;
+			Assert.AreEqual ("file:///Users/%D0%A2%D0%B5%D0%BA%D1%81%D1%82.txt", escUrl);
+		}
 	}
 }

--- a/mcs/class/referencesource/System/net/System/URI.cs
+++ b/mcs/class/referencesource/System/net/System/URI.cs
@@ -3969,13 +3969,6 @@ namespace System {
                 if (hasUnicode && iriParsing && hostNotUnicodeNormalized){
                     flags |= Flags.HostUnicodeNormalized;// no host
 
-#if MONO
-                    // I am not certain this is the best fix but for Unix implicit paths with
-                    // unicode characters the host must be valid (null or non-empty) as
-                    // CreateUriInfo assumes. This should happen only for paths like /foo/path-with-unicode
-                    if (newHost.Length == 0 && (flags & Flags.BasicHostType) != 0)
-                        newHost = null;
-#endif
                 }
 
                  return idx;

--- a/mcs/errors/cs0164-2.cs
+++ b/mcs/errors/cs0164-2.cs
@@ -1,0 +1,17 @@
+// CS0164: This label has not been referenced
+// Line: 13
+// Compiler options: -warnaserror -warn:2
+
+class X {
+	static void Main () {
+	}
+
+	static void foo (bool b, out int c) {
+		if (b) {
+			goto LabelA;
+		}
+		LabelA: LabelB:
+			c = 0;	// Out parameter necessary to force reevaluation of LabelA
+			return;
+	}
+}

--- a/mcs/mcs/flowanalysis.cs
+++ b/mcs/mcs/flowanalysis.cs
@@ -678,7 +678,7 @@ namespace Mono.CSharp
 				large_bits[index >> 5] |= (1 << (index & 31));
 		}
 
-		static bool IsEqual (DefiniteAssignmentBitSet a, DefiniteAssignmentBitSet b)
+		public static bool IsEqual (DefiniteAssignmentBitSet a, DefiniteAssignmentBitSet b)
 		{
 			if (a.large_bits == null)
 				return (a.bits & ~copy_on_write_flag) == (b.bits & ~copy_on_write_flag);

--- a/mcs/mcs/statement.cs
+++ b/mcs/mcs/statement.cs
@@ -271,10 +271,13 @@ namespace Mono.CSharp {
 
 			fc.BranchDefiniteAssignment (fc.DefiniteAssignmentOnTrue);
 			var labels = fc.CopyLabelStack ();
+			var assigmentBefore = new DefiniteAssignmentBitSet(fc.DefiniteAssignment);
 
 			var res = TrueStatement.FlowAnalysis (fc);
 
-			fc.SetLabelStack (labels);
+			// If walking through new labels didn't change the assignment we don't need to flush the labels.
+			if (!DefiniteAssignmentBitSet.IsEqual(fc.DefiniteAssignment, assigmentBefore))
+				fc.SetLabelStack (labels);
 
 			if (FalseStatement == null) {
 
@@ -294,7 +297,11 @@ namespace Mono.CSharp {
 				fc.DefiniteAssignment = da_false;
 
 				res = FalseStatement.FlowAnalysis (fc);
-				fc.SetLabelStack (labels);
+
+				// If walking through new labels didn't change the assignment we don't need to flush the labels.
+				if (!DefiniteAssignmentBitSet.IsEqual(fc.DefiniteAssignment, assigmentBefore))
+					fc.SetLabelStack (labels);
+
 				return res;
 			}
 
@@ -304,7 +311,9 @@ namespace Mono.CSharp {
 
 			res &= FalseStatement.FlowAnalysis (fc);
 
-			fc.SetLabelStack (labels);
+			// If walking through new labels didn't change the assignment we don't need to flush the labels.
+			if (!DefiniteAssignmentBitSet.IsEqual(fc.DefiniteAssignment, assigmentBefore))
+				fc.SetLabelStack (labels);
 
 			if (!TrueStatement.IsUnreachable) {
 				if (false_returns || FalseStatement.IsUnreachable)

--- a/mcs/mcs/statement.cs
+++ b/mcs/mcs/statement.cs
@@ -1499,6 +1499,7 @@ namespace Mono.CSharp {
 		string name;
 		bool defined;
 		bool referenced;
+		bool reportedNotReferenced;
 		Label label;
 		Block block;
 		
@@ -1549,7 +1550,8 @@ namespace Mono.CSharp {
 
 		protected override bool DoFlowAnalysis (FlowAnalysisContext fc)
 		{
-			if (!referenced) {
+			if (!referenced && !reportedNotReferenced) {
+				reportedNotReferenced = true;
 				fc.Report.Warning (164, 2, loc, "This label has not been referenced");
 			}
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1898,6 +1898,8 @@ mono_assembly_load_friends (MonoAssembly* ass)
 		MonoCustomAttrEntry *attr = &attrs->attrs [i];
 		MonoAssemblyName *aname;
 		const gchar *data;
+		uint32_t data_length;
+		gchar *data_with_terminator;
 		/* Do some sanity checking */
 		if (!attr->ctor || attr->ctor->klass != mono_class_try_get_internals_visible_class ())
 			continue;
@@ -1907,14 +1909,17 @@ mono_assembly_load_friends (MonoAssembly* ass)
 		/* 0xFF means null string, see custom attr format */
 		if (data [0] != 1 || data [1] != 0 || (data [2] & 0xFF) == 0xFF)
 			continue;
-		mono_metadata_decode_value (data + 2, &data);
+		data_length = mono_metadata_decode_value (data + 2, &data);
+		data_with_terminator = (char *)g_memdup (data, data_length + 1);
+		data_with_terminator[data_length] = 0;
 		aname = g_new0 (MonoAssemblyName, 1);
 		/*g_print ("friend ass: %s\n", data);*/
-		if (mono_assembly_name_parse_full (data, aname, TRUE, NULL, NULL)) {
+		if (mono_assembly_name_parse_full (data_with_terminator, aname, TRUE, NULL, NULL)) {
 			list = g_slist_prepend (list, aname);
 		} else {
 			g_free (aname);
 		}
+		g_free (data_with_terminator);
 	}
 	mono_custom_attrs_free (attrs);
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1038,6 +1038,9 @@ MonoMethod *
 mono_class_inflate_generic_method_checked (MonoMethod *method, MonoGenericContext *context, MonoError *error);
 
 MonoImageSet *
+mono_metadata_get_image_set_for_class (MonoClass *klass);
+
+MonoImageSet *
 mono_metadata_get_image_set_for_method (MonoMethodInflated *method);
 
 MONO_API MonoMethodSignature *

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -81,6 +81,8 @@ static void mono_generic_class_setup_parent (MonoClass *klass, MonoClass *gklass
 
 static gboolean mono_class_set_failure (MonoClass *klass, MonoErrorBoxed *boxed_error);
 
+static gboolean class_kind_may_contain_generic_instances (MonoTypeKind kind);
+
 
 /*
 We use gclass recording to allow recursive system f types to be referenced by a parent.
@@ -6224,20 +6226,33 @@ mono_ptr_class_get (MonoType *type)
 	MonoClass *el_class;
 	MonoImage *image;
 	char *name;
+	MonoImageSet* image_set;
 
 	el_class = mono_class_from_mono_type (type);
 	image = el_class->image;
+	image_set  = class_kind_may_contain_generic_instances (el_class->class_kind) ? mono_metadata_get_image_set_for_class (el_class) : NULL;
 
-	mono_image_lock (image);
-	if (image->ptr_cache) {
-		if ((result = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
-			mono_image_unlock (image);
-			return result;
+	if (image_set) {
+		mono_image_set_lock (image_set);
+		if (image_set->ptr_cache) {
+			if ((result = (MonoClass *)g_hash_table_lookup (image_set->ptr_cache, el_class))) {
+				mono_image_set_unlock (image_set);
+				return result;
+			}
 		}
+		mono_image_set_unlock (image_set);
+	} else {
+		mono_image_lock (image);
+		if (image->ptr_cache) {
+			if ((result = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
+				mono_image_unlock (image);
+				return result;
+			}
+		}
+		mono_image_unlock (image);
 	}
-	mono_image_unlock (image);
 	
-	result = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassPointer));
+	result = image_set ? (MonoClass *)mono_image_set_alloc0 (image_set, sizeof (MonoClassPointer)) : (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassPointer));
 
 	classes_size += sizeof (MonoClassPointer);
 	++class_pointer_count;
@@ -6245,7 +6260,7 @@ mono_ptr_class_get (MonoType *type)
 	result->parent = NULL; /* no parent for PTR types */
 	result->name_space = el_class->name_space;
 	name = g_strdup_printf ("%s*", el_class->name);
-	result->name = mono_image_strdup (image, name);
+	result->name = image_set ? mono_image_set_strdup (image_set, name) : mono_image_strdup (image, name);
 	result->class_kind = MONO_CLASS_POINTER;
 	g_free (name);
 
@@ -6264,19 +6279,36 @@ mono_ptr_class_get (MonoType *type)
 
 	mono_class_setup_supertypes (result);
 
-	mono_image_lock (image);
-	if (image->ptr_cache) {
-		MonoClass *result2;
-		if ((result2 = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
-			mono_image_unlock (image);
-			mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
-			return result2;
+	if (image_set) {
+		mono_image_set_lock (image_set);
+		if (image_set->ptr_cache) {
+			MonoClass *result2;
+			if ((result2 = (MonoClass *)g_hash_table_lookup (image_set->ptr_cache, el_class))) {
+				mono_image_set_unlock (image_set);
+				mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
+				return result2;
+			}
 		}
+		else {
+			image_set->ptr_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		}
+		g_hash_table_insert (image_set->ptr_cache, el_class, result);
+		mono_image_set_unlock (image_set);
 	} else {
-		image->ptr_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		mono_image_lock (image);
+		if (image->ptr_cache) {
+			MonoClass *result2;
+			if ((result2 = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
+				mono_image_unlock (image);
+				mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
+				return result2;
+			}
+		} else {
+			image->ptr_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		}
+		g_hash_table_insert (image->ptr_cache, el_class, result);
+		mono_image_unlock (image);
 	}
-	g_hash_table_insert (image->ptr_cache, el_class, result);
-	mono_image_unlock (image);
 
 	mono_profiler_class_loaded (result, MONO_PROFILE_OK);
 
@@ -6481,6 +6513,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	GSList *list, *rootlist = NULL;
 	int nsize;
 	char *name;
+	MonoImageSet* image_set;
 
 	g_assert (rank <= 255);
 
@@ -6489,33 +6522,53 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		bounded = FALSE;
 
 	image = eclass->image;
+	image_set = class_kind_may_contain_generic_instances (eclass->class_kind) ? mono_metadata_get_image_set_for_class (eclass) : NULL;
 
 	/* Check cache */
 	cached = NULL;
 	if (rank == 1 && !bounded) {
-		/*
-		 * This case is very frequent not just during compilation because of calls
-		 * from mono_class_from_mono_type (), mono_array_new (),
-		 * Array:CreateInstance (), etc, so use a separate cache + a separate lock.
-		 */
-		mono_os_mutex_lock (&image->szarray_cache_lock);
-		if (!image->szarray_cache)
-			image->szarray_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
-		cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
-		mono_os_mutex_unlock (&image->szarray_cache_lock);
-	} else {
-		mono_loader_lock ();
-		if (!image->array_cache)
-			image->array_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
-		rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
-		for (list = rootlist; list; list = list->next) {
-			k = (MonoClass *)list->data;
-			if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
-				cached = k;
-				break;
-			}
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			cached = (MonoClass *)g_hash_table_lookup (image_set->szarray_cache, eclass);
+			mono_image_set_unlock (image_set);
+		} else {
+			/*
+			 * This case is very frequent not just during compilation because of calls
+			 * from mono_class_from_mono_type (), mono_array_new (),
+			 * Array:CreateInstance (), etc, so use a separate cache + a separate lock.
+			 */
+			mono_os_mutex_lock (&image->szarray_cache_lock);
+			if (!image->szarray_cache)
+				image->szarray_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+			cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
+			mono_os_mutex_unlock (&image->szarray_cache_lock);
 		}
-		mono_loader_unlock ();
+	} else {
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			rootlist = (GSList *)g_hash_table_lookup (image_set->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
+			}
+			mono_image_set_unlock (image_set);
+		} else {
+			mono_loader_lock ();
+			if (!image->array_cache)
+				image->array_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+			rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
+			}
+			mono_loader_unlock ();
+		}
 	}
 	if (cached)
 		return cached;
@@ -6524,7 +6577,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	if (!parent->inited)
 		mono_class_init (parent);
 
-	klass = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassArray));
+	klass = image_set ? (MonoClass *)mono_image_set_alloc0 (image_set, sizeof (MonoClassArray)) : (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassArray));
 
 	klass->image = image;
 	klass->name_space = eclass->name_space;
@@ -6540,7 +6593,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		name [nsize + rank] = '*';
 	name [nsize + rank + bounded] = ']';
 	name [nsize + rank + bounded + 1] = 0;
-	klass->name = mono_image_strdup (image, name);
+	klass->name = image_set ? mono_image_set_strdup (image_set, name) : mono_image_strdup (image, name);
 	g_free (name);
 
 	klass->type_token = 0;
@@ -6611,7 +6664,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	klass->element_class = eclass;
 
 	if ((rank > 1) || bounded) {
-		MonoArrayType *at = (MonoArrayType *)mono_image_alloc0 (image, sizeof (MonoArrayType));
+		MonoArrayType *at = image_set ? (MonoArrayType *)mono_image_set_alloc0 (image_set, sizeof (MonoArrayType)) : (MonoArrayType *)mono_image_alloc0 (image, sizeof (MonoArrayType));
 		klass->byval_arg.type = MONO_TYPE_ARRAY;
 		klass->byval_arg.data.array = at;
 		at->eklass = eclass;
@@ -6629,16 +6682,35 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	/* Check cache again */
 	cached = NULL;
 	if (rank == 1 && !bounded) {
-		mono_os_mutex_lock (&image->szarray_cache_lock);
-		cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
-		mono_os_mutex_unlock (&image->szarray_cache_lock);
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			cached = (MonoClass *)g_hash_table_lookup (image_set->szarray_cache, eclass);
+			mono_image_set_unlock (image_set);
+		} else {
+			mono_os_mutex_lock (&image->szarray_cache_lock);
+			cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
+			mono_os_mutex_unlock (&image->szarray_cache_lock);
+		}
 	} else {
-		rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
-		for (list = rootlist; list; list = list->next) {
-			k = (MonoClass *)list->data;
-			if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
-				cached = k;
-				break;
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			rootlist = (GSList *)g_hash_table_lookup (image_set->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
+			}
+			mono_image_set_unlock (image_set);
+		} else {
+			rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
 			}
 		}
 	}
@@ -6653,12 +6725,25 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	++class_array_count;
 
 	if (rank == 1 && !bounded) {
-		mono_os_mutex_lock (&image->szarray_cache_lock);
-		g_hash_table_insert (image->szarray_cache, eclass, klass);
-		mono_os_mutex_unlock (&image->szarray_cache_lock);
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			g_hash_table_insert (image_set->szarray_cache, eclass, klass);
+			mono_image_set_unlock (image_set);
+		} else {
+			mono_os_mutex_lock (&image->szarray_cache_lock);
+			g_hash_table_insert (image->szarray_cache, eclass, klass);
+			mono_os_mutex_unlock (&image->szarray_cache_lock);
+		}
 	} else {
-		list = g_slist_append (rootlist, klass);
-		g_hash_table_insert (image->array_cache, eclass, list);
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			list = g_slist_append (rootlist, klass);
+			g_hash_table_insert (image_set->array_cache, eclass, list);
+			mono_image_set_unlock (image_set);
+		} else {
+			list = g_slist_append (rootlist, klass);
+			g_hash_table_insert (image->array_cache, eclass, list);
+		}
 	}
 
 	mono_loader_unlock ();
@@ -10794,4 +10879,13 @@ retry:
 
 	g_assert (result != NULL);
 	return result;
+}
+
+
+static gboolean
+class_kind_may_contain_generic_instances (MonoTypeKind kind)
+{
+	/* classes of type generic inst may contain generic arguments from other images,
+	 * as well as arrays and pointers whose element types (recursively) may be a generic inst */
+	return (kind == MONO_CLASS_GINST || kind == MONO_CLASS_ARRAY || kind == MONO_CLASS_POINTER);
 }

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2212,8 +2212,12 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	}
 
 	/*valuetypes can't be neither bigger than 1Mb or empty. */
-	if (klass->valuetype && (klass->instance_size <= 0 || klass->instance_size > (0x100000 + sizeof (MonoObject))))
-		mono_class_set_type_load_failure (klass, "Value type instance size (%d) cannot be zero, negative, or bigger than 1Mb", klass->instance_size);
+	if (klass->valuetype && (klass->instance_size <= 0 || klass->instance_size > (0x100000 + sizeof (MonoObject)))) {
+		/* Special case compiler generated types */
+		/* Hard to check for [CompilerGenerated] here */
+		if (!strstr (klass->name, "StaticArrayInitTypeSize") && !strstr (klass->name, "$ArrayType"))
+			mono_class_set_type_load_failure (klass, "Value type instance size (%d) cannot be zero, negative, or bigger than 1Mb", klass->instance_size);
+	}
 
 	/* Publish the data */
 	mono_loader_lock ();

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -410,7 +410,17 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 	See mono/tests/generic-type-load-exception.2.il
 	FIXME we should better report this error to the caller
 	 */
-	if (!klass->methods || mono_class_has_failure (klass)) {
+	if (mono_class_has_failure (klass)) {
+		MonoError class_failure_error;
+		error_init (&class_failure_error);
+		mono_error_set_for_class_failure (&class_failure_error, klass);
+		mono_error_set_type_load_class (error, klass, "%s", mono_error_get_message (&class_failure_error));
+		mono_error_cleanup (&class_failure_error);
+
+		return NULL;
+	}
+
+	if (!klass->methods) {
 		mono_error_set_type_load_class (error, klass, "Could not find method due to a type load error"); //FIXME get the error from the class 
 
 		return NULL;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -429,6 +429,9 @@ typedef struct {
 	// Generic-specific caches
 	GHashTable *gclass_cache, *ginst_cache, *gmethod_cache, *gsignature_cache;
 
+	/* mirror caches of ones already on MonoImage. These ones contain generics */
+	GHashTable *szarray_cache, *array_cache, *ptr_cache;
+
 	MonoWrapperCaches wrapper_caches;
 
 	mono_mutex_t    lock;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2468,6 +2468,9 @@ get_image_set (MonoImage **images, int nimages)
 		set->gmethod_cache = g_hash_table_new_full (inflated_method_hash, inflated_method_equal, NULL, (GDestroyNotify)free_inflated_method);
 		set->gsignature_cache = g_hash_table_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature);
 
+		set->szarray_cache = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, NULL);
+		set->array_cache = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, NULL);
+
 		for (i = 0; i < nimages; ++i)
 			set->images [i]->image_sets = g_slist_prepend (set->images [i]->image_sets, set);
 
@@ -2493,6 +2496,11 @@ delete_image_set (MonoImageSet *set)
 	g_hash_table_destroy (set->ginst_cache);
 	g_hash_table_destroy (set->gmethod_cache);
 	g_hash_table_destroy (set->gsignature_cache);
+
+	g_hash_table_destroy (set->szarray_cache);
+	g_hash_table_destroy (set->array_cache);
+	if (set->ptr_cache)
+		g_hash_table_destroy (set->ptr_cache);
 
 	mono_wrapper_caches_free (&set->wrapper_caches);
 
@@ -2788,7 +2796,18 @@ inflated_signature_in_image (gpointer key, gpointer value, gpointer data)
 	return signature_in_image (sig->sig, image) ||
 		(sig->context.class_inst && ginst_in_image (sig->context.class_inst, image)) ||
 		(sig->context.method_inst && ginst_in_image (sig->context.method_inst, image));
-}	
+}
+
+static gboolean
+class_in_image (gpointer key, gpointer value, gpointer data)
+{
+	MonoImage *image = (MonoImage *)data;
+	MonoClass *klass = (MonoClass *)key;
+
+	g_assert (type_in_image (&klass->byval_arg, image));
+
+	return TRUE;
+}
 
 static void
 check_gmethod (gpointer key, gpointer value, gpointer data)
@@ -2852,6 +2871,11 @@ mono_metadata_clean_for_image (MonoImage *image)
 		g_hash_table_foreach_steal (set->ginst_cache, steal_ginst_in_image, &ginst_data);
 		g_hash_table_foreach_remove (set->gmethod_cache, inflated_method_in_image, image);
 		g_hash_table_foreach_remove (set->gsignature_cache, inflated_signature_in_image, image);
+
+		g_hash_table_foreach_steal (set->szarray_cache, class_in_image, image);
+		g_hash_table_foreach_steal (set->array_cache, class_in_image, image);
+		if (set->ptr_cache)
+			g_hash_table_foreach_steal (set->ptr_cache, class_in_image, image);
 		mono_image_set_unlock (set);
 	}
 
@@ -2951,6 +2975,20 @@ mono_metadata_get_inflated_signature (MonoMethodSignature *sig, MonoGenericConte
 	mono_image_set_unlock (set);
 
 	return res->sig;
+}
+
+MonoImageSet *
+mono_metadata_get_image_set_for_class (MonoClass *klass)
+{
+	MonoImageSet *set;
+	CollectData image_set_data;
+
+	collect_data_init (&image_set_data);
+	collect_type_images (&klass->byval_arg, &image_set_data);
+	set = get_image_set (image_set_data.images, image_set_data.nimages);
+	collect_data_free (&image_set_data);
+
+	return set;
 }
 
 MonoImageSet *


### PR DESCRIPTION
case 957072 - Improve TypeLoadException messages
case 907918 - Fix URI processing on OSX
case 945353 - Fix InternalsVisibleTo
case 962711 - Fix value types larger than 1MB
case 967206 - Fix random crash due to memory corruption on domain reload
case 948492 - Fix mcs hanging while compiling script