### PR TITLE
Cleaning up mono/mini directory in IL2CPP externals

### DIFF
--- a/external/buildscripts/sources.txt
+++ b/external/buildscripts/sources.txt
@@ -540,23 +540,8 @@ support/libm/math_private.h
 ####################
 #mono mini files
 ####################
-mono/mini/aot-runtime.h
-mono/mini/cfgdump.h
 mono/mini/debugger-agent.c
 mono/mini/debugger-agent.h
 mono/mini/il2cpp-c-types.h
 mono/mini/il2cpp-compat.h
 mono/mini/il2cpp-stubs.cpp
-mono/mini/jit.h
-mono/mini/mini-amd64.h
-mono/mini/mini-arch.h
-mono/mini/mini-ops.h
-mono/mini/mini-runtime.h
-mono/mini/mini-unwind.h
-mono/mini/mini-x86.h
-mono/mini/mini.h
-mono/mini/optflags-def.h
-mono/mini/patch-info.h
-mono/mini/regalloc.h
-mono/mini/seq-points.h
-mono/mini/interp/interp.h

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -78,11 +78,21 @@
 #include <mono/utils/networking.h>
 #include <mono/utils/mono-proclib.h>
 #include <mono/utils/w32api.h>
+
+#ifndef RUNTIME_IL2CPP
 #include "mini.h"
 #include "seq-points.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
 #include "interp/interp.h"
+#endif
+
+#ifdef RUNTIME_IL2CPP
+#include <mono/metadata/seq-points-data.h>
+#include <mono/metadata/profiler.h>
+#include <mono/metadata/tokentype.h>
+#define MONO_ARCH_SOFT_DEBUG_SUPPORTED
+#endif
 
 /*
  * On iOS we can't use System.Environment.Exit () as it will do the wrong
@@ -2267,6 +2277,7 @@ void mono_debugger_il2cpp_init (const Il2CppDebuggerMetadataRegistration *data)
 {
 	s_jit_info_hashtable = g_hash_table_new_full(mono_aligned_addr_hash, NULL, NULL, NULL);
     g_il2cpp_metadata = data;
+    debug_options.native_debugger_break = FALSE;
 }
 
 static gpointer
@@ -4475,6 +4486,8 @@ breakpoints_init (void)
  *   Insert the breakpoint described by BP into the method described by
  * JI.
  */
+#ifndef RUNTIME_IL2CPP
+
 static void
 insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo *ji, MonoBreakpoint *bp, MonoError *error)
 {
@@ -4564,7 +4577,6 @@ insert_breakpoint (MonoSeqPointInfo *seq_points, MonoDomain *domain, MonoJitInfo
 	DEBUG_PRINTF (1, "[dbg] Inserted breakpoint at %s:[il=0x%x,native=0x%x] [%p](%d).\n", mono_method_full_name (jinfo_get_method (ji), TRUE), (int)it.seq_point.il_offset, (int)it.seq_point.native_offset, inst->ip, count);
 }
 
-#ifndef RUNTIME_IL2CPP
 
 static void
 remove_breakpoint (BreakpointInstance *inst)
@@ -4694,6 +4706,8 @@ add_pending_breakpoints (MonoMethod *method, MonoJitInfo *ji)
 #endif
 }
 
+#ifndef RUNTIME_IL2CPP
+
 static void
 set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_points, MonoBreakpoint *bp, MonoError *error)
 {
@@ -4722,6 +4736,8 @@ set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_
 
 	insert_breakpoint (seq_points, domain, ji, bp, error);
 }
+
+#endif
 
 static void
 clear_breakpoint (MonoBreakpoint *bp);
@@ -8124,8 +8140,10 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 	MonoObject *this_arg, *res, *exc = NULL;
 	MonoDomain *domain;
 	guint8 *this_buf;
-#ifdef MONO_ARCH_SOFT_DEBUG_SUPPORTED
+#ifndef RUNTIME_IL2CPP
+#ifdef MONO_ARCH_SOFT_DEBUG_SUPPORTED 
 	MonoLMFExt ext;
+#endif
 #endif
 	MonoStopwatch watch;
 

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -5,7 +5,10 @@
 #ifndef __MONO_DEBUGGER_AGENT_H__
 #define __MONO_DEBUGGER_AGENT_H__
 
+#ifndef RUNTIME_IL2CPP
 #include "mini.h"
+#endif
+
 #include "il2cpp-compat.h"
 #include <mono/utils/mono-stack-unwinding.h>
 

--- a/mono/mini/il2cpp-c-types.h
+++ b/mono/mini/il2cpp-c-types.h
@@ -52,6 +52,11 @@ typedef struct _Il2CppMonoMethodSignature Il2CppMonoMethodSignature;
 typedef struct _Il2CppMonoRuntimeExceptionHandlingCallbacks Il2CppMonoRuntimeExceptionHandlingCallbacks;
 typedef struct Il2CppDefaults Il2CppMonoDefaults;
 typedef struct _Il2CppMonoTypeNameParse Il2CppMonoTypeNameParse;
+typedef struct _Il2CppMonoDebugOptions Il2CppMonoDebugOptions;
+typedef struct _Il2CppEmptyStruct Il2CppMonoLMF;
+
+typedef MonoStackFrameInfo StackFrameInfo;
+typedef gpointer MonoInterpFrameHandle;
 
 typedef gboolean (*Il2CppMonoInternalStackWalk) (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer data);
 
@@ -76,10 +81,20 @@ struct _Il2CppMonoTypeNameParse
 	void *il2cppTypeNameParseInfo;
 };
 
+struct _Il2CppMonoDebugOptions
+{
+    gboolean native_debugger_break;
+};
+
+struct _Il2CppEmptyStruct
+{
+    int dummy;
+};
+
 TYPED_HANDLE_DECL (MonoObject);
 TYPED_HANDLE_DECL (MonoReflectionAssembly);
 Il2CppMonoDefaults il2cpp_mono_defaults;
-MonoDebugOptions il2cpp_mono_debug_options;
+Il2CppMonoDebugOptions il2cpp_mono_debug_options;
 
 typedef void (*Il2CppMonoProfileFunc) (MonoProfiler *prof);
 typedef void (*Il2CppMonoProfileAppDomainFunc) (MonoProfiler *prof, MonoDomain *domain);

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -50,6 +50,8 @@
 #define MonoRuntimeExceptionHandlingCallbacks Il2CppMonoRuntimeExceptionHandlingCallbacks
 #define debug_options il2cpp_mono_debug_options
 #define MonoTypeNameParse Il2CppMonoTypeNameParse
+#define MonoDebugOptions Il2CppMonoDebugOptions
+#define MonoLMF Il2CppMonoLMF
 
 #define mono_image_get_entry_point il2cpp_mono_image_get_entry_point
 #define mono_image_get_filename il2cpp_mono_image_get_filename
@@ -257,6 +259,9 @@
 #define mono_domain_assemblies_unlock
 
 #define mono_get_string_class il2cpp_mono_get_string_class
+
+#define MONO_MAX_IREGS 1
+#define NOT_IMPLEMENTED do { g_assert_not_reached (); } while (0)
 
 MonoMethod* il2cpp_mono_image_get_entry_point (MonoImage *image);
 const char* il2cpp_mono_image_get_filename (MonoImage *image);

--- a/mono/mini/il2cpp-stubs.cpp
+++ b/mono/mini/il2cpp-stubs.cpp
@@ -40,7 +40,6 @@ extern "C" {
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/profiler.h>
 #include <mono/sgen/sgen-conf.h>
-#include <mono/mini/mini.h>
 #include <mono/metadata/seq-points-data.h>
 #include "il2cpp-c-types.h"
 #include <mono/metadata/il2cpp-compat-metadata.h>
@@ -970,7 +969,7 @@ MonoMethod* il2cpp_mono_marshal_method_from_wrapper(MonoMethod* wrapper)
 	return NULL;
 }
 
-MonoDebugOptions* il2cpp_mini_get_debug_options()
+Il2CppMonoDebugOptions* il2cpp_mini_get_debug_options()
 {
 	IL2CPP_ASSERT(0 && "This method is not yet implemented");
 	return NULL;
@@ -982,13 +981,13 @@ gpointer il2cpp_mono_jit_find_compiled_method_with_jit_info(MonoDomain* domain, 
 	return 0;
 }
 
-MonoLMF** il2cpp_mono_get_lmf_addr()
+Il2CppMonoLMF** il2cpp_mono_get_lmf_addr()
 {
 	IL2CPP_ASSERT(0 && "This method is not yet implemented");
 	return NULL;
 }
 
-void il2cpp_mono_set_lmf(MonoLMF* lmf)
+void il2cpp_mono_set_lmf(Il2CppMonoLMF* lmf)
 {
 	IL2CPP_ASSERT(0 && "This method is not yet implemented");
 }


### PR DESCRIPTION
Removing unneeded files from the IL2CPP external/mono/mono/mini
directory.  The extra files were causing compilation errors on
Android due to pre-existing platform support that we weren't using.
Stubbing out types and re-defining a few things to support these
changes.