### PR TITLE
Reuse class unload cache filter logic in debugger (case 974228)

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -913,5 +913,8 @@ mono_find_image_set_owner (void *ptr);
 void
 mono_loader_register_module (const char *name, MonoDl *module);
 
+gboolean
+mono_type_in_image (MonoType *type, MonoImage *image);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2294,6 +2294,12 @@ retry:
 	}
 }
 
+gboolean
+mono_type_in_image (MonoType *type, MonoImage *image)
+{
+	return type_in_image (type, image);
+}
+
 static inline void
 image_sets_lock (void)
 {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6773,7 +6773,7 @@ clear_event_requests_for_assembly (MonoAssembly *assembly)
 static gboolean
 type_comes_from_assembly (gpointer klass, gpointer also_klass, gpointer assembly)
 {
-	return (mono_class_get_image ((MonoClass*)klass) == mono_assembly_get_image ((MonoAssembly*)assembly));
+	return mono_type_in_image (mono_class_get_type ((MonoClass*)klass), mono_assembly_get_image ((MonoAssembly*)assembly));
 }
 
 /*


### PR DESCRIPTION
case 974228 - Fix crash on exit when using script debugger

Debugger maintains it's own list of loaded classes. The unload/filter
logic does not handle composite types like arrays and generic instances.
Expose and reuse the logic from metadata that properly detects any
usage of an image within a type.

This prevents the cache from containing MonoClass values which have
already been freed by the metadata cleaning code.