### PR TITLE
Expose two public types

### DIFF
--- a/mcs/class/System.Design/System.Web.UI.Design.WebControls/CompositeControlDesigner.cs
+++ b/mcs/class/System.Design/System.Web.UI.Design.WebControls/CompositeControlDesigner.cs
@@ -35,7 +35,7 @@ using System.ComponentModel;
 
 namespace System.Web.UI.Design.WebControls
 {
-	class CompositeControlDesigner : ControlDesigner
+	public class CompositeControlDesigner : ControlDesigner
 	{
 		public CompositeControlDesigner () {
 			throw new NotImplementedException ();

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransactionMessageProperty.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/TransactionMessageProperty.cs
@@ -36,7 +36,7 @@ using System.Xml;
 
 namespace System.ServiceModel.Channels
 {
-	internal class TransactionMessageProperty
+	public class TransactionMessageProperty
 	{
 		Transaction tx;
 		Message msg;


### PR DESCRIPTION
These types are public in the .NET 4.7.1 profile, so they should be
public in Mono as well.

I'll plan to back port this change to 2018.1 and upstream it.