### PR TITLE
Fix for "double-step" issue in il2cpp debugger

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -12277,9 +12277,9 @@ unity_process_breakpoint_inner(DebuggerTlsData *tls, gboolean from_signal, Il2Cp
 
 	if (ss_reqs->len > 0)
 		ss_events = create_event_list(EVENT_KIND_STEP, ss_reqs, sequencePoint, NULL, &suspend_policy);
-	if (bp_reqs->len > 0)
+	else if (bp_reqs->len > 0)
 		bp_events = create_event_list(EVENT_KIND_BREAKPOINT, bp_reqs, sequencePoint, NULL, &suspend_policy);
-	if (kind != EVENT_KIND_BREAKPOINT)
+	else if (kind != EVENT_KIND_BREAKPOINT)
 		enter_leave_events = create_event_list(kind, NULL, sequencePoint, NULL, &suspend_policy);
 
 	mono_loader_unlock();


### PR DESCRIPTION
unity_process_breakpoint_inner(), like its Mono counterpart, will
process breakpoint, stepping, and method exit/entry events all at the
same time when checking a sequence point.  So, if there is is a
breakpoint and a stepping event at the same time, the debugger agent
will suspend the current thread twice, which means you have to click
the step button in the debugger client twice on that line.  The fix
for this is to only consider one of these events at a time and ignore
the others.