### PR TITLE
[Facades] Add missing Facades that exist in .NET 4.7.1 (#7541)

### DIFF
--- a/mcs/class/Facades/System.Net.Http.Rtc/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Net.Http.Rtc/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle ("System.Net.Http.Rtc")]
+[assembly: AssemblyDescription ("System.Net.Http.Rtc")]
+[assembly: AssemblyDefaultAlias ("System.Net.Http.Rtc")]
+[assembly: AssemblyCompany ("Mono development team")]
+[assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
+[assembly: AssemblyVersion ("4.0.0.0")]
+[assembly: AssemblyInformationalVersion ("4.0.0.0")]
+[assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Net.Http.Rtc/Makefile
+++ b/mcs/class/Facades/System.Net.Http.Rtc/Makefile
@@ -1,0 +1,21 @@
+MCS_BUILD_DIR = ../../../build
+
+thisdir = class/Facades/System.Net.Http.Rtc
+SUBDIRS =
+include $(MCS_BUILD_DIR)/rules.make
+
+LIBRARY_SUBDIR = Facades
+LIBRARY_INSTALL_DIR = $(mono_libdir)/mono/$(FRAMEWORK_VERSION)/Facades
+
+LIBRARY = System.Net.Http.Rtc.dll
+
+KEYFILE = ../../msfinal.pub
+SIGN_FLAGS = /delaysign /nowarn:1616,1699
+LIB_REFS = System
+LIB_MCS_FLAGS = $(SIGN_FLAGS)
+
+PLATFORM_DEBUG_FLAGS =
+
+NO_TEST = yes
+
+include $(MCS_BUILD_DIR)/library.make

--- a/mcs/class/Facades/System.Net.Http.Rtc/System.Net.Http.Rtc.dll.sources
+++ b/mcs/class/Facades/System.Net.Http.Rtc/System.Net.Http.Rtc.dll.sources
@@ -1,0 +1,2 @@
+TypeForwarders.cs
+AssemblyInfo.cs

--- a/mcs/class/Facades/System.Net.Http.Rtc/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Net.Http.Rtc/TypeForwarders.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if false // it is forwarded to System.Net.Http.WebRequest.dll but doesn't actually exist there in the .NET 4.7.1 reference assemblies ...
+[assembly:System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Net.Http.RtcRequestFactory))]
+#endif

--- a/mcs/class/Facades/System.Resources.Reader/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Resources.Reader/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+// 
+// Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle ("System.Resources.Reader")]
+[assembly: AssemblyDescription ("System.Resources.Reader")]
+[assembly: AssemblyDefaultAlias ("System.Resources.Reader")]
+[assembly: AssemblyCompany ("Mono development team")]
+[assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
+[assembly: AssemblyVersion ("4.0.2.0")]
+[assembly: AssemblyInformationalVersion ("4.0.0.0")]
+[assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Resources.Reader/Makefile
+++ b/mcs/class/Facades/System.Resources.Reader/Makefile
@@ -1,0 +1,23 @@
+MCS_BUILD_DIR = ../../../build
+
+thisdir = class/Facades/System.Resources.Reader
+SUBDIRS = 
+include $(MCS_BUILD_DIR)/rules.make
+
+LIBRARY_SUBDIR = Facades
+LIBRARY_INSTALL_DIR = $(mono_libdir)/mono/$(FRAMEWORK_VERSION)/Facades
+
+LIBRARY = System.Resources.Reader.dll
+
+KEYFILE = ../../msfinal.pub
+SIGN_FLAGS = /delaysign /nowarn:1616,1699
+LIB_REFS = System
+LIB_MCS_FLAGS = $(SIGN_FLAGS) 
+
+PLATFORM_DEBUG_FLAGS =
+
+NO_TEST = yes
+
+include $(MCS_BUILD_DIR)/library.make
+
+

--- a/mcs/class/Facades/System.Resources.Reader/System.Resources.Reader.dll.sources
+++ b/mcs/class/Facades/System.Resources.Reader/System.Resources.Reader.dll.sources
@@ -1,0 +1,3 @@
+TypeForwarders.cs
+AssemblyInfo.cs
+

--- a/mcs/class/Facades/System.Resources.Reader/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Resources.Reader/TypeForwarders.cs
@@ -1,0 +1,25 @@
+// 
+// Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Resources.ResourceReader))]
+
+

--- a/mcs/class/Facades/System.Resources.Writer/AssemblyInfo.cs
+++ b/mcs/class/Facades/System.Resources.Writer/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+// 
+// Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle ("System.Resources.Writer")]
+[assembly: AssemblyDescription ("System.Resources.Writer")]
+[assembly: AssemblyDefaultAlias ("System.Resources.Writer")]
+[assembly: AssemblyCompany ("Mono development team")]
+[assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
+[assembly: AssemblyVersion ("4.0.2.0")]
+[assembly: AssemblyInformationalVersion ("4.0.0.0")]
+[assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/System.Resources.Writer/Makefile
+++ b/mcs/class/Facades/System.Resources.Writer/Makefile
@@ -1,0 +1,23 @@
+MCS_BUILD_DIR = ../../../build
+
+thisdir = class/Facades/System.Resources.Writer
+SUBDIRS = 
+include $(MCS_BUILD_DIR)/rules.make
+
+LIBRARY_SUBDIR = Facades
+LIBRARY_INSTALL_DIR = $(mono_libdir)/mono/$(FRAMEWORK_VERSION)/Facades
+
+LIBRARY = System.Resources.Writer.dll
+
+KEYFILE = ../../msfinal.pub
+SIGN_FLAGS = /delaysign /nowarn:1616,1699
+LIB_REFS = System
+LIB_MCS_FLAGS = $(SIGN_FLAGS) 
+
+PLATFORM_DEBUG_FLAGS =
+
+NO_TEST = yes
+
+include $(MCS_BUILD_DIR)/library.make
+
+

--- a/mcs/class/Facades/System.Resources.Writer/System.Resources.Writer.dll.sources
+++ b/mcs/class/Facades/System.Resources.Writer/System.Resources.Writer.dll.sources
@@ -1,0 +1,3 @@
+TypeForwarders.cs
+AssemblyInfo.cs
+

--- a/mcs/class/Facades/System.Resources.Writer/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Resources.Writer/TypeForwarders.cs
@@ -1,0 +1,25 @@
+// 
+// Copyright (c) 2015 Xamarin Inc. (http://www.xamarin.com)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Resources.ResourceWriter))]
+
+

--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -27,7 +27,8 @@ System.Xml.XPath System.Xml.XmlDocument System.Xml.Xsl.Primitives Microsoft.Win3
 System.IO.FileSystem.AccessControl System.Reflection.TypeExtensions System.Reflection.Emit.Lightweight System.Reflection.Emit.ILGeneration System.Reflection.Emit \
 System.Threading.AccessControl System.ValueTuple \
 System.Security.Cryptography.Primitives System.Text.Encoding.CodePages System.IO.FileSystem.Watcher \
-System.Security.Cryptography.ProtectedData System.ServiceProcess.ServiceController System.IO.Pipes
+System.Security.Cryptography.ProtectedData System.ServiceProcess.ServiceController System.IO.Pipes \
+System.Net.Http.Rtc System.Net.Ping System.Resources.Reader System.Resources.Writer System.Runtime.Serialization.Formatters System.Security.Cryptography.Csp
 
 # common_SUBDIRS dependencies
 common_DEPS_SUBDIRS = System.Security.Cryptography.X509Certificates System.ServiceModel.Primitives System.Runtime.Serialization.Primitives \
@@ -95,7 +96,7 @@ unreal_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS)
 wasm_SUBDIRS = $(common_DEPS_SUBDIRS) $(netstandard_drawing_SUBDIRS) $(mobile_only_DEPS_SUBDIRS)
 wasm_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS)
 
-mobile_only_SUBDIRS = System.Net.Ping System.Runtime.Serialization.Formatters System.Security.Cryptography.Csp System.Security.Cryptography.Pkcs \
+mobile_only_SUBDIRS = System.Security.Cryptography.Pkcs \
 System.Security.Cryptography.Cng System.Runtime.Loader System.Xml.XPath.XmlDocument System.Reflection.DispatchProxy
 
 mobile_only_DEPS_SUBDIRS = System.Security.Cryptography.OpenSsl


### PR DESCRIPTION
Some of them we had on mobile only, others were missing completely.

Fixes https://github.com/mono/mono/issues/7536

Jonathan - I think this may fix case 996947: https://issuetracker.unity3d.com/issues/system-dot-runtime-dot-serialization-dot-formatters-needs-to-be-included-when-included-console-outputs-that-its-defined-multiple-times