### PR TITLE
Free cached custom attrs in domain (case 911661)

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1199,7 +1199,7 @@ mono_domain_create (void)
 	domain->jit_info_table = jit_info_table_new (domain);
 	domain->jit_info_free_queue = NULL;
 	domain->finalizable_objects_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
-	domain->class_custom_attributes = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_custom_attrs_free);
+	domain->class_custom_attributes = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_custom_attrs_free_cached);
 #ifndef HAVE_SGEN_GC
 	domain->track_resurrection_handles_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 #endif

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1228,6 +1228,15 @@ mono_custom_attrs_free (MonoCustomAttrInfo *ainfo)
 		g_free (ainfo);
 }
 
+void
+mono_custom_attrs_free_cached (MonoCustomAttrInfo *ainfo)
+{
+	if (ainfo) {
+		g_assert (ainfo->cached);
+		g_free (ainfo);
+	}
+}
+
 /*
  * idx is the table index of the object
  * type is one of MONO_CUSTOM_ATTR_*

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -88,6 +88,7 @@ MonoCustomAttrInfo* mono_custom_attrs_from_param    (MonoMethod *method, guint32
 gboolean            mono_custom_attrs_has_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
 MonoObject*         mono_custom_attrs_get_attr      (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass);
 void                mono_custom_attrs_free          (MonoCustomAttrInfo *ainfo);
+void                mono_custom_attrs_free_cached   (MonoCustomAttrInfo *ainfo);
 
 
 #define MONO_DECLSEC_ACTION_MIN		0x1


### PR DESCRIPTION
Add mono_custom_attrs_free_cached that is explicitly for freeing
cached attributes. The hash table destructor was using the normal
mono_custom_attrs_free which avoids freeing cached attrs.

Release Notes: Fix memory leak when entering play mode

Backports: To at least 2017.2