### PR TITLE
Add API to control behavior of thread abort within handler blocks (case 979679).

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -55,6 +55,8 @@
 #include <mono/utils/w32api.h>
 #include <mono/utils/mono-os-wait.h>
 
+#include <mono/metadata/unity-utils.h>
+
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
@@ -4851,7 +4853,7 @@ async_abort_critical (MonoThreadInfo *info, gpointer ud)
 	gboolean protected_wrapper;
 	gboolean running_managed;
 
-	if (mono_get_eh_callbacks ()->mono_install_handler_block_guard (mono_thread_info_get_suspend_state (info)))
+	if (mono_unity_get_enable_handler_block_guards () && mono_get_eh_callbacks ()->mono_install_handler_block_guard (mono_thread_info_get_suspend_state (info)))
 		return MonoResumeThread;
 
 	/*someone is already interrupting it*/

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1293,3 +1293,17 @@ mono_class_set_allow_gc_aware_layout(mono_bool allow)
 {
 	mono_allow_gc_aware_layout = allow;
 }
+
+static mono_bool enable_handler_block_guards = TRUE;
+
+void
+mono_unity_set_enable_handler_block_guards (mono_bool allow)
+{
+	enable_handler_block_guards = allow;
+}
+
+mono_bool
+mono_unity_get_enable_handler_block_guards (void)
+{
+	return enable_handler_block_guards;
+}

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -180,4 +180,10 @@ mono_method_get_method_definition(MonoMethod *method);
 void
 mono_class_set_allow_gc_aware_layout(mono_bool allow);
 
+MONO_API void
+mono_unity_set_enable_handler_block_guards (mono_bool allow);
+
+mono_bool
+mono_unity_get_enable_handler_block_guards (void);
+
 #endif


### PR DESCRIPTION

Unity unloads domains and this is accomplished via thread abort exceptions.
Mono now matches .NET behavior by not interrupting catch/finally blocks with
thread abort exceptions. This can lead to hangs in Unity as domain unload
blocks until all thread are interrupted.