### PR TITLE
Fixup dllmap for MonoPosixHelper

### DIFF
--- a/data/config.in
+++ b/data/config.in
@@ -10,8 +10,8 @@
 	<dllmap dll="i:odbc32.dll" target="libiodbc.dylib" os="osx"/>
 	<dllmap dll="oci" target="libclntsh@libsuffix@" os="!windows"/>
 	<dllmap dll="db2cli" target="libdb2_36@libsuffix@" os="!windows"/>
-	<dllmap dll="MonoPosixHelper" target="$mono_libdir/libMonoPosixHelper@libsuffix@" os="!windows" />
-	<dllmap dll="libmono-btls-shared" target="$mono_libdir/libmono-btls-shared@libsuffix@" os="!windows" />
+	<dllmap dll="MonoPosixHelper" target="libMonoPosixHelper@libsuffix@" os="!windows" />
+	<dllmap dll="libmono-btls-shared" target="libmono-btls-shared@libsuffix@" os="!windows" />
 	<dllmap dll="i:msvcrt" target="@LIBC@" os="!windows"/>
 	<dllmap dll="i:msvcrt.dll" target="@LIBC@" os="!windows"/>
 	<dllmap dll="sqlite" target="@SQLITE@" os="!windows"/>


### PR DESCRIPTION
Ran ABV ( https://katana.bf.unity3d.com/projects/Unity/builders/proj0-ABuildVerification/builds/52090?unity_branch=fixes/levi/mbe-monoposixhelper ) plus Linux editor runtime tests with 4.6 and 2.0 standard