### PR TITLE
UnityTls install dummy function for old mono

### DIFF
--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -846,3 +846,4 @@ mono_unity_thread_fast_attach
 mono_unity_thread_fast_detach
 mono_profiler_set_profiler_events
 mono_profiler_create
+mono_unity_install_unitytls_interface

--- a/unity/unity_utils.c
+++ b/unity/unity_utils.c
@@ -299,3 +299,9 @@ MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token)
 {
 	return mono_class_get(image, type_token);
 }
+
+// unitytls is only available in new mono (mbe). This dummy makes sure that the editor does not need to distinguish between those versions.
+void
+mono_unity_install_unitytls_interface(mono_unity_unitytls_interface* callbacks)
+{
+}

--- a/unity/unity_utils.h
+++ b/unity/unity_utils.h
@@ -43,4 +43,8 @@ void mono_unity_set_data_dir(const char* dir);
 char* mono_unity_get_data_dir();
 MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token);
 
+
+typedef struct mono_unity_unitytls_interface mono_unity_unitytls_interface;
+void mono_unity_install_unitytls_interface(mono_unity_unitytls_interface* callbacks);
+
 #endif


### PR DESCRIPTION
Dummy function for `mono_unity_install_unitytls_interface` since the editor can't distinguish between old and new mono.

See:
https://github.com/Unity-Technologies/mono/pull/784