### PR TITLE
Remove the machine.config check for IPv6 support

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket_2_1.cs
@@ -85,18 +85,6 @@ namespace System.Net.Sockets {
 			}
 
 			if (ipv6Supported == -1) {
-#if !NET_2_1
-#if NET_2_0 && CONFIGURATION_DEP
-				SettingsSection config;
-				config = (SettingsSection) System.Configuration.ConfigurationManager.GetSection ("system.net/settings");
-				if (config != null)
-					ipv6Supported = config.Ipv6.Enabled ? -1 : 0;
-#else
-				NetConfig config = System.Configuration.ConfigurationSettings.GetConfig("system.net/settings") as NetConfig;
-				if (config != null)
-					ipv6Supported = config.ipv6Enabled ? -1 : 0;
-#endif
-#endif
 				if (ipv6Supported != 0) {
 					try {
 						Socket tmp = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
We want the .NET 2.0 and the .NET 2.0 Subset profile to work the same
with respect to IPv6. Previously, the .NET 2.0 profile checked the
machine.config file for IPv6 support. On Android, we don't ship a
machine.config file, so IPv6 support was not working on Android with the
.NET 2.0 profile.

This change removes the code which checks the machine.config file, and
instead always asks the `Socket` code if it supports IPv6, which should
give us back the proper answer.

This change corrects Unity case 804510 and case 803576.

Release notes:

Add support for IPv6 on Android with the .NET 2.0 profile.