### PR TITLE
IL2CPP Debugger VSTU stepping tweaks

### DIFF
--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -972,8 +972,8 @@ Il2CppMonoImage* il2cpp_mono_assembly_get_image(Il2CppMonoAssembly* assembly)
 
 gboolean il2cpp_mono_runtime_try_shutdown()
 {
-	IL2CPP_ASSERT(0 && "This method is not yet implemented");
-	return 0;
+	il2cpp::vm::Runtime::Shutdown();
+	return TRUE;
 }
 
 gboolean il2cpp_mono_verifier_is_method_valid_generic_instantiation(Il2CppMonoMethod* method)


### PR DESCRIPTION
* Using a count for sequence point activation instead of a boolean.  This fixes an
issue when single stepping starts from a breakpoint.  The previous breakpoints would be cleared and not be hit when we returned to them.
* Filtering out the method enter/exit sequence points and only honoring them when
a method entry/exit request is active.  This fixes issues with VSTU "invalid frames"
when stepping into/out of a function.