### PR TITLE
Fix copying of mono executable and library after osx 32-bit removal

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1564,7 +1564,7 @@ if ($artifact)
 	elsif($^O eq 'darwin')
 	{
 		$embedDirArchDestination = "$embedDirRoot/osx";
-		$distDirArchBin = "$distdir/bin-osx";
+		$distDirArchBin = "$distdir/bin";
 		$versionsOutputFile = "$buildsroot/versions-osx.txt";
 	}
 	else

--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -66,11 +66,13 @@ system("perl", "$buildscriptsdir/build.pl", "--clean=1", "--classlibtests=0", @p
 
 if ($artifact)
 {
-	print(">>> Creating universal binaries\n");
-	# Merge stuff in the embedruntimes directory
-	my $embedDirRoot = "$buildsroot/embedruntimes";
-	my $embedDirDestination = "$embedDirRoot/osx";
+	print(">>> Copying libMonoPosixHelper.dylib to lib directory\n");
 
+	my $libDir = "$buildsroot/monodistribution/lib";
+	if (!(-d $libDir))
+	{
+		system("mkdir -p $libDir");
+	}
 
-
+	system("cp","$buildsroot/embedruntimes/osx/libMonoPosixHelper.dylib", "$libDir/")
 }


### PR DESCRIPTION
Fix osx build. I removed too much from build scripts and didn't realize it.