### PR TITLE
Backport Fix issue on android where HTTPClient.GetAsync will fail with libc error (case 935292) 

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/IPGlobalProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPGlobalProperties.cs
@@ -52,8 +52,17 @@ namespace System.Net.NetworkInformation {
 		public override string DomainName {
 			get {
 				byte [] bytes = new byte [256];
-				if (getdomainname (bytes, 256) != 0)
-					throw new NetworkInformationException ();
+#if UNITY
+				try
+				{
+#endif
+					if (getdomainname (bytes, 256) != 0)
+						throw new NetworkInformationException ();
+#if UNITY
+				} catch (EntryPointNotFoundException) {
+					return String.Empty;
+				}
+#endif
 				int len = Array.IndexOf<byte> (bytes, 0);
 				return Encoding.ASCII.GetString (bytes, 0, len < 0 ? 256 : len);
 			}


### PR DESCRIPTION
Release Notes: Fixes an issue where HTTPClient.GetAsync would fail on android with unable to find libc error
--------------------------

libc is not available on android, so getdomainname will throw a EntryPointNotFoundException.  Do what mono does for android in this case and return an empty string.