### PR TITLE
Changing sequence point IDs to integers 

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5675,7 +5675,7 @@ static void
 #ifndef RUNTIME_IL2CPP
 process_single_step_inner (DebuggerTlsData *tls, gboolean from_signal)
 #else
-process_single_step_inner (DebuggerTlsData *tls, gboolean from_signal, uint64_t sequencePointId)
+process_single_step_inner (DebuggerTlsData *tls, gboolean from_signal, int sequencePointId)
 #endif
 {
 	MonoJitInfo *ji;
@@ -5871,7 +5871,7 @@ void
 #ifndef RUNTIME_IL2CPP
 debugger_agent_single_step_from_context (MonoContext *ctx)
 #else
-debugger_agent_single_step_from_context (MonoContext *ctx, uint64_t sequencePointId)
+debugger_agent_single_step_from_context (MonoContext *ctx, int sequencePointId)
 #endif
 {
 	DebuggerTlsData *tls;

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -30,7 +30,7 @@ void
 #ifndef RUNTIME_IL2CPP
 debugger_agent_single_step_from_context (MonoContext *ctx);
 #else
-debugger_agent_single_step_from_context (MonoContext *ctx, uint64_t sequencePointId);
+debugger_agent_single_step_from_context (MonoContext *ctx, int sequencePointId);
 #endif
 
 void

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -444,6 +444,6 @@ MonoGenericInst* il2cpp_method_get_generic_class_inst(MonoMethodInflated *imetho
 MonoClass* il2cpp_generic_class_get_container_class(MonoGenericClass *gclass);
 void il2cpp_mono_thread_detach(MonoThread* thread);
 MonoClass* il2cpp_mono_get_string_class (void);
-Il2CppSequencePoint* il2cpp_get_sequence_point(size_t id);
+Il2CppSequencePoint* il2cpp_get_sequence_point(int id);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -1482,7 +1482,7 @@ MonoClass* il2cpp_mono_get_string_class (void)
 	return (MonoClass*)il2cpp_defaults.string_class;
 }
 
-Il2CppSequencePoint* il2cpp_get_sequence_point(size_t id)
+Il2CppSequencePoint* il2cpp_get_sequence_point(int id)
 {
 #if IL2CPP_MONO_DEBUGGER
     return il2cpp::utils::Debugger::GetSequencePoint(id);


### PR DESCRIPTION
They are array indexes now instead of arbitrary hash codes.