### PR TITLE
Fix Windows Socket.Send not blocking (case 984723)

### DIFF
--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -185,7 +185,7 @@ int mono_w32socket_send (SOCKET s, char *buf, int len, int flags, gboolean block
 {
 	int ret = SOCKET_ERROR;
 	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, FALSE, ret, send, s, buf, len, flags);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, send, s, buf, len, flags);
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }
@@ -194,7 +194,7 @@ int mono_w32socket_sendto (SOCKET s, const char *buf, int len, int flags, const 
 {
 	int ret = SOCKET_ERROR;
 	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, FALSE, ret, sendto, s, buf, len, flags, to, tolen);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, sendto, s, buf, len, flags, to, tolen);
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }
@@ -203,7 +203,7 @@ int mono_w32socket_sendbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCou
 {
 	int ret = SOCKET_ERROR;
 	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, FALSE, ret, WSASend, s, lpBuffers, dwBufferCount, lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, WSASend, s, lpBuffers, dwBufferCount, lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }


### PR DESCRIPTION
Check for 'repeat' before calling alertable_socket_wait to short circuit. The problem was alertable_socket_wait can also modify WSA error state but if we don't repeat the original error gets lost.

Error steps in previous code:

mono_w32socket_send with blocking = TRUE and repeat = FALSE
ALERTABLE_SOCKET_CALL macro for send operation with error code (-1) returned
WSAGetLastError returns WSAEWOULDBLOCK and is stored in _error. This is the real error
alertable_socket_wait is called and succeeds, internally having called WSASetLastError (0);
'repeat' value is false so loop is exited
WSAGetLastError is called, returns 0, and is stored in _saved_error
WSASetLastError is called with _saved_error (0)
ALERTABLE_SOCKET_CALL returns indicating no error even though the send command has failed.
This code is fairly complex (and macro'd) so I tried making minimal change to fix this issue.

case 984723 - Fix incorrect System.IO.IOException being thrown during during Socket.Send