### PR TITLE
Do not throw exceptions when deleting files or directories on TempFileCollection

### DIFF
--- a/mcs/class/System/System.CodeDom.Compiler/TempFileCollection.cs
+++ b/mcs/class/System/System.CodeDom.Compiler/TempFileCollection.cs
@@ -237,19 +237,37 @@ namespace System.CodeDom.Compiler {
 
 			foreach(string file in filenames) {
 				if((bool)filehash[file]==false) {
-					File.Delete(file);
+					DeleteFile(file);
 					filehash.Remove(file);
 				} else
 					allDeleted = false;
 			}
 			if (basepath != null) {
 				string tmpFile = basepath + ".tmp";
-				File.Delete (tmpFile);
+				DeleteFile(tmpFile);
 				basepath = null;
 			}
 			if (allDeleted && ownTempDir != null) {
-				Directory.Delete (ownTempDir, true);
+				DeleteDirectory(ownTempDir, true);
 				ownTempDir = null;
+			}
+		}
+
+		void DeleteDirectory(string path, bool recursive) {
+			try {
+				Directory.Delete(path, recursive);
+			}
+			catch {
+				// Ignore all exceptions
+			}
+		}
+
+		void DeleteFile(string path) {
+			try {
+				File.Delete(path);
+			}
+			catch {
+				// Ignore all exceptions
 			}
 		}
 


### PR DESCRIPTION
*Purpose of this PR*:

Currently TempFileCollection could throw exceptions when deleting temp files because those temp files could not exist anymore. 
Throwing exceptions on these cases would break the deletion loop, so not all the temp files would be deleted leaving garbage on the disk. 
Also, we are making a change on Unity that would log all unhandled exceptions in the console, these exceptions are causing some test to fail.

We have checked on the Microsoft implementation and they are also ignoring the exceptions: https://github.com/dotnet/corefx/blob/master/src/Common/src/System/IO/TempFileCollection.cs#L162

*Release Notes*:

Scripting: Do not throw exceptions when deleting files or directories on TempFileCollection.

