### PR TITLE
Updated unitytls_interface_struct to newest version

### DIFF
--- a/mcs/class/System/Mono.UnityTls/UnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTls.cs
@@ -177,9 +177,9 @@ namespace Mono.Unity
 
             public delegate unitytls_key_ref                              unitytls_key_get_ref_t(unitytls_key* key, unitytls_errorstate* errorState);
             public unitytls_key_get_ref_t                                 unitytls_key_get_ref;
-            public delegate unitytls_key*                                 unitytls_key_parse_pem_t(Int8* buffer, size_t bufferLen, UInt8* password, size_t passwordLen, unitytls_errorstate* errorState);
+            public delegate unitytls_key*                                 unitytls_key_parse_pem_t(Int8* buffer, size_t bufferLen, Int8* password, size_t passwordLen, unitytls_errorstate* errorState);
             public unitytls_key_parse_der_t                               unitytls_key_parse_pem;
-            public delegate unitytls_key*                                 unitytls_key_parse_der_t(UInt8* buffer, size_t bufferLen, UInt8* password, size_t passwordLen, unitytls_errorstate* errorState);
+            public delegate unitytls_key*                                 unitytls_key_parse_der_t(UInt8* buffer, size_t bufferLen, Int8* password, size_t passwordLen, unitytls_errorstate* errorState);
             public unitytls_key_parse_der_t                               unitytls_key_parse_der;
             public delegate void                                          unitytls_key_free_t(unitytls_key* key);
             public unitytls_key_free_t                                    unitytls_key_free;

--- a/mcs/class/System/Mono.UnityTls/UnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTls.cs
@@ -168,6 +168,7 @@ namespace Mono.Unity
         public class unitytls_interface_struct
         {
             public readonly UInt64 UNITYTLS_INVALID_HANDLE;
+            public readonly unitytls_tlsctx_protocolrange UNITYTLS_TLSCTX_PROTOCOLRANGE_DEFAULT;
 
             public delegate unitytls_errorstate                           unitytls_errorstate_create_t();
             public unitytls_errorstate_create_t                           unitytls_errorstate_create;
@@ -176,6 +177,8 @@ namespace Mono.Unity
 
             public delegate unitytls_key_ref                              unitytls_key_get_ref_t(unitytls_key* key, unitytls_errorstate* errorState);
             public unitytls_key_get_ref_t                                 unitytls_key_get_ref;
+            public delegate unitytls_key*                                 unitytls_key_parse_pem_t(Int8* buffer, size_t bufferLen, UInt8* password, size_t passwordLen, unitytls_errorstate* errorState);
+            public unitytls_key_parse_der_t                               unitytls_key_parse_pem;
             public delegate unitytls_key*                                 unitytls_key_parse_der_t(UInt8* buffer, size_t bufferLen, UInt8* password, size_t passwordLen, unitytls_errorstate* errorState);
             public unitytls_key_parse_der_t                               unitytls_key_parse_der;
             public delegate void                                          unitytls_key_free_t(unitytls_key* key);
@@ -194,6 +197,8 @@ namespace Mono.Unity
             public unitytls_x509list_append_t                             unitytls_x509list_append;
             public delegate void                                          unitytls_x509list_append_der_t(unitytls_x509list* list, UInt8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
             public unitytls_x509list_append_der_t                         unitytls_x509list_append_der;
+            public delegate void                                          unitytls_x509list_append_pem_t(unitytls_x509list* list, Int8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
+            public unitytls_x509list_append_der_t                         unitytls_x509list_append_pem;
             public delegate void                                          unitytls_x509list_free_t(unitytls_x509list* list);
             public unitytls_x509list_free_t                               unitytls_x509list_free;
 


### PR DESCRIPTION
Since we don't use the interface actively outside of local testing, it is still safe to add functions and fields in the struct.
The added fields/functions are needed for Curl integration which relies on this struct as well.

Later on once all this is in active use, we can only safely change the struct by appending elements *at the end*. Right now however, we still have the luxury of changing the byte offsets to make it look pretty