### PR TITLE
Reconciling thread changes from recent Mono master merge

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -11654,7 +11654,7 @@ debugger_thread (void *arg)
 	DEBUG_PRINTF (1, "[dbg] Agent thread started, pid=%p\n", (gpointer) (gsize) mono_native_thread_id_get ());
     debugger_thread_id = mono_native_thread_id_get ();
 #ifdef IL2CPP_MONO_DEBUGGER
-    mono_thread_attach (il2cpp_mono_get_root_domain ());
+	MonoThread *thread = mono_thread_attach (il2cpp_mono_get_root_domain ());
 #endif
 
 	MonoInternalThread *internal = mono_thread_internal_current ();
@@ -11834,6 +11834,10 @@ debugger_thread (void *arg)
 		DEBUG_PRINTF (2, "[dbg] Detached - restarting clean debugger thread.\n");
 		start_debugger_thread ();
 	}
+
+#ifdef IL2CPP_MONO_DEBUGGER
+	mono_thread_detach (thread);
+#endif
 
 	return 0;
 }

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -284,6 +284,7 @@
 #define mono_thread_current il2cpp_mono_thread_current
 #define mono_thread_get_main il2cpp_mono_thread_get_main
 #define mono_thread_attach il2cpp_mono_thread_attach
+#define mono_thread_detach il2cpp_mono_thread_detach
 #define mono_domain_lock il2cpp_mono_domain_lock
 #define mono_domain_unlock il2cpp_mono_domain_unlock
 #define mono_jit_info_table_find_internal il2cpp_mono_jit_info_table_find_internal
@@ -656,7 +657,7 @@ il2cpp_internal_thread_get_threadpool_thread(Il2CppMonoInternalThread* thread);
 Il2CppMonoMethod* il2cpp_method_get_generic_definition(Il2CppMonoMethodInflated *imethod);
 Il2CppMonoGenericInst* il2cpp_method_get_generic_class_inst(Il2CppMonoMethodInflated *imethod);
 Il2CppMonoClass* il2cpp_generic_class_get_container_class(Il2CppMonoGenericClass *gclass);
-
+void il2cpp_mono_thread_detach(Il2CppMonoThread* thread);
 Il2CppMonoClass* il2cpp_mono_get_string_class (void);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -490,6 +490,11 @@ Il2CppMonoThread* il2cpp_mono_thread_attach(Il2CppMonoDomain* domain)
 	return (Il2CppMonoThread*)il2cpp::vm::Thread::Attach((Il2CppDomain*)domain);
 }
 
+void il2cpp_mono_thread_detach(Il2CppMonoThread* thread)
+{
+	il2cpp::vm::Thread::Detach((Il2CppThread*)thread);
+}
+
 Il2CppMonoInternalThread* il2cpp_mono_thread_get_internal(Il2CppMonoThread* thread)
 {
 	return (Il2CppMonoInternalThread*)(((Il2CppThread*)thread)->internal_thread);


### PR DESCRIPTION
Detaching the debugger thread before it exits so cleanup is performed properly.