### PR TITLE
Preprocessor cleanup for il2cpp debugger

### DIFF
--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -12,10 +12,10 @@
 MONO_API void
 mono_debugger_agent_parse_options (char *options);
 
-#ifdef IL2CPP_MONO_DEBUGGER
+#ifdef RUNTIME_IL2CPP
 void
 mono_debugger_run_debugger_thread_func(void* arg);
-#endif // IL2CPP_MONO_DEBUGGER
+#endif // RUNTIME_IL2CPP
 
 void
 mono_debugger_agent_init (void);
@@ -27,7 +27,7 @@ void
 mono_debugger_agent_single_step_event (void *sigctx);
 
 void
-#ifndef IL2CPP_MONO_DEBUGGER
+#ifndef RUNTIME_IL2CPP
 debugger_agent_single_step_from_context (MonoContext *ctx);
 #else
 debugger_agent_single_step_from_context (MonoContext *ctx, uint64_t sequencePointId);

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -10,7 +10,7 @@
 #include <mono/metadata/profiler.h>
 #endif //RUNTIME_IL2CPP
 
-#ifdef IL2CPP_MONO_DEBUGGER
+#ifdef RUNTIME_IL2CPP
 
 #define THREAD_STATIC_FIELD_OFFSET -1
 

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -397,7 +397,9 @@ gint32 il2cpp_mono_debug_il_offset_from_address(MonoMethod* method, MonoDomain* 
 
 void il2cpp_mono_set_is_debugger_attached(gboolean attached)
 {
+#if IL2CPP_MONO_DEBUGGER
 	il2cpp::utils::Debugger::SetIsDebuggerAttached(attached == TRUE);
+#endif
 }
 
 char* il2cpp_mono_type_full_name(MonoType* type)
@@ -1238,7 +1240,9 @@ MonoAssembly* il2cpp_domain_get_assemblies_iter(MonoAppDomain *domain, void* *it
 
 void il2cpp_start_debugger_thread()
 {
+#if IL2CPP_MONO_DEBUGGER
 	il2cpp::utils::Debugger::StartDebuggerThread();
+#endif
 }
 
 void* il2cpp_gc_alloc_fixed(size_t size)
@@ -1258,15 +1262,23 @@ const char* il2cpp_domain_get_name(MonoDomain* domain)
 
 Il2CppSequencePoint* il2cpp_get_sequence_points(void* *iter)
 {
+#if IL2CPP_MONO_DEBUGGER
 	return (Il2CppSequencePoint*)il2cpp::utils::Debugger::GetSequencePoints(iter);
+#else
+    return NULL;
+#endif
 }
 
 Il2CppSequencePoint* il2cpp_get_method_sequence_points(MonoMethod* method, void* *iter)
 {
+#if IL2CPP_MONO_DEBUGGER
 	if (!method)
 		return (Il2CppSequencePoint*)il2cpp::utils::Debugger::GetSequencePoints(iter);
 	else
 		return (Il2CppSequencePoint*)il2cpp::utils::Debugger::GetSequencePoints((const MethodInfo*)method, iter);
+#else
+    return NULL;
+#endif
 }
 
 gboolean il2cpp_mono_methods_match(MonoMethod* left, MonoMethod* right)
@@ -1431,7 +1443,11 @@ MonoClass* il2cpp_iterate_loaded_classes(void* *iter)
 
 const char** il2cpp_get_source_files_for_type(MonoClass *klass, int *count)
 {
+#if IL2CPP_MONO_DEBUGGER
 	return il2cpp::utils::Debugger::GetTypeSourceFiles((Il2CppClass*)klass, *count);
+#else
+    return NULL;
+#endif
 }
 
 MonoMethod* il2cpp_method_get_generic_definition(MonoMethodInflated *imethod)
@@ -1468,7 +1484,11 @@ MonoClass* il2cpp_mono_get_string_class (void)
 
 Il2CppSequencePoint* il2cpp_get_sequence_point(size_t id)
 {
+#if IL2CPP_MONO_DEBUGGER
     return il2cpp::utils::Debugger::GetSequencePoint(id);
+#else
+    return NULL;
+#endif
 }
 }
 #endif // RUNTIME_IL2CPP


### PR DESCRIPTION
* Changed IL2CPP specific sections in debugger-agent.c to use the
RUNTIME_IL2CPP macro instead of IL2CPP_MONO_DEBUGGER, as the latter is
switched off on release builds to control debugger code usage.  We will
still build the debugger-agent in release, but the native linker
should strip it out.
* Stripping out code in stubs that reference code in utils::Debugger when
the debugging code is turned off.  utils::Debugger implementation is stripped
out completely in this case.