### PR TITLE
Fix HttpWebRequest on UWP and Xbox One (case 989588)

### DIFF
--- a/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
+++ b/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
@@ -46,14 +46,22 @@ namespace System.Net
 			WebProxyData data;
 
 			// TODO: Could re-use some pieces from _AutoWebProxyScriptEngine.cs
-			if (IsWindows ()) {
-				data = InitializeRegistryGlobalProxy ();
+			try {
+				if (IsWindows ()) {
+					data = InitializeRegistryGlobalProxy ();
+					if (data != null)
+						return data;
+				}
+
+				data = ReadEnvVariables ();
 				if (data != null)
 					return data;
 			}
+			catch (DllNotFoundException) {
+				// This path will be hit on UWP since we're not allowed to read from registry
+			}
 
-			data = ReadEnvVariables ();
-			return data ?? new WebProxyData ();
+			return new WebProxyData ();
 		}
 
 		WebProxyData ReadEnvVariables ()


### PR DESCRIPTION
Don't fail constructing WebProxyData if retrieving proxy data from the registry fails with DllNotFoundException. We don't construct it on Unity AOT profile anyway, and it's better for it to work without proxy support than not work at all.

Release notes:

• Universal Windows Platform: Fixed HttpWebRequest throwing DllNotFoundException on IL2CPP scripting backend (case 989588).