### PR TITLE
Backport TimeZoneInfo Fixes to 2018.1 (Case 943047)

### DIFF
--- a/mcs/class/corlib/System/TimeZone.cs
+++ b/mcs/class/corlib/System/TimeZone.cs
@@ -210,5 +210,18 @@ namespace System
 
 			return LocalTimeZone.IsDaylightSavingTime (dateTime);
 		}
+
+
+		// Internal method to get timezone data.
+		//    data[0]:  start of daylight saving time (in DateTime ticks).
+		//    data[1]:  end of daylight saving time (in DateTime ticks).
+		//    data[2]:  utcoffset (in TimeSpan ticks).
+		//    data[3]:  additional offset when daylight saving (in TimeSpan ticks).
+		//    name[0]:  name of this timezone when not daylight saving.
+		//    name[1]:  name of this timezone when daylight saving.
+#if UNITY
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		public static extern bool GetTimeZoneData (int year, out Int64[] data, out string[] names);
+#endif
 	}
 }

--- a/mcs/class/corlib/System/TimeZoneInfo.Unity.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.Unity.cs
@@ -1,0 +1,136 @@
+//
+// System.TimeZoneInfo helper for MonoTouch
+// 	because the devices cannot access the file system to read the data
+//
+// Authors:
+//	Sebastien Pouliot  <sebastien@xamarin.com>
+//
+// Copyright 2011-2013 Xamarin Inc.
+//
+// The class can be either constructed from a string (from user code)
+// or from a handle (from iphone-sharp.dll internal calls).  This
+// delays the creation of the actual managed string until actually
+// required
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#if UNITY
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+
+namespace System {
+
+	public partial class TimeZoneInfo {
+		enum TimeZoneData
+		{
+		    DaylightSavingStartIdx,
+		    DaylightSavingEndIdx,
+		    UtcOffsetIdx,
+		    AdditionalDaylightOffsetIdx
+		};
+		
+		enum TimeZoneNames
+		{
+		    StandardNameIdx,
+		    DaylightNameIdx
+		};
+		static TimeZoneInfo CreateLocalUnity ()
+		{
+			Int64[] data;
+		    string[] names;
+		    if (!System.CurrentSystemTimeZone.GetTimeZoneData (1973, out data, out names))
+				throw new NotSupportedException ("Can't get timezone name.");
+
+		    TimeSpan utcOffsetTS = TimeSpan.FromTicks(data[(int)TimeZoneData.UtcOffsetIdx]);
+		    char utcOffsetSign = (utcOffsetTS >= TimeSpan.Zero) ? '+' : '-';
+		    string displayName = "(GMT" + utcOffsetSign + utcOffsetTS.ToString(@"hh\:mm") + ") Local Time";
+		    string standardDisplayName = names[(int)TimeZoneNames.StandardNameIdx];
+		    string daylightDisplayName = names[(int)TimeZoneNames.DaylightNameIdx];
+		    
+		    //Create The Adjustment Rules For This TimeZoneInfo.
+		    var adjustmentList = new List<TimeZoneInfo.AdjustmentRule>();
+		    for(int year = 1973; year <= 2037; year++)
+		    {	    
+				if (!System.CurrentSystemTimeZone.GetTimeZoneData (year, out data, out names))
+					continue;
+				
+				DaylightTime dlt = new DaylightTime (new DateTime (data[(int)TimeZoneData.DaylightSavingStartIdx]),
+								     new DateTime (data[(int)TimeZoneData.DaylightSavingEndIdx]),
+								     new TimeSpan (data[(int)TimeZoneData.AdditionalDaylightOffsetIdx]));
+				
+				DateTime dltStartTime = new DateTime(1, 1, 1).Add(dlt.Start.TimeOfDay);
+				DateTime dltEndTime = new DateTime(1, 1, 1).Add(dlt.End.TimeOfDay);
+
+				if (dlt.Start == dlt.End)
+					continue;
+
+				TimeZoneInfo.TransitionTime startTime = TimeZoneInfo.TransitionTime.CreateFixedDateRule(dltStartTime, dlt.Start.Month, dlt.Start.Day);
+				TimeZoneInfo.TransitionTime endTime = TimeZoneInfo.TransitionTime.CreateFixedDateRule(dltEndTime, dlt.End.Month, dlt.End.Day);
+				
+
+				//mktime only supports dates starting in 1973, so create an adjustment rule for years before 1973 following 1973s rules 
+				if (year == 1973)
+				{
+				    TimeZoneInfo.AdjustmentRule firstRule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(DateTime.MinValue,
+															     new DateTime(1969, 12, 31),
+															     dlt.Delta,
+															     startTime,
+															     endTime);
+				    adjustmentList.Add(firstRule);
+				}
+				
+				TimeZoneInfo.AdjustmentRule rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(new DateTime(year, 1, 1),
+														    new DateTime(year, 12, 31),
+														    dlt.Delta,
+														    startTime,
+														    endTime);
+				adjustmentList.Add(rule);
+				
+				//mktime only supports dates up to 2037, so create an adjustment rule for years after 2037 following 2037s rules 
+				if (year == 2037)
+				{
+					// create a max date that does not include any time of day offset to make CreateAdjustmentRule happy
+					var maxDate = new DateTime(DateTime.MaxValue.Year, DateTime.MaxValue.Month, DateTime.MaxValue.Day);
+				    TimeZoneInfo.AdjustmentRule lastRule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(new DateTime(2038, 1, 1),
+				    											maxDate,
+															    dlt.Delta,
+															    startTime,
+															    endTime);
+				    adjustmentList.Add(lastRule);
+				}
+		    }
+		    
+		    return TimeZoneInfo.CreateCustomTimeZone("local",
+									   utcOffsetTS,
+									   displayName,
+									   standardDisplayName,
+									   daylightDisplayName,
+									   adjustmentList.ToArray(),
+									   false);
+		}
+	}
+}
+
+#endif

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -170,9 +170,15 @@ namespace System
 #endif
 
 #if UNITY
-			var localTimeZoneFallback = CreateLocalUnity();
-			if(localTimeZoneFallback == null)
-			    localTimeZoneFallback = Utc;
+			TimeZoneInfo localTimeZoneFallback = null;
+			try {
+				localTimeZoneFallback = CreateLocalUnity();
+			} catch {
+				localTimeZoneFallback = null;
+			}
+
+			if (localTimeZoneFallback == null)
+				localTimeZoneFallback = Utc;
 #endif
 
 			var tz = Environment.GetEnvironmentVariable ("TZ");

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -142,6 +142,7 @@ System/TimeZoneInfo.cs
 System/TimeZoneInfo.Android.cs
 System/TimeZoneInfo.MonoTouch.cs
 System/TimeZoneInfo.Serialization.cs
+System/TimeZoneInfo.Unity.cs
 System/TimeZoneInfo.WinRT.cs
 ../../build/common/MonoTODOAttribute.cs
 System/TypeIdentifier.cs

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -147,7 +147,8 @@ unity_sources = \
 	unity-memory-info.c \
 	unity-memory-info.h \
 	unity-utils.c   \
-	unity-utils.h
+	unity-utils.h	\
+	unity-icall.c
 
 common_sources = \
 	$(platform_sources)	\

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -186,6 +186,9 @@ ICALL(CONSOLE_3, "SetBreak", ves_icall_System_ConsoleDriver_SetBreak )
 ICALL(CONSOLE_4, "SetEcho", ves_icall_System_ConsoleDriver_SetEcho )
 ICALL(CONSOLE_5, "TtySetup", ves_icall_System_ConsoleDriver_TtySetup )
 
+ICALL_TYPE(TZONE, "System.CurrentSystemTimeZone", TZONE_1)
+ICALL(TZONE_1, "GetTimeZoneData", ves_icall_System_CurrentSystemTimeZone_GetTimeZoneData)
+
 ICALL_TYPE(DTIME, "System.DateTime", DTIME_1)
 ICALL(DTIME_1, "GetSystemTimeAsFileTime", mono_100ns_datetime)
 

--- a/mono/metadata/icall-internals.h
+++ b/mono/metadata/icall-internals.h
@@ -10,6 +10,10 @@
 #include <glib.h>
 #include <mono/metadata/object-internals.h>
 
+// UNITY
+guint32
+ves_icall_System_CurrentSystemTimeZone_GetTimeZoneData (guint32 year, MonoArray **data, MonoArray **names);
+
 // On Windows platform implementation of bellow methods are hosted in separate source file
 // icall-windows.c or icall-windows-*.c. On other platforms the implementation is still keept
 // in icall.c still declared as static and in some places even inlined.

--- a/mono/metadata/unity-icall.c
+++ b/mono/metadata/unity-icall.c
@@ -1,0 +1,259 @@
+/**
+ * \file
+ * Unity icall support for Mono.
+ *
+ * Copyright 2016 Unity
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+#include <config.h>
+#include <glib.h>
+#include "mono/utils/mono-compiler.h"
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/domain-internals.h>
+#include <mono/metadata/exception.h>
+#include <mono/metadata/metadata-internals.h>
+#include <mono/metadata/object.h>
+#include <mono/metadata/object-internals.h>
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+
+/*
+ * Magic number to convert a time which is relative to
+ * Jan 1, 1970 into a value which is relative to Jan 1, 0001.
+ */
+#define	EPOCH_ADJUST	((guint64)62135596800LL)
+
+/*
+ * Magic number to convert FILETIME base Jan 1, 1601 to DateTime - base Jan, 1, 0001
+ */
+#define FILETIME_ADJUST ((guint64)504911232000000000LL)
+
+#ifdef PLATFORM_WIN32
+/* convert a SYSTEMTIME which is of the form "last thursday in october" to a real date */
+static void
+convert_to_absolute_date(SYSTEMTIME *date)
+{
+#define IS_LEAP(y) ((y % 4) == 0 && ((y % 100) != 0 || (y % 400) == 0))
+	static int days_in_month[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+	static int leap_days_in_month[] = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+	/* from the calendar FAQ */
+	int a = (14 - date->wMonth) / 12;
+	int y = date->wYear - a;
+	int m = date->wMonth + 12 * a - 2;
+	int d = (1 + y + y/4 - y/100 + y/400 + (31*m)/12) % 7;
+
+	/* d is now the day of the week for the first of the month (0 == Sunday) */
+
+	int day_of_week = date->wDayOfWeek;
+
+	/* set day_in_month to the first day in the month which falls on day_of_week */    
+	int day_in_month = 1 + (day_of_week - d);
+	if (day_in_month <= 0)
+		day_in_month += 7;
+
+	/* wDay is 1 for first weekday in month, 2 for 2nd ... 5 means last - so work that out allowing for days in the month */
+	date->wDay = day_in_month + (date->wDay - 1) * 7;
+	if (date->wDay > (IS_LEAP(date->wYear) ? leap_days_in_month[date->wMonth - 1] : days_in_month[date->wMonth - 1]))
+		date->wDay -= 7;
+}
+#endif
+
+#ifndef PLATFORM_WIN32
+/*
+ * Return's the offset from GMT of a local time.
+ * 
+ *  tm is a local time
+ *  t  is the same local time as seconds.
+ */
+static int 
+gmt_offset(struct tm *tm, time_t t)
+{
+#if defined (HAVE_TM_GMTOFF)
+	return tm->tm_gmtoff;
+#else
+	struct tm g;
+	time_t t2;
+	g = *gmtime(&t);
+	g.tm_isdst = tm->tm_isdst;
+	t2 = mktime(&g);
+	return (int)difftime(t, t2);
+#endif
+}
+#endif
+/*
+ * This is heavily based on zdump.c from glibc 2.2.
+ *
+ *  * data[0]:  start of daylight saving time (in DateTime ticks).
+ *  * data[1]:  end of daylight saving time (in DateTime ticks).
+ *  * data[2]:  utcoffset (in TimeSpan ticks).
+ *  * data[3]:  additional offset when daylight saving (in TimeSpan ticks).
+ *  * name[0]:  name of this timezone when not daylight saving.
+ *  * name[1]:  name of this timezone when daylight saving.
+ *
+ *  FIXME: This only works with "standard" Unix dates (years between 1900 and 2100) while
+ *         the class library allows years between 1 and 9999.
+ *
+ *  Returns true on success and zero on failure.
+ */
+guint32
+ves_icall_System_CurrentSystemTimeZone_GetTimeZoneData (guint32 year, MonoArray **data, MonoArray **names)
+{
+	MonoError error;
+#ifndef PLATFORM_WIN32
+	MonoDomain *domain = mono_domain_get ();
+	struct tm start, tt;
+	time_t t;
+
+	long int gmtoff;
+	int is_daylight = 0, day;
+	char tzone [64];
+
+	MONO_CHECK_ARG_NULL (data, FALSE);
+	MONO_CHECK_ARG_NULL (names, FALSE);
+
+	mono_gc_wbarrier_generic_store (data, (MonoObject*) mono_array_new_checked (domain, mono_defaults.int64_class, 4, &error));
+	mono_gc_wbarrier_generic_store (names, (MonoObject*) mono_array_new_checked (domain, mono_defaults.string_class, 2, &error));
+
+	/* 
+	 * no info is better than crashing: we'll need our own tz data
+	 * to make this work properly, anyway. The range is probably
+	 * reduced to 1970 .. 2037 because that is what mktime is
+	 * guaranteed to support (we get into an infinite loop
+	 * otherwise).
+	 */
+
+	memset (&start, 0, sizeof (start));
+
+	start.tm_mday = 1;
+	start.tm_year = year-1900;
+
+	t = mktime (&start);
+
+	if ((year < 1970) || (year > 2037) || (t == -1)) {
+		t = time (NULL);
+		tt = *localtime (&t);
+		strftime (tzone, sizeof (tzone), "%Z", &tt);
+		mono_array_setref ((*names), 0, mono_string_new_checked (domain, tzone, &error));
+		mono_array_setref ((*names), 1, mono_string_new_checked (domain, tzone, &error));
+		return 1;
+	}
+
+	gmtoff = gmt_offset (&start, t);
+
+	/* For each day of the year, calculate the tm_gmtoff. */
+	for (day = 0; day < 365; day++) {
+
+		t += 3600*24;
+		tt = *localtime (&t);
+
+		/* Daylight saving starts or ends here. */
+		if (gmt_offset (&tt, t) != gmtoff) {
+			struct tm tt1;
+			time_t t1;
+
+			/* Try to find the exact hour when daylight saving starts/ends. */
+			t1 = t;
+			do {
+				t1 -= 3600;
+				tt1 = *localtime (&t1);
+			} while (gmt_offset (&tt1, t1) != gmtoff);
+
+			/* Try to find the exact minute when daylight saving starts/ends. */
+			do {
+				t1 += 60;
+				tt1 = *localtime (&t1);
+			} while (gmt_offset (&tt1, t1) == gmtoff);
+			t1+=gmtoff;
+			strftime (tzone, sizeof (tzone), "%Z", &tt);
+			
+			/* Write data, if we're already in daylight saving, we're done. */
+			if (is_daylight) {
+				mono_array_setref ((*names), 0, mono_string_new_checked (domain, tzone, &error));
+				mono_array_set ((*data), gint64, 1, ((gint64)t1 + EPOCH_ADJUST) * 10000000L);
+				return 1;
+			} else {
+				mono_array_setref ((*names), 1, mono_string_new_checked (domain, tzone, &error));
+				mono_array_set ((*data), gint64, 0, ((gint64)t1 + EPOCH_ADJUST) * 10000000L);
+				is_daylight = 1;
+			}
+
+			/* This is only set once when we enter daylight saving. */
+			mono_array_set ((*data), gint64, 2, (gint64)gmtoff * 10000000L);
+			mono_array_set ((*data), gint64, 3, (gint64)(gmt_offset (&tt, t) - gmtoff) * 10000000L);
+
+			gmtoff = gmt_offset (&tt, t);
+		}
+	}
+
+	if (!is_daylight) {
+		strftime (tzone, sizeof (tzone), "%Z", &tt);
+		mono_array_setref ((*names), 0, mono_string_new_checked (domain, tzone, &error));
+		mono_array_setref ((*names), 1, mono_string_new_checked (domain, tzone, &error));
+		mono_array_set ((*data), gint64, 0, 0);
+		mono_array_set ((*data), gint64, 1, 0);
+		mono_array_set ((*data), gint64, 2, (gint64) gmtoff * 10000000L);
+		mono_array_set ((*data), gint64, 3, 0);
+	}
+
+	return 1;
+#else
+	MonoDomain *domain = mono_domain_get ();
+	TIME_ZONE_INFORMATION tz_info;
+	FILETIME ft;
+	int i;
+	int err, tz_id;
+
+	tz_id = GetTimeZoneInformation (&tz_info);
+	if (tz_id == TIME_ZONE_ID_INVALID)
+		return 0;
+
+	MONO_CHECK_ARG_NULL (data);
+	MONO_CHECK_ARG_NULL (names);
+
+	mono_gc_wbarrier_generic_store (data, mono_array_new (domain, mono_defaults.int64_class, 4));
+	mono_gc_wbarrier_generic_store (names, mono_array_new (domain, mono_defaults.string_class, 2));
+
+	for (i = 0; i < 32; ++i)
+		if (!tz_info.DaylightName [i])
+			break;
+	mono_array_setref ((*names), 1, mono_string_new_utf16 (domain, tz_info.DaylightName, i));
+	for (i = 0; i < 32; ++i)
+		if (!tz_info.StandardName [i])
+			break;
+	mono_array_setref ((*names), 0, mono_string_new_utf16 (domain, tz_info.StandardName, i));
+
+	if ((year <= 1601) || (year > 30827)) {
+		/*
+		 * According to MSDN, the MS time functions can't handle dates outside
+		 * this interval.
+		 */
+		return 1;
+	}
+
+	/* even if the timezone has no daylight savings it may have Bias (e.g. GMT+13 it seems) */
+	if (tz_id != TIME_ZONE_ID_UNKNOWN) {
+		tz_info.StandardDate.wYear = year;
+		convert_to_absolute_date(&tz_info.StandardDate);
+		err = SystemTimeToFileTime (&tz_info.StandardDate, &ft);
+		//g_assert(err);
+		if (err == 0)
+			return 0;
+		
+		mono_array_set ((*data), gint64, 1, FILETIME_ADJUST + (((guint64)ft.dwHighDateTime<<32) | ft.dwLowDateTime));
+		tz_info.DaylightDate.wYear = year;
+		convert_to_absolute_date(&tz_info.DaylightDate);
+		err = SystemTimeToFileTime (&tz_info.DaylightDate, &ft);
+		//g_assert(err);
+		if (err == 0)
+			return 0;
+		
+		mono_array_set ((*data), gint64, 0, FILETIME_ADJUST + (((guint64)ft.dwHighDateTime<<32) | ft.dwLowDateTime));
+	}
+	mono_array_set ((*data), gint64, 2, (tz_info.Bias + tz_info.StandardBias) * -600000000LL);
+	mono_array_set ((*data), gint64, 3, (tz_info.DaylightBias - tz_info.StandardBias) * -600000000LL);
+
+	return 1;
+#endif
+}

--- a/msvc/libmonoruntime-unity.targets
+++ b/msvc/libmonoruntime-unity.targets
@@ -6,6 +6,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\unity-memory-info.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\unity-utils.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\unity-utils.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\unity-icall.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\oop.c" />
   </ItemGroup>
 </Project>

--- a/msvc/libmonoruntime-unity.targets.filters
+++ b/msvc/libmonoruntime-unity.targets.filters
@@ -22,7 +22,6 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\oop.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\unity</Filter>
     </ClCompile>
-
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files$(MonoRuntimeFilterSubFolder)\unity">

--- a/msvc/libmonoruntime-unity.targets.filters
+++ b/msvc/libmonoruntime-unity.targets.filters
@@ -16,9 +16,13 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\unity-utils.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\unity</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\unity-icall.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\unity</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\oop.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\unity</Filter>
     </ClCompile>
+
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files$(MonoRuntimeFilterSubFolder)\unity">


### PR DESCRIPTION
Release Notes: Fixes an issue where certain platforms failed to do time conversions to a user's local timezone
---