### PR TITLE
Fix up Code Coverage support

### DIFF
--- a/mono/metadata/debug-internals.h
+++ b/mono/metadata/debug-internals.h
@@ -84,7 +84,4 @@ mono_debug_free_method_async_debug_info (MonoDebugMethodAsyncInfo *info);
 gboolean
 mono_debug_image_has_debug_info (MonoImage *image);
 
-MonoDebugSourceLocation *
-mono_debug_lookup_source_location_by_il (MonoMethod *method, guint32 il_offset, MonoDomain *domain);
-
 #endif /* __DEBUG_INTERNALS_H__ */

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -370,6 +370,7 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 	location = g_new0 (MonoDebugSourceLocation, 1);
 	location->source_file = docname;
 	location->row = start_line;
+	location->column = start_col;
 	location->il_offset = iloffset;
 
 	return location;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -453,6 +453,7 @@ mono_domain_create (void)
 #endif
 
 	mono_debug_domain_create (domain);
+	mono_profiler_coverage_domain_init (domain);
 
 	if (create_domain_hook)
 		create_domain_hook (domain);
@@ -1270,6 +1271,8 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 
 	if (domain == mono_root_domain)
 		mono_root_domain = NULL;
+
+	mono_profiler_coverage_domain_free(domain);
 }
 
 /**

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -201,6 +201,9 @@ mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset);
 MONO_API MonoDebugSourceLocation *
 mono_debug_lookup_source_location (MonoMethod *method, uint32_t address, MonoDomain *domain);
 
+MONO_API MonoDebugSourceLocation *
+mono_debug_lookup_source_location_by_il (MonoMethod *method, uint32_t il_offset, MonoDomain *domain);
+
 MONO_API int32_t
 mono_debug_il_offset_from_address (MonoMethod *method, MonoDomain *domain, uint32_t native_offset);
 

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -51,7 +51,7 @@ typedef struct {
 
 	gboolean code_coverage;
 	mono_mutex_t coverage_mutex;
-	GHashTable *coverage_hash;
+	MonoDomainCoverage *coverage_domains;
 
 	MonoProfilerHandle sampling_owner;
 	MonoSemType sampling_semaphore;
@@ -112,8 +112,18 @@ mono_profiler_installed (void)
 	return !!mono_profiler_state.profilers;
 }
 
-MonoProfilerCoverageInfo *mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries);
-void mono_profiler_coverage_free (MonoMethod* method, MonoProfilerCoverageInfo* info);
+MonoProfilerCoverageInfo *mono_profiler_coverage_alloc (MonoDomain* domain, MonoMethod *method, guint32 entries);
+
+struct _MonoDomainCoverage
+{
+	MonoDomain* domain;
+	GHashTable *coverage_hash;
+	mono_mutex_t mutex;
+	MonoDomainCoverage *next;
+};
+
+void mono_profiler_coverage_domain_init (MonoDomain* domain);
+void mono_profiler_coverage_domain_free (MonoDomain* domain);
 
 struct _MonoProfilerCallContext {
 	/*

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -113,6 +113,7 @@ mono_profiler_installed (void)
 }
 
 MonoProfilerCoverageInfo *mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries);
+void mono_profiler_coverage_free (MonoMethod* method, MonoProfilerCoverageInfo* info);
 
 struct _MonoProfilerCallContext {
 	/*

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -564,6 +564,20 @@ mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries)
 	return info;
 }
 
+void mono_profiler_coverage_free (MonoMethod* method, MonoProfilerCoverageInfo* info)
+{
+	if (!mono_profiler_state.code_coverage)
+		return;
+
+	coverage_lock ();
+
+	g_hash_table_remove(mono_profiler_state.coverage_hash, method);
+
+	coverage_unlock ();
+
+	g_free (info);
+}
+
 /**
  * mono_profiler_enable_sampling:
  *

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -408,11 +408,11 @@ mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, 
 	return TRUE;
 }
 
-struct InvokeCallbackInfo
+typedef struct
 {
 	MonoProfilerCoverageCallback cb;
 	MonoProfilerHandle handle;
-};
+} InvokeCallbackInfo;
 
 static void invoke_coverage_callback_for_hashtable_entry (gpointer key, gpointer value, gpointer user_data)
 {

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -407,6 +407,115 @@ mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, 
 
 	return TRUE;
 }
+
+static void invoke_coverage_callback_for_hashtable_entry (gpointer key, gpointer value, gpointer user_data)
+{
+	MonoMethod* method = (MonoMethod*)key;
+	MonoProfilerCoverageInfo *info = (MonoProfilerCoverageInfo*)value;
+	MonoProfilerCoverageCallback cb = (MonoProfilerCoverageCallback)user_data;
+
+	MonoError error;
+	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
+	mono_error_assert_ok (&error);
+
+	guint32 size;
+
+	const unsigned char *start = mono_method_header_get_code (header, &size, NULL);
+	const unsigned char *end = start + size;
+	MonoDebugMethodInfo *minfo = mono_debug_lookup_method (method);
+
+	for (guint32 i = 0; i < info->entries; i++) {
+		guchar *cil_code = info->data [i].cil_code;
+
+		if (cil_code && cil_code >= start && cil_code < end) {
+			guint32 offset = cil_code - start;
+
+			MonoProfilerCoverageData data = {
+				.method = method,
+				.il_offset = offset,
+				.counter = info->data [i].count,
+				.line = 1,
+				.column = 1,
+			};
+
+			if (minfo) {
+				MonoDebugSourceLocation *loc = mono_debug_method_lookup_location (minfo, offset);
+
+				if (loc) {
+					data.file_name = g_strdup (loc->source_file);
+					data.line = loc->row;
+					data.column = loc->column;
+
+					mono_debug_free_source_location (loc);
+				}
+			}
+
+			cb (handle->prof, &data);
+
+			g_free ((char *) data.file_name);
+		}
+	}
+
+	mono_metadata_free_mh (header);
+}
+
+mono_bool
+mono_profiler_get_all_coverage_data(MonoProfilerHandle handle, MonoProfilerCoverageCallback cb)
+{
+	if (!mono_profiler_state.code_coverage)
+		return FALSE;
+
+	coverage_lock ();
+
+	g_hash_table_foreach (mono_profiler_state.coverage_hash, invoke_coverage_callback_for_hashtable_entry, cb);
+
+	coverage_unlock ();
+
+	return TRUE;
+}
+
+void
+mono_profiler_reset_coverage(MonoMethod* method)
+{
+	if (!mono_profiler_state.code_coverage)
+		return;
+
+	if ((method->flags & METHOD_ATTRIBUTE_ABSTRACT) || (method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) || (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) || (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
+		return;
+
+	coverage_lock ();
+
+	MonoProfilerCoverageInfo *info = g_hash_table_lookup (mono_profiler_state.coverage_hash, method);
+
+	coverage_unlock ();
+
+	if (!info)
+		return;
+
+	for (guint32 i = 0; i < info->entries; i++)
+		info->data[i].count = 0;
+}
+
+static void reset_coverage_for_hashtable_entry (gpointer key, gpointer value, gpointer user_data)
+{
+	MonoProfilerCoverageInfo *info = (MonoProfilerCoverageInfo*)value;
+
+	for (guint32 i = 0; i < info->entries; i++)
+		info->data[i].count = 0;
+}
+
+void mono_profiler_reset_all_coverage()
+{
+	if (!mono_profiler_state.code_coverage)
+		return;
+
+	coverage_lock ();
+
+	g_hash_table_foreach (mono_profiler_state.coverage_hash, reset_coverage_for_hashtable_entry, NULL);
+
+	coverage_unlock ();
+}
+
 #endif
 
 MonoProfilerCoverageInfo *

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -45,10 +45,10 @@ MONO_API mono_bool mono_profiler_enable_coverage (void);
 MONO_API void mono_profiler_set_coverage_filter_callback (MonoProfilerHandle handle, MonoProfilerCoverageFilterCallback cb);
 #ifndef RUNTIME_IL2CPP
 MONO_API mono_bool mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, MonoProfilerCoverageCallback cb);
-MONO_API mono_bool mono_profiler_get_all_coverage_data(MonoProfilerHandle handle, MonoProfilerCoverageCallback cb);
+MONO_API mono_bool mono_profiler_get_all_coverage_data (MonoProfilerHandle handle, MonoProfilerCoverageCallback cb);
 
-MONO_API mono_bool mono_profiler_reset_coverage(MonoMethod* method);
-MONO_API void mono_profiler_reset_all_coverage();
+MONO_API mono_bool mono_profiler_reset_coverage (MonoMethod* method);
+MONO_API void mono_profiler_reset_all_coverage (void);
 #endif
 
 typedef enum {

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -45,6 +45,10 @@ MONO_API mono_bool mono_profiler_enable_coverage (void);
 MONO_API void mono_profiler_set_coverage_filter_callback (MonoProfilerHandle handle, MonoProfilerCoverageFilterCallback cb);
 #ifndef RUNTIME_IL2CPP
 MONO_API mono_bool mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, MonoProfilerCoverageCallback cb);
+MONO_API mono_bool mono_profiler_get_all_coverage_data(MonoProfilerHandle handle, MonoProfilerCoverageCallback cb);
+
+MONO_API mono_bool mono_profiler_reset_coverage(MonoMethod* method);
+MONO_API void mono_profiler_reset_all_coverage();
 #endif
 
 typedef enum {

--- a/mono/metadata/profiler.h
+++ b/mono/metadata/profiler.h
@@ -38,6 +38,8 @@ typedef struct {
 	uint32_t column;
 } MonoProfilerCoverageData;
 
+typedef struct _MonoDomainCoverage MonoDomainCoverage;
+
 typedef mono_bool (*MonoProfilerCoverageFilterCallback) (MonoProfiler *prof, MonoMethod *method);
 typedef void (*MonoProfilerCoverageCallback) (MonoProfiler *prof, const MonoProfilerCoverageData *data);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7255,7 +7255,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	}
 
 	if (cfg->method == method)
-		cfg->coverage_info = mono_profiler_coverage_alloc (cfg->method, header->code_size);
+		cfg->coverage_info = mono_profiler_coverage_alloc (cfg->domain, cfg->method, header->code_size);
 	if (cfg->compile_aot && cfg->coverage_info)
 		g_error ("Coverage profiling is not supported with AOT.");
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1908,11 +1908,6 @@ mono_empty_compile (MonoCompile *cfg)
 	}
 	cfg->headers_to_free = NULL;
 
-	if (cfg->coverage_info) {
-		mono_profiler_coverage_free(cfg->method, cfg->coverage_info);
-		cfg->coverage_info = NULL;
-	}
-
 	if (cfg->mempool) {
 	//mono_mempool_stats (cfg->mempool);
 		mono_mempool_destroy (cfg->mempool);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1908,6 +1908,11 @@ mono_empty_compile (MonoCompile *cfg)
 	}
 	cfg->headers_to_free = NULL;
 
+	if (cfg->coverage_info) {
+		mono_profiler_coverage_free(cfg->method, cfg->coverage_info);
+		cfg->coverage_info = NULL;
+	}
+
 	if (cfg->mempool) {
 	//mono_mempool_stats (cfg->mempool);
 		mono_mempool_destroy (cfg->mempool);


### PR DESCRIPTION
Fix up the Code Coverage support in MonoBleedingEdge:

- Change coverage data to be stored in a separate hash table per MonoDomain, so that we can throw away coverage data when a domain is unloaded
- Support for resetting (zeroing) coverage stats for one/all methods
- Support for getting coverage stats for all methods

Also fixed PPDB support to provide column information to mono_ppdb_lookup_location.