### PR TITLE
Fix legacy mono incorrectly freeing a handle (Case 929984)

### DIFF
--- a/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafePipeHandle.cs
+++ b/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafePipeHandle.cs
@@ -46,12 +46,8 @@ namespace Microsoft.Win32.SafeHandles
 
 		protected override bool ReleaseHandle ()
 		{
-			try {
-				Marshal.FreeHGlobal (handle);
-				return true;
-			} catch (ArgumentException) {
-				return false;
-			}
+			MonoIOError error;
+			return MonoIO.Close (handle, out error);
 		}
 	}
 }

--- a/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafePipeHandle.cs
+++ b/mcs/class/System.Core/Microsoft.Win32.SafeHandles/SafePipeHandle.cs
@@ -32,6 +32,13 @@ using System.Security.AccessControl;
 using System.Security.Permissions;
 using System.Security.Principal;
 
+namespace System.IO
+{
+	internal enum MonoIOError: int {
+		ERROR_SUCCESS = 0
+	}
+}
+
 namespace Microsoft.Win32.SafeHandles
 {
 	[HostProtection (SecurityAction.LinkDemand, MayLeakOnAbort = true)]

--- a/mcs/class/System.Core/System.Core.dll.sources
+++ b/mcs/class/System.Core/System.Core.dll.sources
@@ -3,6 +3,7 @@
 ../../build/common/MonoTODOAttribute.cs
 ../corlib/Mono.Security.Cryptography/CryptoTools.cs
 ../corlib/Mono.Security.Cryptography/SymmetricTransform.cs
+../System/System.IO/MonoIO.cs
 Assembly/AssemblyInfo.cs
 System/Actions.cs
 System/Funcs.cs

--- a/mcs/class/System.Core/System.IO.Pipes/PipeStream.cs
+++ b/mcs/class/System.Core/System.IO.Pipes/PipeStream.cs
@@ -128,7 +128,7 @@ namespace System.IO.Pipes
 				if (!IsConnected)
 					throw new InvalidOperationException ("Pipe is not connected");
 				if (stream == null)
-					stream = new FileStream (handle.DangerousGetHandle (), CanRead ? (CanWrite ? FileAccess.ReadWrite : FileAccess.Read) : FileAccess.Write, true, buffer_size, IsAsync);
+					stream = new FileStream (handle.DangerousGetHandle (), CanRead ? (CanWrite ? FileAccess.ReadWrite : FileAccess.Read) : FileAccess.Write, false, buffer_size, IsAsync);
 				return stream;
 			}
 			set { stream = value; }


### PR DESCRIPTION
Release Notes:
Fixes an issue in the 3.5 mono libraries, which cause pipestream handles to be incorrectly closed, leading to a crash
--------------------

To fix the old runtime, we need both a fix for incorrectly freeing memory at the address of a handle (corrupting memory) as well as the fix needed for the 4.6 runtime, where the pipestream claims ownership of the handle, and tells and internal filestream that it also owns the handle. Both of these fixes have been cherry picked into this old runtime