### PR TITLE
Unity master invalid string allocations

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6285,6 +6285,24 @@ mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length,
 	return o;
 }
 
+static MonoString*
+mono_string_new_internal (MonoDomain *domain, const char *text)
+{
+	MonoError error;
+	MonoString *res = NULL;
+	res = mono_string_new_checked (domain, text, &error);
+	if (!is_ok (&error)) {
+		/* Mono API compatability: assert on Out of Memory errors,
+		* return NULL otherwise (most likely an invalid UTF-8 byte
+		* sequence). */
+		if (mono_error_get_error_code (&error) == MONO_ERROR_OUT_OF_MEMORY)
+			mono_error_assert_ok (&error);
+		else
+			mono_error_cleanup (&error);
+	}
+	return res;
+}
+
 /**
  * mono_string_new:
  * \param text a pointer to a UTF-8 string
@@ -6295,19 +6313,7 @@ mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length,
 MonoString*
 mono_string_new (MonoDomain *domain, const char *text)
 {
-	MonoError error;
-	MonoString *res = NULL;
-	res = mono_string_new_checked (domain, text, &error);
-	if (!is_ok (&error)) {
-		/* Mono API compatability: assert on Out of Memory errors,
-		 * return NULL otherwise (most likely an invalid UTF-8 byte
-		 * sequence). */
-		if (mono_error_get_error_code (&error) == MONO_ERROR_OUT_OF_MEMORY)
-			mono_error_assert_ok (&error);
-		else
-			mono_error_cleanup (&error);
-	}
-	return res;
+	return mono_string_new_internal (domain, text);
 }
 
 /**
@@ -6380,16 +6386,7 @@ mono_string_new_wrapper (const char *text)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoDomain *domain = mono_domain_get ();
-
-	if (text) {
-		MonoError error;
-		MonoString *result = mono_string_new_checked (domain, text, &error);
-		mono_error_assert_ok (&error);
-		return result;
-	}
-
-	return NULL;
+	return mono_string_new_internal (mono_domain_get (), text);
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6298,7 +6298,15 @@ mono_string_new (MonoDomain *domain, const char *text)
 	MonoError error;
 	MonoString *res = NULL;
 	res = mono_string_new_checked (domain, text, &error);
-	mono_error_assert_ok (&error);
+	if (!is_ok (&error)) {
+		/* Mono API compatability: assert on Out of Memory errors,
+		 * return NULL otherwise (most likely an invalid UTF-8 byte
+		 * sequence). */
+		if (mono_error_get_error_code (&error) == MONO_ERROR_OUT_OF_MEMORY)
+			mono_error_assert_ok (&error);
+		else
+			mono_error_cleanup (&error);
+	}
 	return res;
 }
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -63,7 +63,7 @@ struct _MonoErrorBoxed {
 void
 mono_error_assert_ok_pos (MonoError *error, const char* filename, int lineno) MONO_LLVM_INTERNAL;
 
-#define mono_error_assert_ok(e) mono_error_assert_ok_pos (e, __FILE__, __LINE__);
+#define mono_error_assert_ok(e) mono_error_assert_ok_pos (e, __FILE__, __LINE__)
 
 void
 mono_error_dup_strings (MonoError *error, gboolean dup_strings);


### PR DESCRIPTION
case 1015822 - Avoid assert and crash on invalid text content