### PR TITLE
Fixed calling conventions for unitytls callbacks

### DIFF
--- a/mcs/class/System/Mono.UnityTls/UnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTls.cs
@@ -112,6 +112,7 @@ namespace Mono.Unity
             UNITYTLS_X509VERIFY_FLAG_UNKNOWN_ERROR = 0x08000000,
         }
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate unitytls_x509verify_result unitytls_x509verify_callback(void* userData, unitytls_x509_ref cert, unitytls_x509verify_result result, unitytls_errorstate* errorState);
 
         // ------------------------------------
@@ -144,10 +145,15 @@ namespace Mono.Unity
             public unitytls_protocol max;
         };
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate size_t unitytls_tlsctx_write_callback(void* userData, UInt8* data, size_t bufferLen, unitytls_errorstate* errorState);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate size_t unitytls_tlsctx_read_callback(void* userData, UInt8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void   unitytls_tlsctx_trace_callback(void* userData, unitytls_tlsctx* ctx, Int8* traceMessage, size_t traceMessageLen);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void   unitytls_tlsctx_certificate_callback(void* userData, unitytls_tlsctx* ctx, Int8* cn, size_t cnLen, unitytls_x509name* caList, size_t caListLen, unitytls_x509list_ref* chain, unitytls_key_ref* key, unitytls_errorstate* errorState);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate unitytls_x509verify_result unitytls_tlsctx_x509verify_callback(void* userData, unitytls_x509list_ref chain, unitytls_errorstate* errorState);
 
         [StructLayout (LayoutKind.Sequential)]

--- a/mcs/class/System/Mono.UnityTls/UnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTls.cs
@@ -178,72 +178,103 @@ namespace Mono.Unity
             public readonly UInt64 UNITYTLS_INVALID_HANDLE;
             public readonly unitytls_tlsctx_protocolrange UNITYTLS_TLSCTX_PROTOCOLRANGE_DEFAULT;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_errorstate                           unitytls_errorstate_create_t();
             public unitytls_errorstate_create_t                           unitytls_errorstate_create;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_errorstate_raise_error_t(unitytls_errorstate* errorState, unitytls_error_code errorCode);
             public unitytls_errorstate_raise_error_t                      unitytls_errorstate_raise_error;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_key_ref                              unitytls_key_get_ref_t(unitytls_key* key, unitytls_errorstate* errorState);
             public unitytls_key_get_ref_t                                 unitytls_key_get_ref;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_key*                                 unitytls_key_parse_der_t(UInt8* buffer, size_t bufferLen, Int8* password, size_t passwordLen, unitytls_errorstate* errorState);
             public unitytls_key_parse_der_t                               unitytls_key_parse_der;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_key*                                 unitytls_key_parse_pem_t(Int8* buffer, size_t bufferLen, Int8* password, size_t passwordLen, unitytls_errorstate* errorState);
             public unitytls_key_parse_pem_t                               unitytls_key_parse_pem;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_key_free_t(unitytls_key* key);
             public unitytls_key_free_t                                    unitytls_key_free;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate size_t                                        unitytls_x509_export_der_t(unitytls_x509_ref cert, UInt8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
             public unitytls_x509_export_der_t                             unitytls_x509_export_der;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_x509list_ref                         unitytls_x509list_get_ref_t(unitytls_x509list* list, unitytls_errorstate* errorState);
             public unitytls_x509list_get_ref_t                            unitytls_x509list_get_ref;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_x509_ref                             unitytls_x509list_get_x509_t(unitytls_x509list_ref list, size_t index, unitytls_errorstate* errorState);
             public unitytls_x509list_get_x509_t                           unitytls_x509list_get_x509;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_x509list*                            unitytls_x509list_create_t(unitytls_errorstate* errorState);
             public unitytls_x509list_create_t                             unitytls_x509list_create;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_x509list_append_t(unitytls_x509list* list, unitytls_x509_ref cert, unitytls_errorstate* errorState);
             public unitytls_x509list_append_t                             unitytls_x509list_append;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_x509list_append_der_t(unitytls_x509list* list, UInt8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
             public unitytls_x509list_append_der_t                         unitytls_x509list_append_der;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_x509list_append_pem_t(unitytls_x509list* list, Int8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
             public unitytls_x509list_append_der_t                         unitytls_x509list_append_pem;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_x509list_free_t(unitytls_x509list* list);
             public unitytls_x509list_free_t                               unitytls_x509list_free;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_x509verify_result                    unitytls_x509verify_default_ca_t(unitytls_x509list_ref chain, Int8* cn, size_t cnLen, unitytls_x509verify_callback cb, void* userData, unitytls_errorstate* errorState);
             public unitytls_x509verify_default_ca_t                       unitytls_x509verify_default_ca;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_x509verify_result                    unitytls_x509verify_explicit_ca_t(unitytls_x509list_ref chain, unitytls_x509list_ref trustCA, Int8* cn, size_t cnLen, unitytls_x509verify_callback cb, void* userData, unitytls_errorstate* errorState);
             public unitytls_x509verify_explicit_ca_t                      unitytls_x509verify_explicit_ca;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_tlsctx*                              unitytls_tlsctx_create_server_t(unitytls_tlsctx_protocolrange supportedProtocols, unitytls_tlsctx_callbacks callbacks, unitytls_x509list_ref certChain, unitytls_key_ref leafCertificateKey, unitytls_errorstate* errorState);
             public unitytls_tlsctx_create_server_t                        unitytls_tlsctx_create_server;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_tlsctx*                              unitytls_tlsctx_create_client_t(unitytls_tlsctx_protocolrange supportedProtocols, unitytls_tlsctx_callbacks callbacks, Int8* cn, size_t cnLen, unitytls_errorstate* errorState);
             public unitytls_tlsctx_create_client_t                        unitytls_tlsctx_create_client;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_server_require_client_authentication_t(unitytls_tlsctx* ctx, unitytls_x509list_ref clientAuthCAList, unitytls_errorstate* errorState);
             public unitytls_tlsctx_server_require_client_authentication_t unitytls_tlsctx_server_require_client_authentication;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_set_certificate_callback_t(unitytls_tlsctx* ctx, unitytls_tlsctx_certificate_callback cb, void* userData, unitytls_errorstate* errorState);
             public unitytls_tlsctx_set_certificate_callback_t             unitytls_tlsctx_set_certificate_callback;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_set_trace_callback_t(unitytls_tlsctx* ctx, unitytls_tlsctx_trace_callback cb, void* userData, unitytls_errorstate* errorState);
             public unitytls_tlsctx_set_trace_callback_t                   unitytls_tlsctx_set_trace_callback;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_set_x509verify_callback_t(unitytls_tlsctx* ctx, unitytls_tlsctx_x509verify_callback cb, void* userData, unitytls_errorstate* errorState);
             public unitytls_tlsctx_set_x509verify_callback_t              unitytls_tlsctx_set_x509verify_callback;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_set_supported_ciphersuites_t(unitytls_tlsctx* ctx, unitytls_ciphersuite* supportedCiphersuites, size_t supportedCiphersuitesLen, unitytls_errorstate* errorState);
             public unitytls_tlsctx_set_supported_ciphersuites_t           unitytls_tlsctx_set_supported_ciphersuites;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_ciphersuite                          unitytls_tlsctx_get_ciphersuite_t(unitytls_tlsctx* ctx, unitytls_errorstate* errorState);
             public unitytls_tlsctx_get_ciphersuite_t                      unitytls_tlsctx_get_ciphersuite;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_protocol                             unitytls_tlsctx_get_protocol_t(unitytls_tlsctx* ctx, unitytls_errorstate* errorState);
             public unitytls_tlsctx_get_protocol_t                         unitytls_tlsctx_get_protocol;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate unitytls_x509verify_result                    unitytls_tlsctx_process_handshake_t(unitytls_tlsctx* ctx, unitytls_errorstate* errorState);
             public unitytls_tlsctx_process_handshake_t                    unitytls_tlsctx_process_handshake;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate size_t                                        unitytls_tlsctx_read_t(unitytls_tlsctx* ctx, UInt8* buffer, size_t bufferLen, unitytls_errorstate* errorState);
             public unitytls_tlsctx_read_t                                 unitytls_tlsctx_read;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate size_t                                        unitytls_tlsctx_write_t(unitytls_tlsctx* ctx, UInt8* data, size_t bufferLen, unitytls_errorstate* errorState);
             public unitytls_tlsctx_write_t                                unitytls_tlsctx_write;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_notify_close_t(unitytls_tlsctx* ctx, unitytls_errorstate* errorState);
             public unitytls_tlsctx_notify_close_t                         unitytls_tlsctx_notify_close;
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_tlsctx_free_t(unitytls_tlsctx* ctx);
             public unitytls_tlsctx_free_t                                 unitytls_tlsctx_free;
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void                                          unitytls_random_generate_bytes_t(UInt8 * buffer, size_t bufferLen, unitytls_errorstate * errorState);
             public unitytls_random_generate_bytes_t                       unitytls_random_generate_bytes;
         }


### PR DESCRIPTION
for calls native -> managed

Led to crashes on Win32

