### PR TITLE
[w32process] Ensure process_handle is a legal value (#6449)

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -60,9 +60,7 @@ namespace System.Diagnostics
 			 * the Start_internal icall in
 			 * mono/metadata/process.c
 			 */
-			public IntPtr thread_handle;
 			public int pid; // Contains -GetLastError () on failure.
-			public int tid;
 			public string[] envVariables;
 			public string UserName;
 			public string Domain;

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -2062,10 +2062,6 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		if (process_info != NULL) {
 			process_info->process_handle = handle;
 			process_info->pid = pid;
-
-			/* FIXME: we might need to handle the thread info some day */
-			process_info->thread_handle = INVALID_HANDLE_VALUE;
-			process_info->tid = 0;
 		}
 
 		mono_w32handle_unref (handle_data);
@@ -2218,20 +2214,18 @@ ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStar
 		}
 		/* Shell exec should not return a process handle when it spawned a GUI thing, like a browser. */
 		mono_w32handle_close (process_info->process_handle);
-		process_info->process_handle = NULL;
+		process_info->process_handle = INVALID_HANDLE_VALUE;
 	}
 
 done:
 	if (ret == FALSE) {
 		process_info->pid = -mono_w32error_get_last ();
 	} else {
-		process_info->thread_handle = NULL;
 #if !defined(MONO_CROSS_COMPILE)
 		process_info->pid = mono_w32process_get_pid (process_info->process_handle);
 #else
 		process_info->pid = 0;
 #endif
-		process_info->tid = 0;
 	}
 
 	return ret;

--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -111,13 +111,11 @@ ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStar
 		process_info->pid = -GetLastError ();
 	} else {
 		process_info->process_handle = shellex.hProcess;
-		process_info->thread_handle = NULL;
 #if !defined(MONO_CROSS_COMPILE)
 		process_info->pid = GetProcessId (shellex.hProcess);
 #else
 		process_info->pid = 0;
 #endif
-		process_info->tid = 0;
 	}
 
 	return ret;
@@ -335,11 +333,9 @@ ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoW32ProcessStart
 	if (ret) {
 		process_info->process_handle = procinfo.hProcess;
 		/*process_info->thread_handle=procinfo.hThread;*/
-		process_info->thread_handle = NULL;
 		if (procinfo.hThread != NULL && procinfo.hThread != INVALID_HANDLE_VALUE)
 			CloseHandle (procinfo.hThread);
 		process_info->pid = procinfo.dwProcessId;
-		process_info->tid = procinfo.dwThreadId;
 	} else {
 		process_info->pid = -GetLastError ();
 	}

--- a/mono/metadata/w32process.h
+++ b/mono/metadata/w32process.h
@@ -34,9 +34,7 @@ typedef enum {
 typedef struct 
 {
 	gpointer process_handle;
-	gpointer thread_handle;
 	guint32 pid; /* Contains mono_w32error_get_last () on failure */
-	guint32 tid;
 	MonoArray *env_variables;
 	MonoString *username;
 	MonoString *domain;


### PR DESCRIPTION
Unity: case 1018162 - Fix crash when calling Process.Start() to open a folder

* [w32process] Ensure process_handle is a legal value

Fixes https://github.com/mono/mono/issues/6383

* [w32process] Remove dead code