### PR TITLE
Report the proper socket error

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -1160,7 +1160,19 @@ namespace System.Net.Sockets
 			// while skipping entries that do not match the address family
 			DnsEndPoint dep = e.RemoteEndPoint as DnsEndPoint;
 			if (dep != null) {
-				addresses = Dns.GetHostAddresses (dep.Host);
+				var possibleAddresses = Dns.GetHostAddresses (dep.Host);
+				var numberOfAddresses = 0;
+				int[] addressIndices = new int[possibleAddresses.Length];
+				for (var i = 0; i < possibleAddresses.Length; i++) {
+					if (possibleAddresses[i].AddressFamily == dep.AddressFamily) {
+						addressIndices[numberOfAddresses] = i;
+						numberOfAddresses++;
+					}
+				}
+				addresses = new IPAddress[numberOfAddresses];
+				for (var i = 0; i < numberOfAddresses; i++)
+					addresses[i] = possibleAddresses[addressIndices[i]];
+
 				return true;
 			} else {
 				e.ConnectByNameError = null;


### PR DESCRIPTION
When a connection fails, the socket error was being incorrectly reported
as an address family not supported error, instead of connection refused.

It looks like this happened between
c4e698cece510bce0a05a741ba4b9274354110c0 (Unity 2018.1b5), where the
proper error was reported, and ec98a4eeb5de45d7dfa30a79c1574bd95d5a4681
(Unity 2018.1b6), there the incorrect error is reported.

Why did this happen? Between those two changesets (there are about 180
intervening changesets), the order of addresses returned from
`Dns.GetHostAddresses` changed. The newer code returns the IPv6 address
first, and the IPv4 address second. While `GetCheckedIPs` mentioned in a
comment that it skips addresses that don't match the address family, it
did not. The code using the addresses returned by `GetCheckedIPs` will
use the first address in the array. If this address happens to match the
address family of the socket, things will work "properly" (the correct
socket error will occur).

If, however the first entry has the wrong address family, then the
socket error will be an address family not supported error, since the
socket was created with different address family.

This change modifies `GetCheckedIPs` to filter the addresses, removing
those which do not match the address family.

This corrects Unity case 1012875.

Release notes:
Scripting: Provide the proper socket error when an IPv4 connection is refused.

Should we back port this change? I think it should go to 2018.1. Also, should we upstream this? I think that we should.