### PR TITLE
Fixing debugger command CMD_TYPE_IS_INITIALIZED for il2cpp

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10076,7 +10076,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 #ifndef RUNTIME_IL2CPP
 			buffer_add_int (buf, (vtable->initialized || vtable->init_failed) ? 1 : 0);
 #else
-			buffer_add_int (buf, vtable->initialized ? 1 : 0);
+			buffer_add_int (buf, klass->initialized ? 1 : 0);
 #endif
 		else
 			buffer_add_int (buf, 0);


### PR DESCRIPTION
Changing the CMD_TYPE_IS_INITIALIZED command for the il2cpp case in
the debugger agent to use the klass instead of the vtable.  The local
vtable variable in this case points to the actual IL2CPP vtable and
will not have the "initialized" bit we are looking for.