### PR TITLE
[Backport 2017.2] System.Math.Round produces wrong result with .NET 3.5 (Case 993302)

### DIFF
--- a/mcs/class/corlib/System/Math.cs
+++ b/mcs/class/corlib/System/Math.cs
@@ -411,6 +411,8 @@ namespace System
 		{
 			if (digits < 0 || digits > 15)
 				throw new ArgumentOutOfRangeException (Locale.GetText ("Value is too small or too big."));
+			if (digits == 0)
+				return Round (value);
 
 			return Round2(value, digits, false);
 		}
@@ -437,6 +439,8 @@ namespace System
 		{
 			if ((mode != MidpointRounding.ToEven) && (mode != MidpointRounding.AwayFromZero))
 				throw new ArgumentException ("The value '" + mode + "' is not valid for this usage of the type MidpointRounding.", "mode");
+			if (digits == 0)
+				return Round (value, mode);
 
 			if (mode == MidpointRounding.ToEven)
 				return Round (value, digits);

--- a/mcs/class/corlib/Test/System/MathTest.cs
+++ b/mcs/class/corlib/Test/System/MathTest.cs
@@ -964,6 +964,8 @@ namespace MonoTests.System
 
 			Assert.AreEqual (-63987.83593942D, Math.Round (-63987.83593942D, 8, MidpointRounding.ToEven), "#3B");
 			Assert.AreEqual (-63987.83593942D, Math.Round (-63987.83593942D, 8, MidpointRounding.AwayFromZero), "#3C");
+
+			Assert.AreEqual (1, Math.Round (0.5, 0, MidpointRounding.AwayFromZero));
 		}
 #endif
 		

--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -66,8 +66,6 @@ gdouble ves_icall_System_Math_Round2 (gdouble value, gint32 digits, gboolean awa
 		return HUGE_VAL;
 	if (value == -HUGE_VAL)
 		return -HUGE_VAL;
-	if (digits == 0)
-		return ves_icall_System_Math_Round(value);
 	p = pow(10, digits);
 #if defined (HAVE_ROUND) && defined (HAVE_RINT)
 	if (away_from_zero)


### PR DESCRIPTION
Release Notes: Fixes an issue where System.Math.Round would fail to follow the MidpointRounding.AwayFromZero parameter.
----------------------------------

Before this fix midpoint rounding mode was lost in case digits = 0.
Now this case is checked on the managed side and Round2 is only
used for digits > 0.