### PR TITLE
Cache class custom attributes on MonoClass rather than domain and mak…

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -4,6 +4,7 @@
 #include <mono/metadata/class.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/mempool.h>
+#include <mono/metadata/reflection.h>
 #include <mono/io-layer/io-layer.h>
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/mono-error.h"
@@ -356,6 +357,9 @@ struct _MonoClass {
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;
+
+	/* cached custom attributes for the class */
+	MonoCustomAttrInfo* cattrs;
 
 	MonoImage *image;
 	const char *name;

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -254,9 +254,6 @@ struct _MonoDomain {
 	GHashTable	   *generic_virtual_cases;
 	MonoThunkFreeList **thunk_free_lists;
 
-	/* Hashing class attributes as a lookup optimization */
-	GHashTable	*class_custom_attributes;
-
 	/* Information maintained by the JIT engine */
 	gpointer runtime_info;
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1199,7 +1199,6 @@ mono_domain_create (void)
 	domain->jit_info_table = jit_info_table_new (domain);
 	domain->jit_info_free_queue = NULL;
 	domain->finalizable_objects_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
-	domain->class_custom_attributes = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_custom_attrs_free_cached);
 #ifndef HAVE_SGEN_GC
 	domain->track_resurrection_handles_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 #endif
@@ -1988,10 +1987,8 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 #endif	
 
 	g_hash_table_destroy (domain->finalizable_objects_hash);
-	g_hash_table_destroy (domain->class_custom_attributes);
 
 	domain->finalizable_objects_hash = NULL;
-	domain->class_custom_attributes = NULL;
 	
 #ifndef HAVE_SGEN_GC
 	if (domain->track_resurrection_objects_hash) {


### PR DESCRIPTION
…e caching operation thread safe

Potential fix to make custom attribute caching for classes thread safe. I haven't tried this extensively and wanted feedback. This increases the MonoClass size but caching this on the class makes more sense IMO as this is per class and not per domain.

cc @corngood