### PR TITLE
[mcs] Inflate constraints of compiler generated proxy base call metho…

### DIFF
--- a/mcs/mcs/ecore.cs
+++ b/mcs/mcs/ecore.cs
@@ -3356,6 +3356,8 @@ namespace Mono.CSharp {
 				// introduce redundant storey but with `this' only but it's tricky to avoid
 				// at this stage as we don't know what expressions follow base
 				//
+				// TODO: It's needed only when the method with base call is moved to a storey
+				//
 				if (rc.CurrentAnonymousMethod != null) {
 					if (targs == null && method.IsGeneric) {
 						targs = method.TypeArguments;

--- a/mcs/mcs/generic.cs
+++ b/mcs/mcs/generic.cs
@@ -428,13 +428,13 @@ namespace Mono.CSharp {
 		public TypeParameter (TypeParameterSpec spec, TypeSpec parentSpec, MemberName name, Attributes attrs)
 			: base (null, name, attrs)
 		{
-			this.spec = new TypeParameterSpec (parentSpec, spec.DeclaredPosition, spec.MemberDefinition, spec.SpecialConstraint, spec.Variance, null) {
+			this.spec = new TypeParameterSpec (parentSpec, spec.DeclaredPosition, this, spec.SpecialConstraint, spec.Variance, null) {
 				BaseType = spec.BaseType,
 				InterfacesDefined = spec.InterfacesDefined,
 				TypeArguments = spec.TypeArguments
 			};
 		}
-		
+
 		#region Properties
 
 		public override AttributeTargets AttributeTargets {
@@ -2162,6 +2162,10 @@ namespace Mono.CSharp {
 				return this;
 
 			var mutated = (InflatedTypeSpec) MemberwiseClone ();
+#if DEBUG
+			mutated.ID += 1000000;
+#endif
+
 			if (decl != DeclaringType) {
 				// Gets back MethodInfo in case of metaInfo was inflated
 				//mutated.info = MemberCache.GetMember<TypeSpec> (DeclaringType.GetDefinition (), this).info;

--- a/mcs/mcs/method.cs
+++ b/mcs/mcs/method.cs
@@ -444,6 +444,10 @@ namespace Mono.CSharp {
 			return ms;
 		}
 
+#if DEBUG
+		int counter = 100000;
+#endif
+
 		public MethodSpec MakeGenericMethod (IMemberContext context, params TypeSpec[] targs)
 		{
 			if (targs == null)
@@ -465,6 +469,10 @@ namespace Mono.CSharp {
 			inflated.constraints = TypeParameterSpec.InflateConstraints (inflator, constraints ?? GenericDefinition.TypeParameters);
 			inflated.state |= StateFlags.PendingMakeMethod;
 
+#if DEBUG
+			inflated.ID += counter;
+			counter += 100000;
+#endif
 			//			if (inflated.parent == null)
 			//				inflated.parent = parent;
 

--- a/mcs/tests/test-anon-178.cs
+++ b/mcs/tests/test-anon-178.cs
@@ -1,0 +1,31 @@
+using System;
+
+public abstract class BaseClass<T>
+{
+}
+
+public class DerivedClass : BaseClass<int>
+{
+}
+
+public abstract class CA
+{
+	[Obsolete]
+	public virtual void Foo<T, U> (U args) where T : BaseClass<U>, new()
+	{
+	}
+}
+
+public class CB : CA
+{
+	public CB ()
+	{
+		int x = 4;
+		Action<int> pp = r => base.Foo<DerivedClass, int> (x);
+	}
+
+	public static void Main ()
+	{
+		new CB ();
+	}
+}

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -56785,6 +56785,45 @@
       </method>
     </type>
   </test>
+  <test name="test-anon-178.cs">
+    <type name="BaseClass`1[T]">
+      <method name="Void .ctor()" attrs="6276">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="DerivedClass">
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="CA">
+      <method name="Void Foo[T,U](U)" attrs="454">
+        <size>2</size>
+      </method>
+      <method name="Void .ctor()" attrs="6276">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="CB">
+      <method name="Void Main()" attrs="150">
+        <size>8</size>
+      </method>
+      <method name="Void &lt;Foo&gt;__BaseCallProxy0[T,U](U)" attrs="129">
+        <size>8</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>41</size>
+      </method>
+    </type>
+    <type name="CB+&lt;CB&gt;c__AnonStorey0">
+      <method name="Void &lt;&gt;m__0(Int32)" attrs="131">
+        <size>18</size>
+      </method>
+      <method name="Void .ctor()" attrs="6278">
+        <size>7</size>
+      </method>
+    </type>
+  </test>
   <test name="test-anon-18.cs">
     <type name="A">
       <method name="Void Invoke()" attrs="454">


### PR DESCRIPTION
…ds. Fixes #52294

case 991464 - Corrected a C# compiler bug which could result in "the type cannot be used as type parameter `T' in the generic type or method" errors. 