### PR TITLE
Two types should be public to match .NET 4.7.1

### DIFF
--- a/mcs/class/referencesource/System/net/System/Net/UnicodeDecodingConformance.cs
+++ b/mcs/class/referencesource/System/net/System/Net/UnicodeDecodingConformance.cs
@@ -16,7 +16,7 @@ namespace System.Net.Configuration
     /// See http://www.w3.org/International/questions/qa-escapes#bytheway for more information
     /// on how Unicode characters in the SMP are supposed to be encoded in HTML.
     /// </remarks>
-#if !MOBILE
+#if !MOBILE || UNITY_AOT
     public
 #endif
     enum UnicodeDecodingConformance

--- a/mcs/class/referencesource/System/net/System/Net/UnicodeEncodingConformance.cs
+++ b/mcs/class/referencesource/System/net/System/Net/UnicodeEncodingConformance.cs
@@ -16,7 +16,7 @@ namespace System.Net.Configuration
     /// See http://www.w3.org/International/questions/qa-escapes#bytheway for more information
     /// on how Unicode characters in the SMP are supposed to be encoded in HTML.
     /// </remarks>
-#if !MOBILE
+#if !MOBILE || UNITY_AOT
     public
 #endif
     enum UnicodeEncodingConformance


### PR DESCRIPTION
This change allows the unityaot profile to match .NET 4.7.1 for these
two types.