### PR TITLE
Remove the machine.config check for IPv6 support

### DIFF
--- a/mcs/class/System/ReferenceSources/SettingsSectionInternal.cs
+++ b/mcs/class/System/ReferenceSources/SettingsSectionInternal.cs
@@ -30,6 +30,7 @@ namespace System.Net.Configuration {
 
 		internal bool Ipv6Enabled {
 			get {
+#if !UNITY
 #if CONFIGURATION_DEP && !MOBILE
 				try {
 					var config = (SettingsSection) System.Configuration.ConfigurationManager.GetSection ("system.net/settings");
@@ -37,6 +38,7 @@ namespace System.Net.Configuration {
 						return config.Ipv6.Enabled;
 				} catch {
 				}
+#endif
 #endif
 
 				return true;


### PR DESCRIPTION
We want the .NET 4.x and the .NET Standard 2.0 profiles to work the same
with respect to IPv6.  Previously, the .NET 4.x profile checked the
machine.config file for IPv6 support.

This change removes the code which checks the machine.config file, and
instead always returns true. Later, we will use the Unity PAL to get the
proper value for each platform. For now, we want consistency.

I'll back port this to 2018.1.

No release notes for this change.