### PR TITLE
IL2CPP debugger metadata improvement

### DIFF
--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -446,5 +446,8 @@ void il2cpp_mono_thread_detach(MonoThread* thread);
 MonoClass* il2cpp_mono_get_string_class (void);
 Il2CppSequencePoint* il2cpp_get_sequence_point(int id);
 char* il2cpp_assembly_get_full_name(MonoAssembly *assembly);
+const MonoMethod* il2cpp_get_seq_point_method(Il2CppSequencePoint *seqPoint);
+const MonoClass* il2cpp_get_class_from_index(int index);
+const MonoType* il2cpp_get_type_from_index(int index);
 
 #endif // RUNTIME_IL2CPP

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -1504,5 +1504,23 @@ char* il2cpp_assembly_get_full_name(MonoAssembly *assembly)
     return g_strdup(s.c_str());
 }
 
+const MonoMethod* il2cpp_get_seq_point_method(Il2CppSequencePoint *seqPoint)
+{
+    return il2cpp::utils::Debugger::GetSequencePointMethod(seqPoint);
+}
+
+const MonoClass* il2cpp_get_class_from_index(int index)
+{
+    if (index < 0)
+        return NULL;
+
+    return il2cpp::vm::MetadataCache::GetTypeInfoFromTypeIndex(index);
+}
+
+const MonoType* il2cpp_get_type_from_index(int index)
+{
+    return il2cpp::vm::MetadataCache::GetIl2CppTypeFromIndex(index);
+}
+
 }
 #endif // RUNTIME_IL2CPP


### PR DESCRIPTION
Changing debugger metadata to a format that will be faster to compile
as well lend itself to being output as a binary format that can be
memory-mapped at runtime.  Changed everything to use static
initializers instead of function calls, replaced externally linked
pointers with indexes, and pulled out redundant string data into
separate tables.  Using a table-of-tables format with a separate
index for large amounts of data that must be spread among multiple
files.