### PR TITLE
Allow Environment.TickCount to be monotonic on Mac

### DIFF
--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -104,7 +104,7 @@ inline void test_time_and_possibly_refresh_cache(struct timeval* now)
 
 	timersub(now, &last_time, &difference);
 
-	long diff_microseconds = (difference.tv_sec * 1e6) + difference.tv_usec;
+	gint64 diff_microseconds = ((gint64)difference.tv_sec * 1e6) + difference.tv_usec;
 
 	if (diff_microseconds > max_delta_time_jump_before_cache_invalidation_us|| diff_microseconds < 0)
 	{


### PR DESCRIPTION
The previous code here could cause the `TickCount` property to decrease
if the system time changes. The new code is taken from Unity's
implementation, which caches calls to `sysctl` and handles the system
clock moving backwards.

This is part of the fix for case 914305 in Unity.

I'm not planning to merge this until 2018.1 branches.

Make Environment.TickCount monotonic on macOS, even when the system time changes.