### PR TITLE
Unity master expose mono type attrs

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6613,7 +6613,7 @@ mono_type_is_byref (MonoType *type)
  *
  * Returns: the param attributes.
  */
-uint16_t
+uint32_t
 mono_type_get_attrs (MonoType *type)
 {
 	return type->attrs;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6608,6 +6608,18 @@ mono_type_is_byref (MonoType *type)
 }
 
 /**
+ * mono_type_get_attrs:
+ * @type: the MonoType operated on
+ *
+ * Returns: the param attributes.
+ */
+uint16_t
+mono_type_get_attrs (MonoType *type)
+{
+	return type->attrs;
+}
+
+/**
  * mono_type_get_type:
  * \param type the \c MonoType operated on
  * \returns the IL type value for \p type. This is one of the \c MonoTypeEnum

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -335,7 +335,7 @@ typedef enum {
 MONO_API mono_bool
 mono_type_is_byref       (MonoType *type);
 
-MONO_API uint32_t
+MONO_API uint16_t
 mono_type_get_attrs      (MonoType *type);
 
 MONO_API int

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -335,7 +335,7 @@ typedef enum {
 MONO_API mono_bool
 mono_type_is_byref       (MonoType *type);
 
-MONO_API uint16_t
+MONO_API uint32_t
 mono_type_get_attrs      (MonoType *type);
 
 MONO_API int

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -335,6 +335,9 @@ typedef enum {
 MONO_API mono_bool
 mono_type_is_byref       (MonoType *type);
 
+MONO_API uint32_t
+mono_type_get_attrs      (MonoType *type);
+
 MONO_API int
 mono_type_get_type       (MonoType *type);
 

--- a/mono/mini/il2cpp-compat.h
+++ b/mono/mini/il2cpp-compat.h
@@ -248,6 +248,7 @@
 #define mono_class_get_element_class il2cpp_class_get_element_class
 #define mono_class_get_type_token il2cpp_class_get_type_token
 #define mono_type_is_byref il2cpp_type_is_byref
+#define mono_type_get_attrs il2cpp_type_get_attrs
 #define mono_class_is_enum il2cpp_class_is_enum
 #define mono_method_get_flags il2cpp_method_get_flags
 #define mono_method_get_token il2cpp_method_get_token


### PR DESCRIPTION
*Purpose of this PR*:

Currently Unity crashes when a Unity supported message has parameters with ref or out keyword on the C# script [case: 968454].

To be able to fix the problem we need to be able to do some checks on the mono type attrs, so I am exposing that data so we could query it from Unity code.

*Katana build*:

https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?boo_branch=unity-trunk&cecil_branch=unity-master&il2cpp_branch=master&krait-signal-handler_branch=master&mono_branch=unity-master-expose-mono-type-attrs&mono-build-deps_branch=default&unityscript_branch=unity-trunk