### PR TITLE
Expose mono_assembly_name_free

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -490,7 +490,7 @@ gboolean
 mono_assembly_name_parse (const char *name, MonoAssemblyName *aname) /*MONO_INTERNAL*/;
 
 void
-mono_assembly_name_free (MonoAssemblyName *aname) MONO_INTERNAL;
+mono_assembly_name_free (MonoAssemblyName *aname) /*MONO_INTERNAL*/;
 
 MonoImage *mono_assembly_open_from_bundle (const char *filename,
 					   MonoImageOpenStatus *status,

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -17,6 +17,7 @@ mono_image_open_from_data_with_name
 mono_assembly_fill_assembly_name
 mono_stringify_assembly_name
 mono_assembly_name_parse
+mono_assembly_name_free
 mono_assembly_loaded
 mono_loader_get_last_error
 mono_loader_error_prepare_exception


### PR DESCRIPTION
Seems like `mono_assembly_name_parse` was exposed in a similar way, now we need to be able to free memory it allocates.