### PR TITLE
Add folder specifically for UnityScript and Boo assemblies.

### DIFF
--- a/external/buildscripts/build_us_and_boo.pl
+++ b/external/buildscripts/build_us_and_boo.pl
@@ -137,4 +137,21 @@ sub BuildUnityScriptFor45
 	
 	print(">>> Copying $monoprefix45/us.exe to $usBuildDir\n");
 	copy("$monoprefix45/us.exe", "$usBuildDir/.");
+
+	# put unityscript and boo into their own directories that we can reference for compilation only in Unity
+	my $usLibDir = "$monoprefix/lib/mono/unityscript";
+	
+	if (!(-d "$usLibDir"))
+	{
+		print(">>> Removing directory $usLibDir\n");
+		rmtree($usLibDir);
+	}
+	
+	mkdir($usLibDir);
+
+	foreach my $file (glob "$usBuildDir/*")
+	{
+		print(">>> Copying $file to $usLibDir\n");
+		copy($file, "$usLibDir/.");
+	}
 }


### PR DESCRIPTION
This starts process of treating them as not part of standard set of
system assemblies. We can easily reference them as needed rather than
assuming they are in all the mono profile directories.