### PR TITLE
Add .NET FW to beginning of path rather than end

### DIFF
--- a/external/buildscripts/build_unityscript_bareminimum_win.pl
+++ b/external/buildscripts/build_unityscript_bareminimum_win.pl
@@ -37,7 +37,7 @@ sub AddDotNetFolderToPath() {
     }
 
 	print("Using .Net framework: $netFrameworkLocation");
-	$ENV{PATH} = "$ENV{PATH};$netFrameworkLocation";
+	$ENV{PATH} = "$netFrameworkLocation;$ENV{PATH}";
 }
 
 AddDotNetFolderToPath();


### PR DESCRIPTION
Fixes bare minimum runtime build. Windows agents now have Mono in the path with an MSBuild.exe.