### PR TITLE
Set the frame ID for the debugger

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3453,18 +3453,18 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls)
 	for (tmp = user_data.frames; tmp; tmp = tmp->next) {
 		f = (StackFrame *)tmp->data;
 
-#ifndef RUNTIME_IL2CPP
 		/* 
 		 * Reuse the id for already existing stack frames, so invokes don't invalidate
 		 * the still valid stack frames.
 		 */
 		for (i = 0; i < tls->frame_count; ++i) {
+#ifndef RUNTIME_IL2CPP
 			if (MONO_CONTEXT_GET_SP (&tls->frames [i]->ctx) == MONO_CONTEXT_GET_SP (&f->ctx)) {
 				f->id = tls->frames [i]->id;
 				break;
 			}
-		}
 #endif // !RUNTIME_IL2CPP
+		}
 
 		if (i >= tls->frame_count)
 			f->id = mono_atomic_inc_i32 (&frame_id);


### PR DESCRIPTION
This code is a bit odd. It depends on the `i` variable value after the
`for` loop. If that `for` loop does not execute (even if the loop body
does nothing), the code won't set the frame ID properly. This causes
locals to be reported for the wrong frame in the `GET_FRAME_INFO`
command.

On a side note, maybe we should implement something for IL2CPP in the
body of for loop, but that is a different issue.

This syncs with the debugger code in the IL2CPP repo. I'll back port this change to 2018.1