### PR TITLE
Unity trunk expose mono type attrs

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5549,7 +5549,7 @@ mono_type_is_byref (MonoType *type)
  *
  * Returns: the param attributes.
  */
-guint
+guint16
 mono_type_get_attrs (MonoType *type)
 {
 	return type->attrs;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5544,6 +5544,18 @@ mono_type_is_byref (MonoType *type)
 }
 
 /**
+ * mono_type_get_attrs:
+ * @type: the MonoType operated on
+ *
+ * Returns: the param attributes.
+ */
+guint
+mono_type_get_attrs (MonoType *type)
+{
+	return type->attrs;
+}
+
+/**
  * mono_type_get_type:
  * @type: the MonoType operated on
  *

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5549,7 +5549,7 @@ mono_type_is_byref (MonoType *type)
  *
  * Returns: the param attributes.
  */
-guint16
+guint32
 mono_type_get_attrs (MonoType *type)
 {
 	return type->attrs;

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -386,6 +386,9 @@ typedef enum {
 gboolean
 mono_type_is_byref       (MonoType *type);
 
+guint
+mono_type_get_attrs      (MonoType *type);
+
 int
 mono_type_get_type       (MonoType *type);
 

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -386,7 +386,7 @@ typedef enum {
 gboolean
 mono_type_is_byref       (MonoType *type);
 
-guint
+guint16
 mono_type_get_attrs      (MonoType *type);
 
 int

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -386,7 +386,7 @@ typedef enum {
 gboolean
 mono_type_is_byref       (MonoType *type);
 
-guint16
+guint32
 mono_type_get_attrs      (MonoType *type);
 
 int

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -802,6 +802,7 @@ mono_type_get_signature
 mono_type_get_type
 mono_type_get_underlying_type
 mono_type_is_byref
+mono_type_get_attrs
 mono_type_size
 mono_type_stack_size
 mono_type_to_unmanaged


### PR DESCRIPTION
*Purpose of this PR*:

Currently Unity crashes when a Unity supported message has parameters with ref or out keyword on the C# script [case: 968454].

To be able to fix the problem we need to be able to do some checks on the mono type attrs, so I am exposing that data so we could query it from Unity code.

*Katana build*:

https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?boo_branch=unity-trunk&cecil_branch=unity-master&il2cpp_branch=master&krait-signal-handler_branch=master&mono_branch=unity-trunk-expose-mono-type-attrs&mono-build-deps_branch=default&unityscript_branch=unity-trunk