### PR TITLE
Unity 2018.2 backports

### DIFF
--- a/external/buildscripts/build_runtime_android.sh
+++ b/external/buildscripts/build_runtime_android.sh
@@ -136,7 +136,6 @@ function clean_build
 	make && echo "Build SUCCESS!" || exit 1
 
 	mkdir -p $3
-	cp mono/mini/.libs/libmono.a $3
 	cp mono/mini/.libs/libmono.so $3
 }
 
@@ -158,10 +157,10 @@ clean_build "$CCFLAGS_ARMv7_VFP" "$LDFLAGS_ARMv7" "$OUTDIR/armv7a"
 source ${BUILDSCRIPTSDIR}/build_runtime_android_x86.sh dontclean
 
 NUM_LIBS_BUILT=`ls -AlR $OUTDIR | grep libmono | wc -l`
-if [ $NUM_LIBS_BUILT -eq 8 ]; then
-	echo "Android STATIC/SHARED libraries are found here: $OUTDIR"
+if [ $NUM_LIBS_BUILT -eq 4 ]; then
+	echo "Android SHARED libraries are found here: $OUTDIR"
 else
-	echo "Build failed? Android STATIC/SHARED library cannot be found... Found $NUM_LIBS_BUILT libs under $OUTDIR"
+	echo "Build failed? Android SHARED library cannot be found... Found $NUM_LIBS_BUILT libs under $OUTDIR"
 	ls -Al $OUTDIR
 	exit 1
 fi

--- a/external/buildscripts/build_runtime_android_x86.sh
+++ b/external/buildscripts/build_runtime_android_x86.sh
@@ -110,7 +110,6 @@ function clean_build
 	make && echo "Build SUCCESS!" || exit 1
 
 	mkdir -p $3
-	cp mono/mini/.libs/libmono.a $3
 	cp mono/mini/.libs/libmono.so $3
 }
 

--- a/external/buildscripts/build_runtime_qnx.sh
+++ b/external/buildscripts/build_runtime_qnx.sh
@@ -1,42 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
-# Set up QNX dev environment
-# Taken from/opt/bbndk/NativeSDK-env-1_0_7.2942.sh
+# The build configs are looking for this file rather than the perl script.
+# easier to add this 
 
-PREFIX=`pwd`/../builds/qnx
-
-OUTDIR=../builds/embedruntimes/qnx
-BUILDSCRIPTSDIR=external/buildscripts
-
-perl ${BUILDSCRIPTSDIR}/PrepareBB10NDK.pl -ndk=r09 -env=envsetup.sh && source envsetup.sh
-
-source $BB10_NDK_ROOT/bbndk-env.sh
-
-make clean && make distclean
-
-rm -r *.cache config.status nto-arm-le-v7 libgc/config.status autom4te.cache Makefile
-
-NOCONFIGURE=1 ./autogen.sh
-cd eglib; NOCONFIGURE=1 ./autogen.sh
-
-cd ..
-addvariant nto arm le-v7
-cd nto-arm-le-v7
-
-# Run Make
-make && echo "Build SUCCESS!" || exit 1
-
-rm -rf ../builds
-
-mkdir -p $OUTDIR
-cp -f mono/mini/.libs/libmono.a $OUTDIR
-
-if [ -d ../builds/monodistribution ] ; then
-rm -r ../builds/monodistribution
+# Note : Not Implemented yet.  Script is here to make the katana build pass so that the mono build artifact is created
+if [ -d builds ]; then
+	echo "Skip making builds directory.  Already exists"
+else
+	mkdir builds
 fi
 
-# Clean up for next build
-cd ..
-make clean && make distclean
-rm Makefile
-
+touch builds/dummy_qnx.txt

--- a/external/buildscripts/build_runtime_stv.sh
+++ b/external/buildscripts/build_runtime_stv.sh
@@ -1,74 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
-PREFIX=`pwd`/builds/stv
-BUILDSCRIPTSDIR=external/buildscripts
+# The build configs are looking for this file rather than the perl script.
+# easier to add this 
 
-perl ${BUILDSCRIPTSDIR}/SDKDownloader.pm --repo_name=stv-sdk --artifacts_folder=artifacts && source artifacts/SDKDownloader/stv-sdk/env.sh
+# Note : Not Implemented yet.  Script is here to make the katana build pass so that the mono build artifact is created
+if [ -d builds ]; then
+	echo "Skip making builds directory.  Already exists"
+else
+	mkdir builds
+fi
 
-rm -rf builds
-
-for STV_TARGET in ${STV_TARGETS}; do
-	echo "BUILDING FOR $STV_TARGET"
-	OUTDIR=builds/embedruntimes/stv/$STV_TARGET
-
-	if [[ $STV_TARGET == *_15 ]]; then
-		LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${STV_STANDARD_15}/i386Libs";export LD_LIBRARY_PATH
-		echo "LD_LIBRARY_PATH is : $LD_LIBRARY_PATH"
-	fi
-
-	STV_GCC_PREFIX="STV_GCC_PREFIX_${STV_TARGET}"
-	STV_GCC_PREFIX="${!STV_GCC_PREFIX}"
-
-	# need to swap flags when building for different platforms.
-	CXXFLAGS="-g -DARM_FPU_VFP=1 -DHAVE_ARMV6=1 -D__ARM_EABI__ -DLINUX -D__linux__ -DUSE_PTHREAD_LOCKS -DHAVE_PTHREAD_MUTEX_TIMEDLOCK -march=armv7-a -mfpu=vfp -mfloat-abi=softfp -fpic -funwind-tables -ffunction-sections -fdata-sections";
-	CC="${STV_GCC_PREFIX}gcc"
-	CXX="${STV_GCC_PREFIX}g++"
-	AR="${STV_GCC_PREFIX}ar"
-	LD="${STV_GCC_PREFIX}ld"
-	LDFLAGS="-Wl,--fix-cortex-a8"
-
-	echo "CXXFLAGS= ${CXXFLAGS}"
-	echo "CC= ${CC}"
-	echo "CXX= ${CXX}"
-	echo "AR= ${AR}"
-	echo "LD= ${LD}"
-	echo "LDFLAGS= ${LDFLAGS}"
-
-	CONFIG_OPTS="\
---prefix=$PREFIX \
---cache-file=stv_cross.cache \
---host=arm-unknown-linux-gnueabi \
---disable-mcs-build \
---disable-parallel-mark \
---disable-shared-handles \
---with-sigaltstack=no \
---with-tls=pthread \
---with-glib=embedded \
---disable-nls \
-mono_cv_uscore=yes"
-
-	make clean && make distclean
-	rm stv_cross.cache
-
-	pushd eglib
-	autoreconf -i
-	popd
-	autoreconf -i
-
-	# Run configure
-	./configure $CONFIG_OPTS CFLAGS="$CXXFLAGS" CPPFLAGS="$CXXFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" CC="$CC" CXX="$CXX" AR="$AR" LD="$LD"
-
-	# Run Make
-	make && echo "Build SUCCESS!" || exit 1
-
-	mkdir -p $OUTDIR
-	cp -f mono/mini/.libs/libmono.a $OUTDIR
-
-	if [ -d builds/monodistribution ] ; then
-		rm -r builds/monodistribution
-	fi
-done
-
-# Support backwards compatibility with old file location
-cp -f builds/embedruntimes/stv/STANDARD_13/libmono.a builds/embedruntimes/stv/libmono.a
+touch builds/dummy_stv.txt
 

--- a/external/buildscripts/build_runtime_tizen.sh
+++ b/external/buildscripts/build_runtime_tizen.sh
@@ -1,119 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
-# First build for Tizen mobile devices
-PREFIX="$PWD/builds/tizen"
+# The build configs are looking for this file rather than the perl script.
+# easier to add this 
 
-BUILDDIR=/$PWD
-OUTDIR=builds/embedruntimes/tizen
-BUILDSCRIPTSDIR=external/buildscripts
-
-perl ${BUILDSCRIPTSDIR}/SDKDownloader.pm --repo_name=tizen-sdk --artifacts_folder=artifacts && source artifacts/SDKDownloader/tizen-sdk/env.sh
-
-CXXFLAGS="-Os -DHAVE_ARMV6=1 -DARM_FPU_VFP=1 -D__ARM_EABI__ -march=armv7-a -mfloat-abi=softfp -mfpu=neon -mtune=cortex-a9 \
--ffunction-sections -fdata-sections -fno-strict-aliasing -fPIC"
-CFLAGS="$CXXFLAGS"
-
-TIZEN_PREFIX=${TIZEN_SDK}/tools/arm-linux-gnueabi-gcc-4.9/bin/arm-linux-gnueabi-
-
-CC="${TIZEN_PREFIX}gcc --sysroot=${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP} -I${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP}/usr/include -DTIZEN"
-CXX="${TIZEN_PREFIX}g++ --sysroot=${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP} -I${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP}/usr/include -DTIZEN"
-AR="${TIZEN_PREFIX}ar"
-LD="${TIZEN_PREFIX}ld"
-RANLIB="${TIZEN_PREFIX}ranlib"
-STRIP="${TIZEN_PREFIX}strip"
-
-CONFIG_OPTS="\
---prefix=$PREFIX \
---with-sysroot=${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP} \
---cache-file=tizen_cross.cache \
---host=arm-linux-gnueabi \
---disable-mcs-build \
---disable-parallel-mark \
---disable-shared-handles \
---with-sigaltstack=no \
---with-tls=pthread \
---with-glib=embedded \
---enable-nls=no \
-mono_cv_uscore=yes"
-
-LDFLAGS="-ldlog"
-
-make clean && make distclean
-rm tizen_cross.cache
-
-pushd eglib
-autoreconf -i
-popd
-autoreconf -i
-
-# Run configure
-./configure $CONFIG_OPTS CFLAGS="$CXXFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" CC="$CC" CXX="$CXX" AR="$AR" LD="$LD" RANLIB="$RANLIB" STRIP="$STRIP"
-
-# Run Make
-make && echo "Build SUCCESS!" || exit 1
-
-rm -rf $PWD/builds
-
-mkdir -p $OUTDIR
-cp -f mono/mini/.libs/libmono.so $OUTDIR
-
-# Clean up for next build
-make clean && make distclean
-
-if [ -d builds/monodistribution ] ; then
-rm -r builds/monodistribution
+# Note : Tizen support is removed.  Script is here to make the katana build pass so that the mono build artifact is created
+if [ -d builds ]; then
+	echo "Skip making builds directory.  Already exists"
+else
+	mkdir builds
 fi
 
-# Now build for the Tizen emulator
+touch builds/dummy_tizen.txt
 
-make clean
-rm tizen_cross.cache
-
-OUTDIR=builds/embedruntimes/tizenemulator
-CXXFLAGS="-Os -ffunction-sections -fdata-sections -fno-strict-aliasing -fPIC"
-CFLAGS="$CXXFLAGS"
-
-TIZEN_PREFIX=${TIZEN_SDK}/tools/i386-linux-gnueabi-gcc-4.9/bin/i386-linux-gnueabi-
-TIZEN_ROOTSTRAP=mobile-2.4-emulator.core
-
-CC="${TIZEN_PREFIX}gcc --sysroot=${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP} -I${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/rootstraps/${TIZEN_ROOTSTRAP}/usr/include -DTIZEN"
-CXX="${TIZEN_PREFIX}g++ --sysroot=${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP} -I${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/rootstraps/${TIZEN_ROOTSTRAP}/usr/include -DTIZEN"
-AR="${TIZEN_PREFIX}ar"
-LD="${TIZEN_PREFIX}ld"
-RANLIB="${TIZEN_PREFIX}ranlib"
-STRIP="${TIZEN_PREFIX}strip"
-
-CONFIG_OPTS="\
---prefix=$PREFIX \
---with-sysroot=${TIZEN_SDK}/platforms/${TIZEN_PLATFORM}/mobile/rootstraps/${TIZEN_ROOTSTRAP} \
---cache-file=tizen_cross.cache \
---host=i386-linux-gnueabi \
---disable-mcs-build \
---disable-parallel-mark \
---disable-shared-handles \
---with-sigaltstack=no \
---with-tls=pthread \
---with-glib=embedded \
---enable-nls=no \
-mono_cv_uscore=yes"
-
-pushd eglib
-autoreconf -i
-popd
-autoreconf -i
-
-# Run configure
-./configure $CONFIG_OPTS CFLAGS="$CXXFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" CC="$CC" CXX="$CXX" AR="$AR" LD="$LD" RANLIB="$RANLIB" STRIP="$STRIP"
-
-# Run Make
-make && echo "Build SUCCESS!" || exit 1
-
-mkdir -p $OUTDIR
-cp -f mono/mini/.libs/libmono.so $OUTDIR
-
-# Clean up for next build
-make clean && make distclean
-
-if [ -d builds/monodistribution ] ; then
-rm -r builds/monodistribution
-fi

--- a/external/buildscripts/collect_allbuilds.pl
+++ b/external/buildscripts/collect_allbuilds.pl
@@ -1,7 +1,12 @@
 use lib ('./perl_lib');
+use Cwd 'abs_path';
+use File::Basename;
 use File::Copy::Recursive qw(dircopy rmove);
 use File::Path;
 use Tools qw(InstallNameTool);
+
+my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
+my $monoroot = abs_path($monoroot);
 
 my $path = "incomingbuilds/";
 
@@ -38,3 +43,16 @@ print MYFILE "TC buildconfigname was: $ENV{TEAMCITY_BUILDCONF_NAME}\n";
 close(MYFILE);
 
 system("zip -r builds.zip *") eq 0 or die("failed zipping up builds");
+
+if($^O eq "linux")
+{
+	system("$monoroot/../../mono-build-deps/build/7z/linux64/7za a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
+}
+elsif($^O eq 'darwin')
+{
+	system("$monoroot/../../mono-build-deps/build/7z/osx/7za a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
+}
+else
+{
+	die("Unsupported platform for build collection.")
+}

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -6717,6 +6717,8 @@ mono_class_is_subclass_of (MonoClass *klass, MonoClass *klassc,
 {
 	if (!klass->inited)
 		mono_class_init(klass);
+	if (!klassc->inited)
+		mono_class_init (klassc);
 
 	g_assert (klassc->idepth > 0);
 	if (check_interfaces && MONO_CLASS_IS_INTERFACE (klassc) && !MONO_CLASS_IS_INTERFACE (klass)) {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -6657,7 +6657,10 @@ mono_param_get_objects_internal (MonoDomain *domain, MonoMethod *method, MonoCla
 		param->PositionImpl = i;
 		param->AttrsImpl = sig->params [i]->attrs;
 
-		if (!(param->AttrsImpl & PARAM_ATTRIBUTE_HAS_DEFAULT)) {
+		/* UNITY: check for wrappers avoids processing wrapper methods which have no token and assert/crash.
+		 * Wrapper methods should not be visible to managed code at all, but they seem to leak through
+		 * in some cases (call stacks). */
+		if (method->wrapper_type || !(param->AttrsImpl & PARAM_ATTRIBUTE_HAS_DEFAULT)) {
 			if (param->AttrsImpl & PARAM_ATTRIBUTE_OPTIONAL)
 				MONO_OBJECT_SETREF (param, DefaultValueImpl, get_reflection_missing (domain, &missing));
 			else

--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -28,7 +28,7 @@ static void ContextInsertClass(CollectMetadataContext* context, MonoClass* klass
 	 * If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
 	 * that 0 is a valid class index and was confusing our logic.
 	*/
-	if (klass->inited && g_hash_table_lookup_extended (context->allTypes, klass, &orig_key, &value))
+	if (klass->inited && !g_hash_table_lookup_extended (context->allTypes, klass, &orig_key, &value))
 		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER (context->currentIndex++));
 }
 


### PR DESCRIPTION
1030018 (Internal) - Fix crash when bindings use default values
1027204 (Internal) - Fix crash when bindings expose non-implemented interface
1011626- Fix memory snapshot profiler (regression)