### PR TITLE
Support pointer fields in ValueType Equals & GetHashCode (case 1005597)

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1023,6 +1023,9 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this, MonoArray **fi
 		case MONO_TYPE_I4:
 			result ^= *(gint32*)((guint8*)this + field->offset);
 			break;
+		case MONO_TYPE_PTR:
+			result ^= mono_aligned_addr_hash (*(gpointer*)((guint8*)this + field->offset));
+			break;
 		case MONO_TYPE_STRING: {
 			MonoString *s;
 			s = *(MonoString**)((guint8*)this + field->offset);
@@ -1114,6 +1117,10 @@ ves_icall_System_ValueType_Equals (MonoObject *this, MonoObject *that, MonoArray
 			break;
 		case MONO_TYPE_R8:
 			if (*(double*)((guint8*)this + field->offset) != *(double*)((guint8*)that + field->offset))
+				return FALSE;
+			break;
+		case MONO_TYPE_PTR:
+			if (*(gpointer*)((guint8*)this + field->offset) != *(gpointer*)((guint8*)that + field->offset))
 				return FALSE;
 			break;
 


### PR DESCRIPTION
Release Notes:

case 1005597 - Fix crash when calling NativeArray<T>.Equals