### PR TITLE
MonoBleedingEdge Fixes for 2017.1

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -201,7 +201,7 @@ mono_gc_base_init (void)
 	GC_push_other_roots = mono_push_other_roots;
 #endif
 
-#if !defined(PLATFORM_ANDROID)
+#if defined(HAVE_BDWGC_GC) || !defined(PLATFORM_ANDROID)
 	/* If GC_no_dls is set to true, GC_find_limit is not called. This causes a seg fault on Android. */
 	GC_no_dls = TRUE;
 #endif

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5051,8 +5051,10 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	/* Set target field */
 	/* Optimize away setting of NULL target */
 	if (!(target->opcode == OP_PCONST && target->inst_p0 == 0)) {
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, target->dreg, 0);
-		MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+		if (!(method->flags & METHOD_ATTRIBUTE_STATIC)) {
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, target->dreg, 0);
+			MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+		}
 		MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, target), target->dreg);
 		if (cfg->gen_write_barriers) {
 			dreg = alloc_preg (cfg);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1067,6 +1067,7 @@ type_from_op (MonoCompile *cfg, MonoInst *ins, MonoInst *src1, MonoInst *src2)
 			break;
 		case STACK_PTR:
 		case STACK_MP:
+		case STACK_OBJ:
 #if SIZEOF_VOID_P == 8
 			ins->opcode = OP_LCONV_TO_U;
 #else

--- a/mono/tests/delegate14.cs
+++ b/mono/tests/delegate14.cs
@@ -6,6 +6,12 @@ public static class Program
 {
 	public static int Main (string[] args)
 	{
+		// calling delegate on extension method with null target is allowed
+		Func<int> func = null;
+		if (CallFunc(func.CallFuncIfNotNull) != 0)
+			return 2;
+
+		// constructing delegate on instance method with null target should throw
 		ITest obj = null;
 		try
 		{
@@ -22,5 +28,21 @@ public static class Program
 	interface ITest
 	{
 		void Func ();
+	}
+
+	static int CallFunc(Func<int> func)
+	{
+		return func();
+	}
+}
+
+public static class FuncExtensions
+{
+	public static int CallFuncIfNotNull(this Func<int> func)
+	{
+		if (func != null)
+			return func();
+
+		return 0;
 	}
 }


### PR DESCRIPTION
case 960555 - Fix crash when using 'fixed' statement on a string
ase 954427 - Fix Android crash when NullReferenceException is raised