### PR TITLE
MonoBleedingEdge fixes for 2017.2

### DIFF
--- a/mcs/class/System/Test/System/UriTest.cs
+++ b/mcs/class/System/Test/System/UriTest.cs
@@ -2071,5 +2071,16 @@ namespace MonoTests.System
 			var uri = new Uri ("https://_foo/bar.html");
 			Assert.AreEqual ("https", uri.Scheme);
 		}
+
+		[Test]
+		public void ImplicitUnixFileWithUnicodeGetAbsoluleUri ()
+		{
+			if (isWin32)
+				Assert.Ignore ();
+
+			string escFilePath = "/Users/Текст.txt";
+			string escUrl = new Uri (escFilePath, UriKind.Absolute).AbsoluteUri;
+			Assert.AreEqual ("file:///Users/%D0%A2%D0%B5%D0%BA%D1%81%D1%82.txt", escUrl);
+		}
 	}
 }

--- a/mcs/class/referencesource/System/net/System/URI.cs
+++ b/mcs/class/referencesource/System/net/System/URI.cs
@@ -3969,13 +3969,6 @@ namespace System {
                 if (hasUnicode && iriParsing && hostNotUnicodeNormalized){
                     flags |= Flags.HostUnicodeNormalized;// no host
 
-#if MONO
-                    // I am not certain this is the best fix but for Unix implicit paths with
-                    // unicode characters the host must be valid (null or non-empty) as
-                    // CreateUriInfo assumes. This should happen only for paths like /foo/path-with-unicode
-                    if (newHost.Length == 0 && (flags & Flags.BasicHostType) != 0)
-                        newHost = null;
-#endif
                 }
 
                  return idx;

--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -105,6 +105,10 @@ typedef enum
 #define AMD64_ARGUMENT_REGS ((1<<AMD64_RDX) | (1<<AMD64_RCX) | (1<<AMD64_R8) | (1<<AMD64_R9))
 #define AMD64_IS_ARGUMENT_REG(reg) (AMD64_ARGUMENT_REGS & (1 << (reg)))
 
+/* xmm0-xmm3 for standard calling convention, additionally xmm4-xmm5 for __vectorcall (not currently used) */
+#define AMD64_ARGUMENT_XREGS ((1<<AMD64_XMM0) | (1<<AMD64_XMM1) | (1<<AMD64_XMM2) | (1<<AMD64_XMM3) | (1<<AMD64_XMM4) | (1<<AMD64_XMM5))
+#define AMD64_IS_ARGUMENT_XREG(reg) (AMD64_ARGUMENT_XREGS & (1 << (reg)))
+
 #define AMD64_CALLEE_SAVED_REGS ((1<<AMD64_RDI) | (1<<AMD64_RSI) | (1<<AMD64_RBX) | (1<<AMD64_R12) | (1<<AMD64_R13) | (1<<AMD64_R14) | (1<<AMD64_R15) | (1<<AMD64_RBP))
 #define AMD64_IS_CALLEE_SAVED_REG(reg) (AMD64_CALLEE_SAVED_REGS & (1 << (reg)))
 #else
@@ -113,6 +117,9 @@ typedef enum
 
 #define AMD64_ARGUMENT_REGS ((1<<AMD64_RDI) | (1<<AMD64_RSI) | (1<<AMD64_RDX) | (1<<AMD64_RCX) | (1<<AMD64_R8) | (1<<AMD64_R9))
 #define AMD64_IS_ARGUMENT_REG(reg) (AMD64_ARGUMENT_REGS & (1 << (reg)))
+
+#define AMD64_ARGUMENT_XREGS ((1<<AMD64_XMM0) | (1<<AMD64_XMM1) | (1<<AMD64_XMM2) | (1<<AMD64_XMM3) | (1<<AMD64_XMM4) | (1<<AMD64_XMM5) | (1<<AMD64_XMM6) | (1<<AMD64_XMM7))
+#define AMD64_IS_ARGUMENT_XREG(reg) (AMD64_ARGUMENT_XREGS & (1 << (reg)))
 
 #define AMD64_CALLEE_SAVED_REGS ((1<<AMD64_RBX) | (1<<AMD64_R12) | (1<<AMD64_R13) | (1<<AMD64_R14) | (1<<AMD64_R15) | (1<<AMD64_RBP))
 #define AMD64_IS_CALLEE_SAVED_REG(reg) (AMD64_CALLEE_SAVED_REGS & (1 << (reg)))
@@ -537,6 +544,17 @@ typedef union {
 		amd64_codegen_post(inst); \
 	} while (0)
 
+#define amd64_movdqu_reg_membase(inst,reg,basereg,disp)	\
+	do {	\
+		amd64_codegen_pre(inst); \
+		x86_prefix((inst), 0xf3); \
+		amd64_emit_rex(inst, 0, (reg), 0, (basereg)); \
+		*(inst)++ = (unsigned char)0x0f;	\
+		*(inst)++ = (unsigned char)0x6f;	\
+		x86_membase_emit ((inst), (reg) & 0x7, (basereg) & 0x7, (disp));	\
+		amd64_codegen_post(inst); \
+	} while (0)
+
 #define amd64_movsd_reg_membase(inst,reg,basereg,disp)	\
 	do {	\
 		amd64_codegen_pre(inst); \
@@ -555,6 +573,17 @@ typedef union {
 		amd64_emit_rex(inst, 0, (reg), 0, (basereg)); \
 		*(inst)++ = (unsigned char)0x0f;	\
 		*(inst)++ = (unsigned char)0x10;	\
+		x86_membase_emit ((inst), (reg) & 0x7, (basereg) & 0x7, (disp));	\
+		amd64_codegen_post(inst); \
+	} while (0)
+
+#define amd64_movdqu_membase_reg(inst,basereg,disp,reg)	\
+	do {	\
+		amd64_codegen_pre(inst); \
+		x86_prefix((inst), 0xf3); \
+		amd64_emit_rex(inst, 0, (reg), 0, (basereg)); \
+		*(inst)++ = (unsigned char)0x0f;	\
+		*(inst)++ = (unsigned char)0x7f;	\
 		x86_membase_emit ((inst), (reg) & 0x7, (basereg) & 0x7, (disp));	\
 		amd64_codegen_post(inst); \
 	} while (0)

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1898,6 +1898,8 @@ mono_assembly_load_friends (MonoAssembly* ass)
 		MonoCustomAttrEntry *attr = &attrs->attrs [i];
 		MonoAssemblyName *aname;
 		const gchar *data;
+		uint32_t data_length;
+		gchar *data_with_terminator;
 		/* Do some sanity checking */
 		if (!attr->ctor || attr->ctor->klass != mono_class_try_get_internals_visible_class ())
 			continue;
@@ -1907,14 +1909,17 @@ mono_assembly_load_friends (MonoAssembly* ass)
 		/* 0xFF means null string, see custom attr format */
 		if (data [0] != 1 || data [1] != 0 || (data [2] & 0xFF) == 0xFF)
 			continue;
-		mono_metadata_decode_value (data + 2, &data);
+		data_length = mono_metadata_decode_value (data + 2, &data);
+		data_with_terminator = (char *)g_memdup (data, data_length + 1);
+		data_with_terminator[data_length] = 0;
 		aname = g_new0 (MonoAssemblyName, 1);
 		/*g_print ("friend ass: %s\n", data);*/
-		if (mono_assembly_name_parse_full (data, aname, TRUE, NULL, NULL)) {
+		if (mono_assembly_name_parse_full (data_with_terminator, aname, TRUE, NULL, NULL)) {
 			list = g_slist_prepend (list, aname);
 		} else {
 			g_free (aname);
 		}
+		g_free (data_with_terminator);
 	}
 	mono_custom_attrs_free (attrs);
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1038,6 +1038,9 @@ MonoMethod *
 mono_class_inflate_generic_method_checked (MonoMethod *method, MonoGenericContext *context, MonoError *error);
 
 MonoImageSet *
+mono_metadata_get_image_set_for_class (MonoClass *klass);
+
+MonoImageSet *
 mono_metadata_get_image_set_for_method (MonoMethodInflated *method);
 
 MONO_API MonoMethodSignature *

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -81,6 +81,8 @@ static void mono_generic_class_setup_parent (MonoClass *klass, MonoClass *gklass
 
 static gboolean mono_class_set_failure (MonoClass *klass, MonoErrorBoxed *boxed_error);
 
+static gboolean class_kind_may_contain_generic_instances (MonoTypeKind kind);
+
 
 /*
 We use gclass recording to allow recursive system f types to be referenced by a parent.
@@ -6228,20 +6230,33 @@ mono_ptr_class_get (MonoType *type)
 	MonoClass *el_class;
 	MonoImage *image;
 	char *name;
+	MonoImageSet* image_set;
 
 	el_class = mono_class_from_mono_type (type);
 	image = el_class->image;
+	image_set  = class_kind_may_contain_generic_instances (el_class->class_kind) ? mono_metadata_get_image_set_for_class (el_class) : NULL;
 
-	mono_image_lock (image);
-	if (image->ptr_cache) {
-		if ((result = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
-			mono_image_unlock (image);
-			return result;
+	if (image_set) {
+		mono_image_set_lock (image_set);
+		if (image_set->ptr_cache) {
+			if ((result = (MonoClass *)g_hash_table_lookup (image_set->ptr_cache, el_class))) {
+				mono_image_set_unlock (image_set);
+				return result;
+			}
 		}
+		mono_image_set_unlock (image_set);
+	} else {
+		mono_image_lock (image);
+		if (image->ptr_cache) {
+			if ((result = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
+				mono_image_unlock (image);
+				return result;
+			}
+		}
+		mono_image_unlock (image);
 	}
-	mono_image_unlock (image);
 	
-	result = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassPointer));
+	result = image_set ? (MonoClass *)mono_image_set_alloc0 (image_set, sizeof (MonoClassPointer)) : (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassPointer));
 
 	classes_size += sizeof (MonoClassPointer);
 	++class_pointer_count;
@@ -6249,7 +6264,7 @@ mono_ptr_class_get (MonoType *type)
 	result->parent = NULL; /* no parent for PTR types */
 	result->name_space = el_class->name_space;
 	name = g_strdup_printf ("%s*", el_class->name);
-	result->name = mono_image_strdup (image, name);
+	result->name = image_set ? mono_image_set_strdup (image_set, name) : mono_image_strdup (image, name);
 	result->class_kind = MONO_CLASS_POINTER;
 	g_free (name);
 
@@ -6268,19 +6283,36 @@ mono_ptr_class_get (MonoType *type)
 
 	mono_class_setup_supertypes (result);
 
-	mono_image_lock (image);
-	if (image->ptr_cache) {
-		MonoClass *result2;
-		if ((result2 = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
-			mono_image_unlock (image);
-			mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
-			return result2;
+	if (image_set) {
+		mono_image_set_lock (image_set);
+		if (image_set->ptr_cache) {
+			MonoClass *result2;
+			if ((result2 = (MonoClass *)g_hash_table_lookup (image_set->ptr_cache, el_class))) {
+				mono_image_set_unlock (image_set);
+				mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
+				return result2;
+			}
 		}
+		else {
+			image_set->ptr_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		}
+		g_hash_table_insert (image_set->ptr_cache, el_class, result);
+		mono_image_set_unlock (image_set);
 	} else {
-		image->ptr_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		mono_image_lock (image);
+		if (image->ptr_cache) {
+			MonoClass *result2;
+			if ((result2 = (MonoClass *)g_hash_table_lookup (image->ptr_cache, el_class))) {
+				mono_image_unlock (image);
+				mono_profiler_class_loaded (result, MONO_PROFILE_FAILED);
+				return result2;
+			}
+		} else {
+			image->ptr_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+		}
+		g_hash_table_insert (image->ptr_cache, el_class, result);
+		mono_image_unlock (image);
 	}
-	g_hash_table_insert (image->ptr_cache, el_class, result);
-	mono_image_unlock (image);
 
 	mono_profiler_class_loaded (result, MONO_PROFILE_OK);
 
@@ -6485,6 +6517,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	GSList *list, *rootlist = NULL;
 	int nsize;
 	char *name;
+	MonoImageSet* image_set;
 
 	g_assert (rank <= 255);
 
@@ -6493,33 +6526,53 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		bounded = FALSE;
 
 	image = eclass->image;
+	image_set = class_kind_may_contain_generic_instances (eclass->class_kind) ? mono_metadata_get_image_set_for_class (eclass) : NULL;
 
 	/* Check cache */
 	cached = NULL;
 	if (rank == 1 && !bounded) {
-		/*
-		 * This case is very frequent not just during compilation because of calls
-		 * from mono_class_from_mono_type (), mono_array_new (),
-		 * Array:CreateInstance (), etc, so use a separate cache + a separate lock.
-		 */
-		mono_os_mutex_lock (&image->szarray_cache_lock);
-		if (!image->szarray_cache)
-			image->szarray_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
-		cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
-		mono_os_mutex_unlock (&image->szarray_cache_lock);
-	} else {
-		mono_loader_lock ();
-		if (!image->array_cache)
-			image->array_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
-		rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
-		for (list = rootlist; list; list = list->next) {
-			k = (MonoClass *)list->data;
-			if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
-				cached = k;
-				break;
-			}
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			cached = (MonoClass *)g_hash_table_lookup (image_set->szarray_cache, eclass);
+			mono_image_set_unlock (image_set);
+		} else {
+			/*
+			 * This case is very frequent not just during compilation because of calls
+			 * from mono_class_from_mono_type (), mono_array_new (),
+			 * Array:CreateInstance (), etc, so use a separate cache + a separate lock.
+			 */
+			mono_os_mutex_lock (&image->szarray_cache_lock);
+			if (!image->szarray_cache)
+				image->szarray_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+			cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
+			mono_os_mutex_unlock (&image->szarray_cache_lock);
 		}
-		mono_loader_unlock ();
+	} else {
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			rootlist = (GSList *)g_hash_table_lookup (image_set->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
+			}
+			mono_image_set_unlock (image_set);
+		} else {
+			mono_loader_lock ();
+			if (!image->array_cache)
+				image->array_cache = g_hash_table_new (mono_aligned_addr_hash, NULL);
+			rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
+			}
+			mono_loader_unlock ();
+		}
 	}
 	if (cached)
 		return cached;
@@ -6528,7 +6581,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	if (!parent->inited)
 		mono_class_init (parent);
 
-	klass = (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassArray));
+	klass = image_set ? (MonoClass *)mono_image_set_alloc0 (image_set, sizeof (MonoClassArray)) : (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassArray));
 
 	klass->image = image;
 	klass->name_space = eclass->name_space;
@@ -6544,7 +6597,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 		name [nsize + rank] = '*';
 	name [nsize + rank + bounded] = ']';
 	name [nsize + rank + bounded + 1] = 0;
-	klass->name = mono_image_strdup (image, name);
+	klass->name = image_set ? mono_image_set_strdup (image_set, name) : mono_image_strdup (image, name);
 	g_free (name);
 
 	klass->type_token = 0;
@@ -6615,7 +6668,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	klass->element_class = eclass;
 
 	if ((rank > 1) || bounded) {
-		MonoArrayType *at = (MonoArrayType *)mono_image_alloc0 (image, sizeof (MonoArrayType));
+		MonoArrayType *at = image_set ? (MonoArrayType *)mono_image_set_alloc0 (image_set, sizeof (MonoArrayType)) : (MonoArrayType *)mono_image_alloc0 (image, sizeof (MonoArrayType));
 		klass->byval_arg.type = MONO_TYPE_ARRAY;
 		klass->byval_arg.data.array = at;
 		at->eklass = eclass;
@@ -6633,16 +6686,35 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	/* Check cache again */
 	cached = NULL;
 	if (rank == 1 && !bounded) {
-		mono_os_mutex_lock (&image->szarray_cache_lock);
-		cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
-		mono_os_mutex_unlock (&image->szarray_cache_lock);
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			cached = (MonoClass *)g_hash_table_lookup (image_set->szarray_cache, eclass);
+			mono_image_set_unlock (image_set);
+		} else {
+			mono_os_mutex_lock (&image->szarray_cache_lock);
+			cached = (MonoClass *)g_hash_table_lookup (image->szarray_cache, eclass);
+			mono_os_mutex_unlock (&image->szarray_cache_lock);
+		}
 	} else {
-		rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
-		for (list = rootlist; list; list = list->next) {
-			k = (MonoClass *)list->data;
-			if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
-				cached = k;
-				break;
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			rootlist = (GSList *)g_hash_table_lookup (image_set->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
+			}
+			mono_image_set_unlock (image_set);
+		} else {
+			rootlist = (GSList *)g_hash_table_lookup (image->array_cache, eclass);
+			for (list = rootlist; list; list = list->next) {
+				k = (MonoClass *)list->data;
+				if ((k->rank == rank) && (k->byval_arg.type == (((rank > 1) || bounded) ? MONO_TYPE_ARRAY : MONO_TYPE_SZARRAY))) {
+					cached = k;
+					break;
+				}
 			}
 		}
 	}
@@ -6657,12 +6729,25 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	++class_array_count;
 
 	if (rank == 1 && !bounded) {
-		mono_os_mutex_lock (&image->szarray_cache_lock);
-		g_hash_table_insert (image->szarray_cache, eclass, klass);
-		mono_os_mutex_unlock (&image->szarray_cache_lock);
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			g_hash_table_insert (image_set->szarray_cache, eclass, klass);
+			mono_image_set_unlock (image_set);
+		} else {
+			mono_os_mutex_lock (&image->szarray_cache_lock);
+			g_hash_table_insert (image->szarray_cache, eclass, klass);
+			mono_os_mutex_unlock (&image->szarray_cache_lock);
+		}
 	} else {
-		list = g_slist_append (rootlist, klass);
-		g_hash_table_insert (image->array_cache, eclass, list);
+		if (image_set) {
+			mono_image_set_lock (image_set);
+			list = g_slist_append (rootlist, klass);
+			g_hash_table_insert (image_set->array_cache, eclass, list);
+			mono_image_set_unlock (image_set);
+		} else {
+			list = g_slist_append (rootlist, klass);
+			g_hash_table_insert (image->array_cache, eclass, list);
+		}
 	}
 
 	mono_loader_unlock ();
@@ -10798,4 +10883,13 @@ retry:
 
 	g_assert (result != NULL);
 	return result;
+}
+
+
+static gboolean
+class_kind_may_contain_generic_instances (MonoTypeKind kind)
+{
+	/* classes of type generic inst may contain generic arguments from other images,
+	 * as well as arrays and pointers whose element types (recursively) may be a generic inst */
+	return (kind == MONO_CLASS_GINST || kind == MONO_CLASS_ARRAY || kind == MONO_CLASS_POINTER);
 }

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2210,8 +2210,12 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 	}
 
 	/*valuetypes can't be neither bigger than 1Mb or empty. */
-	if (klass->valuetype && (klass->instance_size <= 0 || klass->instance_size > (0x100000 + sizeof (MonoObject))))
-		mono_class_set_type_load_failure (klass, "Value type instance size (%d) cannot be zero, negative, or bigger than 1Mb", klass->instance_size);
+	if (klass->valuetype && (klass->instance_size <= 0 || klass->instance_size > (0x100000 + sizeof (MonoObject)))) {
+		/* Special case compiler generated types */
+		/* Hard to check for [CompilerGenerated] here */
+		if (!strstr (klass->name, "StaticArrayInitTypeSize") && !strstr (klass->name, "$ArrayType"))
+			mono_class_set_type_load_failure (klass, "Value type instance size (%d) cannot be zero, negative, or bigger than 1Mb", klass->instance_size);
+	}
 
 	/* Publish the data */
 	mono_loader_lock ();

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -410,7 +410,17 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 	See mono/tests/generic-type-load-exception.2.il
 	FIXME we should better report this error to the caller
 	 */
-	if (!klass->methods || mono_class_has_failure (klass)) {
+	if (mono_class_has_failure (klass)) {
+		MonoError class_failure_error;
+		error_init (&class_failure_error);
+		mono_error_set_for_class_failure (&class_failure_error, klass);
+		mono_error_set_type_load_class (error, klass, "%s", mono_error_get_message (&class_failure_error));
+		mono_error_cleanup (&class_failure_error);
+
+		return NULL;
+	}
+
+	if (!klass->methods) {
 		mono_error_set_type_load_class (error, klass, "Could not find method due to a type load error"); //FIXME get the error from the class 
 
 		return NULL;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -429,6 +429,9 @@ typedef struct {
 	// Generic-specific caches
 	GHashTable *gclass_cache, *ginst_cache, *gmethod_cache, *gsignature_cache;
 
+	/* mirror caches of ones already on MonoImage. These ones contain generics */
+	GHashTable *szarray_cache, *array_cache, *ptr_cache;
+
 	MonoWrapperCaches wrapper_caches;
 
 	mono_mutex_t    lock;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2468,6 +2468,9 @@ get_image_set (MonoImage **images, int nimages)
 		set->gmethod_cache = g_hash_table_new_full (inflated_method_hash, inflated_method_equal, NULL, (GDestroyNotify)free_inflated_method);
 		set->gsignature_cache = g_hash_table_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature);
 
+		set->szarray_cache = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, NULL);
+		set->array_cache = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, NULL);
+
 		for (i = 0; i < nimages; ++i)
 			set->images [i]->image_sets = g_slist_prepend (set->images [i]->image_sets, set);
 
@@ -2493,6 +2496,11 @@ delete_image_set (MonoImageSet *set)
 	g_hash_table_destroy (set->ginst_cache);
 	g_hash_table_destroy (set->gmethod_cache);
 	g_hash_table_destroy (set->gsignature_cache);
+
+	g_hash_table_destroy (set->szarray_cache);
+	g_hash_table_destroy (set->array_cache);
+	if (set->ptr_cache)
+		g_hash_table_destroy (set->ptr_cache);
 
 	mono_wrapper_caches_free (&set->wrapper_caches);
 
@@ -2788,7 +2796,18 @@ inflated_signature_in_image (gpointer key, gpointer value, gpointer data)
 	return signature_in_image (sig->sig, image) ||
 		(sig->context.class_inst && ginst_in_image (sig->context.class_inst, image)) ||
 		(sig->context.method_inst && ginst_in_image (sig->context.method_inst, image));
-}	
+}
+
+static gboolean
+class_in_image (gpointer key, gpointer value, gpointer data)
+{
+	MonoImage *image = (MonoImage *)data;
+	MonoClass *klass = (MonoClass *)key;
+
+	g_assert (type_in_image (&klass->byval_arg, image));
+
+	return TRUE;
+}
 
 static void
 check_gmethod (gpointer key, gpointer value, gpointer data)
@@ -2852,6 +2871,11 @@ mono_metadata_clean_for_image (MonoImage *image)
 		g_hash_table_foreach_steal (set->ginst_cache, steal_ginst_in_image, &ginst_data);
 		g_hash_table_foreach_remove (set->gmethod_cache, inflated_method_in_image, image);
 		g_hash_table_foreach_remove (set->gsignature_cache, inflated_signature_in_image, image);
+
+		g_hash_table_foreach_steal (set->szarray_cache, class_in_image, image);
+		g_hash_table_foreach_steal (set->array_cache, class_in_image, image);
+		if (set->ptr_cache)
+			g_hash_table_foreach_steal (set->ptr_cache, class_in_image, image);
 		mono_image_set_unlock (set);
 	}
 
@@ -2951,6 +2975,20 @@ mono_metadata_get_inflated_signature (MonoMethodSignature *sig, MonoGenericConte
 	mono_image_set_unlock (set);
 
 	return res->sig;
+}
+
+MonoImageSet *
+mono_metadata_get_image_set_for_class (MonoClass *klass)
+{
+	MonoImageSet *set;
+	CollectData image_set_data;
+
+	collect_data_init (&image_set_data);
+	collect_type_images (&klass->byval_arg, &image_set_data);
+	set = get_image_set (image_set_data.images, image_set_data.nimages);
+	collect_data_free (&image_set_data);
+
+	return set;
 }
 
 MonoImageSet *

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -355,8 +355,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 		/* cfa = rbp + cfa_offset */
 		mono_add_unwind_op_offset (unwind_ops, code, buf, i, - cfa_offset + saved_regs_offset + (i * sizeof (mgreg_t)));
 	}
-	for (i = 0; i < 8; ++i)
-		amd64_movsd_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)), i);
+	for (i = 0; i < AMD64_XMM_NREG; ++i)
+		if (AMD64_IS_ARGUMENT_XREG (i))
+			amd64_movdqu_membase_reg (code, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)), i);
 
 	/* Check that the stack is aligned */
 	amd64_mov_reg_reg (code, AMD64_R11, AMD64_RSP, sizeof (mgreg_t));
@@ -543,8 +544,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	for (i = 0; i < AMD64_NREG; ++i)
 		if (AMD64_IS_ARGUMENT_REG (i) || i == AMD64_R10 || i == AMD64_RAX)
 			amd64_mov_reg_membase (code, i, AMD64_RBP, saved_regs_offset + (i * sizeof(mgreg_t)), sizeof(mgreg_t));
-	for (i = 0; i < 8; ++i)
-		amd64_movsd_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(mgreg_t)));
+	for (i = 0; i < AMD64_XMM_NREG; ++i)
+		if (AMD64_IS_ARGUMENT_XREG (i))
+			amd64_movdqu_reg_membase (code, i, AMD64_RBP, saved_fpregs_offset + (i * sizeof(MonoContextSimdReg)));
 
 	/* Restore stack */
 #if TARGET_WIN32

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -213,13 +213,14 @@ typedef struct {
 
 #endif
 
+#if !defined(__APPLE__)
+#include <emmintrin.h>
+typedef __m128d MonoContextSimdReg;
+#endif
+
 typedef struct {
 	mgreg_t gregs [AMD64_NREG];
-#ifdef __APPLE__
 	MonoContextSimdReg fregs [AMD64_XMM_NREG];
-#else
-	double fregs [AMD64_XMM_NREG];
-#endif
 } MonoContext;
 
 #define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->gregs [AMD64_RIP] = (mgreg_t)(ip); } while (0);


### PR DESCRIPTION
case 957072 - Improve TypeLoadException messages
case 907918 - Fix URI processing on OSX
case 945353 - Fix InternalsVisibleTo
case 962711 - Fix value types larger than 1MB
case 967206 - Fix random crash due to memory corruption on domain reload