### PR TITLE
Fix issue #7596 on Windows x64. (#7625)

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -606,7 +606,7 @@ add_valuetype_win64 (MonoMethodSignature *signature, ArgInfo *arg_info, MonoType
 	get_valuetype_size_win64 (klass, signature->pinvoke, arg_info, type, &arg_class, &arg_size);
 
 	/* Only drop value type if its not an empty struct as input that must be represented in call */
-	if ((arg_size == 0 && !arg_info->pass_empty_struct) || (arg_size == 0 && arg_info->pass_empty_struct && is_return)) {
+	if ((arg_size == 0 && !arg_info->pass_empty_struct) || (arg_info->pass_empty_struct && is_return)) {
 		arg_info->storage = ArgValuetypeInReg;
 		arg_info->pair_storage [0] = arg_info->pair_storage [1] = ArgNone;
 	} else {
@@ -2228,7 +2228,8 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 		g_assert (ainfo->storage == ArgValuetypeAddrInIReg || (ainfo->storage == ArgValuetypeAddrOnStack && ainfo->pair_storage [0] == ArgNone));
 		
 		vtaddr = mono_compile_create_var (cfg, &ins->klass->byval_arg, OP_LOCAL);
-		
+		vtaddr->backend.is_pinvoke = call->signature->pinvoke;
+
 		MONO_INST_NEW (cfg, load, OP_LDADDR);
 		cfg->has_indirection = TRUE;
 		load->inst_p0 = vtaddr;

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -112,6 +112,12 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-table.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-internals.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
case 1001996 - Fix p/invoke on Win32 when soft debugger is enabled

* Fix error in vcxproj filter causing load error in Visual Studio.

* Fixes issue #7596 on Windows x64.

Passing value types in Windows x64 not fitting into register will be passed
by reference (ArgValuetypeAddrInIReg or ArgValuetypeAddrOnStack )
using a local variable allocated in caller’s frame.

Current implementation sized and marshaled the native struct correctly when
using pinvoke, but it sized the final local passed as reference to the native method
using the managed stack size instead of the native. This caused the final copy
into the local to overwrite other locals on stack if managed and native struct stack
sizes differed.

The fix is to flag the local variable used as stack parameter with its pinvoke state.
This makes sure the stack allocation size will be correct when using value types
passed on the stacks in pinvokes.

When running other unit tests with sequence points I hit a similar issue with
empty structs as return parameters (using [StructLayout (LayoutKind.Sequential, Size = 0)].
This commit includes a fix to ignore the return value if it’s an empty struct on Windows x64.