### PR TITLE
Fix crash on android when script debugging is enabled (case 973794)

### DIFF
--- a/mono/utils/mono-threads-posix-signals.c
+++ b/mono/utils/mono-threads-posix-signals.c
@@ -84,7 +84,7 @@ static int
 suspend_signal_get (void)
 {
 #if defined(HOST_ANDROID)
-	return SIGPWR;
+	return SIGUSR1;
 #elif defined (SIGRTMIN)
 	static int suspend_signum = -1;
 	if (suspend_signum == -1)
@@ -103,7 +103,7 @@ static int
 restart_signal_get (void)
 {
 #if defined(HOST_ANDROID)
-	return SIGXCPU;
+	return SIGUSR2;
 #elif defined (SIGRTMIN)
 	static int restart_signum = -1;
 	if (restart_signum == -1)


### PR DESCRIPTION
Fix crash on startup when script debugging is enabled due to shared signals between mono and the GC by changing mono to use different signals.