### PR TITLE
Make breakpoints_cleanup() safe to call multiple times

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4930,14 +4930,20 @@ breakpoints_cleanup (void)
 		}
 	}
 
-	for (i = 0; i < breakpoints->len; ++i)
-		g_free (g_ptr_array_index (breakpoints, i));
+    if (breakpoints)
+    {
+        for (i = 0; i < breakpoints->len; ++i)
+            g_free (g_ptr_array_index (breakpoints, i));
 
-	g_ptr_array_free (breakpoints, TRUE);
-	g_hash_table_destroy (bp_locs);
+        g_ptr_array_free (breakpoints, TRUE);
+        breakpoints = NULL;
+    }
 
-	breakpoints = NULL;
-	bp_locs = NULL;
+    if (bp_locs)
+    {
+        g_hash_table_destroy (bp_locs);
+        bp_locs = NULL;
+    }
 
 	mono_loader_unlock ();
 }


### PR DESCRIPTION
breakpoints_cleanup() in the debugger agent can be called multiple
times when used with IL2CPP, so added some defense against this to
prevent already-cleared hashtables and arrays from being destroyed multiple
times.