### PR TITLE
Debugger suspend threads

### DIFF
--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -497,5 +497,6 @@ MonoGenericInst* il2cpp_method_get_generic_class_inst(Il2CppMonoMethodInflated *
 MonoClass* il2cpp_generic_class_get_container_class(MonoGenericClass *gclass);
 void il2cpp_mono_thread_detach(MonoThread* thread);
 MonoClass* il2cpp_mono_get_string_class (void);
+Il2CppSequencePoint* il2cpp_get_sequence_point(size_t id);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -1570,6 +1570,9 @@ MonoClass* il2cpp_mono_get_string_class (void)
 	return (MonoClass*)il2cpp_defaults.string_class;
 }
 
+Il2CppSequencePoint* il2cpp_get_sequence_point(size_t id)
+{
+    return il2cpp::utils::Debugger::GetSequencePoint(id);
 }
-
+}
 #endif // RUNTIME_IL2CPP


### PR DESCRIPTION
* Initial work to properly suspend threads running managed code when the debugger requests it.
Enabling more thread related tests after the thread suspension fix.
* Fixing some issues with step filters that were never working.  Hijacking the jitinfo pointer and storing a Il2CppSequencePoint pointer in it for il2cpp.  We can
use the sequence point to access data we need for filtering, in much the same way mono uses the JitInfo pointer.
* Fixing crashing issues that occur when you generate debug code but don't pass in
the appropriate arguments to initialize the debugger.  We need to check that the debugger has been initialized before performing various debugger-related operations.