### PR TITLE
Add legacy profiler support for allocations (case 988906)

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1307,7 +1307,7 @@ mono_gc_get_managed_allocator_by_type (int atype, ManagedAllocatorVariant varian
 guint32
 mono_gc_get_managed_allocator_types (void)
 {
-	return ATYPE_NUM;
+	return 0;
 }
 
 MonoMethod*

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -559,7 +559,7 @@ mono_profiler_sampling_thread_wait (void)
 mono_bool
 mono_profiler_enable_allocations (void)
 {
-	if (mono_profiler_state.startup_done)
+	if (mono_gc_get_managed_allocator_types () > 0 && mono_profiler_state.startup_done)
 		return FALSE;
 
 	return mono_profiler_state.allocations = TRUE;
@@ -1105,6 +1105,9 @@ mono_profiler_set_events (int flags)
 	else
 		mono_profiler_set_call_instrumentation_filter_callback (current->handle, NULL);
 	/* Do nothing. */
+
+	if (flags & MONO_PROFILE_ALLOCATIONS)
+		mono_profiler_enable_allocations ();
 }
 
 static void


### PR DESCRIPTION
Return in Boehm 0 for number of managed allocators.
If GC has no managed allocators, allow allocation profiling to be
set lazily.

case 988906 - Fix GC allocation profiling