### PR TITLE
IL2CPP debugger fixes for working with Unity players

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -12071,7 +12071,7 @@ unity_process_breakpoint_inner(DebuggerTlsData *tls, gboolean from_signal, Il2Cp
 			inst = (BreakpointInstance *)g_ptr_array_index(bp->children, j);
 			if (inst->il_offset == sequencePoint->ilOffset) {
 				if (bp->req->event_kind == EVENT_KIND_STEP) {
-					for (int k = 0; j < bp->children->len; ++k)
+					for (int k = 0; k < bp->children->len; ++k)
 					{
 						BreakpointInstance *inst1 = (BreakpointInstance *)g_ptr_array_index(bp->children, k);
 						if (inst1->seq_point == sequencePoint)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4754,6 +4754,16 @@ set_breakpoint (MonoMethod *method, long il_offset, EventRequest *req, MonoError
 	{
 		if (bp_matches_method(bp, seqPoint->method) && seqPoint->ilOffset == bp->il_offset)
 		{
+            if (req->event_kind == EVENT_KIND_BREAKPOINT && seqPoint->kind == kSequencePointKind_StepOut)
+                continue;
+
+            if (req->event_kind == EVENT_KIND_STEP)
+            {
+                SingleStepReq *ssreq = (SingleStepReq*)req->info;
+                if (ssreq->depth == STEP_DEPTH_OUT && seqPoint->kind != kSequencePointKind_StepOut)
+                    continue;
+            } 
+
 			BreakpointInstance* inst = g_new0(BreakpointInstance, 1);
 			inst->il_offset = bp->il_offset;// it.seq_point.il_offset;
 			inst->native_offset = 0;// it.seq_point.native_offset;
@@ -10280,10 +10290,25 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 				buffer_add_string(buf, "");
 			}
 		}
-		buffer_add_int(buf, sequencePoints->len);
+
+        int numSeqPoints = 0;
+
+        for (i = 0; i < sequencePoints->len; ++i) {
+            Il2CppSequencePoint* sequencePoint = g_ptr_array_index(sequencePoints, i);
+            if (sequencePoint->kind == kSequencePointKind_StepOut)
+                continue;
+            else
+                ++numSeqPoints;
+        }
+
+		buffer_add_int(buf, numSeqPoints);
 		DEBUG_PRINTF(10, "Line number table for method %s:\n", mono_method_full_name(method, TRUE));
 		for (i = 0; i < sequencePoints->len; ++i) {
 			Il2CppSequencePoint* sequencePoint = g_ptr_array_index(sequencePoints, i);
+            
+            if (sequencePoint->kind == kSequencePointKind_StepOut)
+                continue;
+
 			DEBUG_PRINTF(10, "IL%x -> %s:%d %d %d %d\n", sequencePoint->ilOffset, sequencePoint->sourceFile,
 				sequencePoint->lineStart, sequencePoint->columnStart, sequencePoint->lineEnd, sequencePoint->columnEnd);
 			buffer_add_int(buf, sequencePoint->ilOffset);
@@ -12046,10 +12071,10 @@ unity_process_breakpoint_inner(DebuggerTlsData *tls, gboolean from_signal, Il2Cp
 			inst = (BreakpointInstance *)g_ptr_array_index(bp->children, j);
 			if (inst->il_offset == sequencePoint->ilOffset) {
 				if (bp->req->event_kind == EVENT_KIND_STEP) {
-					for (int j = 0; j < bp->children->len; ++j)
+					for (int k = 0; j < bp->children->len; ++k)
 					{
-						BreakpointInstance *inst = (BreakpointInstance *)g_ptr_array_index(bp->children, j);
-						if (inst->seq_point == sequencePoint)
+						BreakpointInstance *inst1 = (BreakpointInstance *)g_ptr_array_index(bp->children, k);
+						if (inst1->seq_point == sequencePoint)
 						{
 							g_ptr_array_add(ss_reqs_orig, bp->req);
 							break;

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -141,6 +141,7 @@ void il2cpp_mono_free_method_signatures()
 	{
 		mono_g_hash_table_foreach(method_signatures, il2cpp_mono_free_method_signature, NULL);
 		mono_g_hash_table_destroy(method_signatures);
+        method_signatures = NULL;
 	}
 }
 


### PR DESCRIPTION
* Ignoring setp_out sequence points when searching for sequence points that don't correspond to step_out requests.
* Not returning step_out sequence points when retrieving method debug  info.  The step out sequence points have the same offset as other sequence points, but different line numbers.
* Hardened the il2cpp_mono_free_method_signatures() function against multiple calls by setting the method_signatures hash table to null after it is cleared.
* The isActive field in Il2CppSequencePoint should be a uint8_t, not a bool, as it gets incremented.  I think this change was made in the previous C-only type for this struct but not propagated to the C++ version, which is the only version we use now.