### PR TITLE
Fix TrimExcess to not increase size (case 969832)

### DIFF
--- a/mcs/class/System.Core/System.Collections.Generic/HashSet.cs
+++ b/mcs/class/System.Core/System.Collections.Generic/HashSet.cs
@@ -193,9 +193,9 @@ namespace System.Collections.Generic {
 			}
 		}
 
-		void Resize ()
+		void Resize (int size)
 		{
-			int newSize = PrimeHelper.ToPrime ((table.Length << 1) | 1);
+			int newSize = PrimeHelper.ToPrime (size);
 
 			// allocate new hash table and link slots array
 			var newTable = new int [newSize];
@@ -244,7 +244,7 @@ namespace System.Collections.Generic {
 				return false;
 
 			if (++count > threshold) {
-				Resize ();
+				Resize ((table.Length << 1) | 1);
 				index = (hashCode & int.MaxValue) % table.Length;
 			}
 
@@ -368,7 +368,7 @@ namespace System.Collections.Generic {
 
 		public void TrimExcess ()
 		{
-			Resize ();
+			Resize (count);
 		}
 
 		// set operations


### PR DESCRIPTION
TrimExcess was calling Resize which assumed the size of the hash
set needed to increase. This meant every call to TrimExcess actually
increased the size of the set.

Release Notes: Reduce capacity when calling HashSet<T>.TrimExcess