### PR TITLE
Remove extra reference count on images loaded via byte array (case 923165)

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2175,6 +2175,9 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 		return refass; 
 	}
 
+	/* Clear the reference added by mono_image_open_from_data_full above */
+	mono_image_close (image);
+
 	refass = mono_assembly_get_object_handle (domain, ass, error);
 	if (!MONO_HANDLE_IS_NULL(refass))
 		MONO_HANDLE_SET (refass, evidence, evidence);


### PR DESCRIPTION
case 923165 - Fix memory corruption/crash after domain reload when using Assembly.Load(Byte[])

Upstream PR: mono#6656