### PR TITLE
Fixes an issue where a pipestream handle may be closed twice (Case 942966)

### DIFF
--- a/mcs/class/System.Core/System.IO.Pipes/PipeStream.cs
+++ b/mcs/class/System.Core/System.IO.Pipes/PipeStream.cs
@@ -137,7 +137,7 @@ namespace System.IO.Pipes
 #pragma warning disable 618
 					stream = new FileStream (handle.DangerousGetHandle (),
 								 CanRead ? (CanWrite ? FileAccess.ReadWrite : FileAccess.Read)
-								 	 : FileAccess.Write, true, buffer_size, IsAsync);
+								 	 : FileAccess.Write, false, buffer_size, IsAsync);
 #pragma warning restore 618					
 				}
 				return stream;


### PR DESCRIPTION
Release Notes: Fixes a random crash when closing named pipes from C#
----------
The PipeStream class has its own Dispose implementation, but it passes a dangerous handle internally to a FileStream, and tells the filestream that it also owns this handle. As a result the finalizer for filestream also closes the handle, which causes problems when the handle has been reused