### PR TITLE
MonoBleedingEdge Fixes for 2017.2

### DIFF
--- a/data/net_2_0/machine.config
+++ b/data/net_2_0/machine.config
@@ -118,6 +118,9 @@
 			<add prefix="file" type="System.Net.FileWebRequestCreator, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			<add prefix="ftp" type="System.Net.FtpRequestCreator, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		</webRequestModules>
+		<settings>
+			<ipv6 enabled="true"/>
+		</settings>
 	</system.net>
 	
 	<system.runtime.remoting>

--- a/data/net_4_0/machine.config
+++ b/data/net_4_0/machine.config
@@ -135,6 +135,9 @@
 			<add prefix="file" type="System.Net.FileWebRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			<add prefix="ftp" type="System.Net.FtpRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		</webRequestModules>
+		<settings>
+			<ipv6 enabled="true"/>
+		</settings>
 	</system.net>
 	
 	<system.runtime.remoting>

--- a/data/net_4_5/machine.config
+++ b/data/net_4_5/machine.config
@@ -138,6 +138,9 @@
 			<add prefix="file" type="System.Net.FileWebRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 			<add prefix="ftp" type="System.Net.FtpRequestCreator, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 		</webRequestModules>
+		<settings>
+			<ipv6 enabled="true"/>
+		</settings>
 	</system.net>
 	
 	<system.runtime.remoting>

--- a/mcs/class/System/ReferenceSources/SecureStringHelper.cs
+++ b/mcs/class/System/ReferenceSources/SecureStringHelper.cs
@@ -14,7 +14,18 @@ namespace System.Net
 
                 if (secureString == null || secureString.Length == 0)
                     return String.Empty;
-
+#if MONO
+                try
+                {
+                    bstr = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+                    plainString = Marshal.PtrToStringUni(bstr);
+                }
+                finally
+                {
+                    if (bstr != IntPtr.Zero)
+                        Marshal.ZeroFreeGlobalAllocUnicode(bstr);
+                }
+#else
                 try
                 {
                     bstr = Marshal.SecureStringToBSTR(secureString);
@@ -25,6 +36,7 @@ namespace System.Net
                     if (bstr != IntPtr.Zero)
                         Marshal.ZeroFreeBSTR(bstr);
                 }
+#endif
                 return plainString;
             }
 

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -203,7 +203,7 @@ mono_gc_base_init (void)
 	GC_push_other_roots = mono_push_other_roots;
 #endif
 
-#if !defined(PLATFORM_ANDROID)
+#if defined(HAVE_BDWGC_GC) || !defined(PLATFORM_ANDROID)
 	/* If GC_no_dls is set to true, GC_find_limit is not called. This causes a seg fault on Android. */
 	GC_no_dls = TRUE;
 #endif

--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -184,21 +184,21 @@ int mono_w32socket_recvbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCou
 int mono_w32socket_send (SOCKET s, char *buf, int len, int flags, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, FALSE, ret, send, s, buf, len, flags);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, send, s, buf, len, flags);
 	return ret;
 }
 
 int mono_w32socket_sendto (SOCKET s, const char *buf, int len, int flags, const struct sockaddr *to, int tolen, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, FALSE, ret, sendto, s, buf, len, flags, to, tolen);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, sendto, s, buf, len, flags, to, tolen);
 	return ret;
 }
 
 int mono_w32socket_sendbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCount, guint32 *lpNumberOfBytesRecvd, guint32 lpFlags, gpointer lpOverlapped, gpointer lpCompletionRoutine, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, FALSE, ret, WSASend, s, lpBuffers, dwBufferCount, lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, WSASend, s, lpBuffers, dwBufferCount, lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
 	return ret;
 }
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4327,8 +4327,10 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	/* Set target field */
 	/* Optimize away setting of NULL target */
 	if (!MONO_INS_IS_PCONST_NULL (target)) {
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, target->dreg, 0);
-		MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+		if (!(method->flags & METHOD_ATTRIBUTE_STATIC)) {
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, target->dreg, 0);
+			MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+		}
 		MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, target), target->dreg);
 		if (cfg->gen_write_barriers) {
 			dreg = alloc_preg (cfg);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1077,6 +1077,7 @@ type_from_op (MonoCompile *cfg, MonoInst *ins, MonoInst *src1, MonoInst *src2)
 			break;
 		case STACK_PTR:
 		case STACK_MP:
+		case STACK_OBJ:
 #if SIZEOF_VOID_P == 8
 			ins->opcode = OP_LCONV_TO_U;
 #else

--- a/mono/tests/delegate14.cs
+++ b/mono/tests/delegate14.cs
@@ -6,6 +6,12 @@ public static class Program
 {
 	public static int Main (string[] args)
 	{
+		// calling delegate on extension method with null target is allowed
+		Func<int> func = null;
+		if (CallFunc(func.CallFuncIfNotNull) != 0)
+			return 2;
+
+		// constructing delegate on instance method with null target should throw
 		ITest obj = null;
 		try
 		{
@@ -22,5 +28,21 @@ public static class Program
 	interface ITest
 	{
 		void Func ();
+	}
+
+	static int CallFunc(Func<int> func)
+	{
+		return func();
+	}
+}
+
+public static class FuncExtensions
+{
+	public static int CallFuncIfNotNull(this Func<int> func)
+	{
+		if (func != null)
+			return func();
+
+		return 0;
 	}
 }

--- a/mono/utils/mono-threads-posix-signals.c
+++ b/mono/utils/mono-threads-posix-signals.c
@@ -81,7 +81,7 @@ static int
 suspend_signal_get (void)
 {
 #if defined(PLATFORM_ANDROID)
-	return SIGPWR;
+	return SIGUSR1;
 #elif defined (SIGRTMIN)
 	static int suspend_signum = -1;
 	if (suspend_signum == -1)
@@ -100,7 +100,7 @@ static int
 restart_signal_get (void)
 {
 #if defined(PLATFORM_ANDROID)
-	return SIGXCPU;
+	return SIGUSR2;
 #elif defined (SIGRTMIN)
 	static int restart_signum = -1;
 	if (restart_signum == -1)


### PR DESCRIPTION
case 960555 - Fix crash when using 'fixed' statement on a string
case 984723 - Fix Socket.Send failing silently on Windows
case 954427 - Fix Android crash when NullReferenceException is raised
case 973794 - Fix Android crash when script debugger is enabled