### PR TITLE
Catch errors from CreateLocalUnity function

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -170,9 +170,15 @@ namespace System
 #endif
 
 #if UNITY
-			var localTimeZoneFallback = CreateLocalUnity();
-			if(localTimeZoneFallback == null)
-			    localTimeZoneFallback = Utc;
+			TimeZoneInfo localTimeZoneFallback = null;
+			try {
+				localTimeZoneFallback = CreateLocalUnity();
+			} catch {
+				localTimeZoneFallback = null;
+			}
+
+			if (localTimeZoneFallback == null)
+				localTimeZoneFallback = Utc;
 #endif
 
 			var tz = Environment.GetEnvironmentVariable ("TZ");


### PR DESCRIPTION
for some regions, specifically Asia/Singapore, the native icall returns incorrectly because the country's timezone changed. In this case in 1981 Asia/Singapore changed from +0730 to +08....Since the UTC offset changed, our logic thinks that daylight savings may have started, and the icall returns incorrect data, which causes the CreateLocalUnity function to throw.  Fixing the icall is important, but for the time being we'll wrap the CreateLocalUnity function with a try catch. then fix the native icall...