### PR TITLE
Use An AOT-friendly Linq implementation

### DIFF
--- a/mcs/class/System.Core/unityaot_System.Core.dll.exclude.sources
+++ b/mcs/class/System.Core/unityaot_System.Core.dll.exclude.sources
@@ -1,0 +1,1 @@
+../../../external/corefx/src/System.Linq/src/System/Linq/*.cs

--- a/mcs/class/System.Core/unityaot_System.Core.dll.sources
+++ b/mcs/class/System.Core/unityaot_System.Core.dll.sources
@@ -1,1 +1,3 @@
 #include winaot_System.Core.dll.sources
+../referencesource/System.Core/System/Linq/Enumerable.cs
+corefx/SR.cs

--- a/mcs/class/referencesource/System.Core/System/Linq/Enumerable.cs
+++ b/mcs/class/referencesource/System.Core/System/Linq/Enumerable.cs
@@ -2776,7 +2776,11 @@ namespace System.Linq
         {
             get
             {
+#if UNITY_AOT
+                return SR.EmptyEnumerable;
+#else
                 return Strings.EmptyEnumerable;
+#endif
             }
         }
     }
@@ -2829,4 +2833,49 @@ namespace System.Linq
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         private int count;
     }
+
+#if UNITY_AOT
+    // <summary>
+    /// An iterator that can produce an array or <see cref="List{TElement}"/> through an optimized path.
+    /// </summary>
+    internal interface IIListProvider<TElement> : IEnumerable<TElement>
+    {
+        /// <summary>
+        /// Produce an array of the sequence through an optimized path.
+        /// </summary>
+        /// <returns>The array.</returns>
+        TElement[] ToArray();
+
+        /// <summary>
+        /// Produce a <see cref="List{TElement}"/> of the sequence through an optimized path.
+        /// </summary>
+        /// <returns>The <see cref="List{TElement}"/>.</returns>
+        List<TElement> ToList();
+
+        /// <summary>
+        /// Returns the count of elements in the sequence.
+        /// </summary>
+        /// <param name="onlyIfCheap">If true then the count should only be calculated if doing
+        /// so is quick (sure or likely to be constant time), otherwise -1 should be returned.</param>
+        /// <returns>The number of elements.</returns>
+        int GetCount(bool onlyIfCheap);
+    }
+
+    internal static partial class Error
+    {
+        internal static Exception ArgumentNull(string s) => new ArgumentNullException(s);
+
+        internal static Exception ArgumentOutOfRange(string s) => new ArgumentOutOfRangeException(s);
+
+        internal static Exception MoreThanOneElement() => new InvalidOperationException(SR.MoreThanOneElement);
+
+        internal static Exception MoreThanOneMatch() => new InvalidOperationException(SR.MoreThanOneMatch);
+
+        internal static Exception NoElements() => new InvalidOperationException(SR.NoElements);
+
+        internal static Exception NoMatch() => new InvalidOperationException(SR.NoMatch);
+
+        internal static Exception NotSupported() => new NotSupportedException();
+    }
+#endif
 }


### PR DESCRIPTION
The corefx implementation of Linq is not AOT-friendly, and won't work
with IL2CPP until IL2CPP gets full generic sharing support. So use the
Linq implementation from reference source for the unityaot profile. This
implementation is AOT-friendly.

This change addresses case 1013854 in Unity.

I'll add release notes with the IL2CPP changes for this issue.