### PR TITLE
Enable IPv6 support in the settings files

### DIFF
--- a/data/net_2_0/machine.config
+++ b/data/net_2_0/machine.config
@@ -118,6 +118,9 @@
 			<add prefix="file" type="System.Net.FileWebRequestCreator, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			<add prefix="ftp" type="System.Net.FtpRequestCreator, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		</webRequestModules>
+		<settings>
+			<ipv6 enabled="true"/>
+		</settings>
 	</system.net>
 	
 	<system.runtime.remoting>

--- a/data/net_4_0/machine.config
+++ b/data/net_4_0/machine.config
@@ -135,6 +135,9 @@
 			<add prefix="file" type="System.Net.FileWebRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			<add prefix="ftp" type="System.Net.FtpRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		</webRequestModules>
+		<settings>
+			<ipv6 enabled="true"/>
+		</settings>
 	</system.net>
 	
 	<system.runtime.remoting>

--- a/data/net_4_5/machine.config
+++ b/data/net_4_5/machine.config
@@ -138,6 +138,9 @@
 			<add prefix="file" type="System.Net.FileWebRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			<add prefix="ftp" type="System.Net.FtpRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		</webRequestModules>
+		<settings>
+			<ipv6 enabled="true"/>
+		</settings>
 	</system.net>
 	
 	<system.runtime.remoting>


### PR DESCRIPTION
It looks like the upstream Mono code uses either the class library PAL
or a fallback to a hard-coded value to enable IPv6 support. The fallback
is not compiled in for the Unity code, so the class library code tries a
final fallback to the settings file. In the old Mono this setting was
present, but it does not exist in the new Mono, as it is not needed
upstream.

This change corrects Unity case 941946 by enabling IPv6 support in the
settings file.

Release notes:
Scripting: Enable IPv6 support with the new Mono runtime for non-desktop devices.