### PR TITLE
Make ProperInfo.GetValue AOt-friendly

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoProperty.cs
+++ b/mcs/class/corlib/System.Reflection/MonoProperty.cs
@@ -378,7 +378,9 @@ namespace System.Reflection {
 		{
 			if (index == null || index.Length == 0) {
 				/*FIXME we should check if the number of arguments matches the expected one, otherwise the error message will be pretty criptic.*/
-#if !FULL_AOT_RUNTIME
+// Once we ship the changes to make il2cpp always use the unityaot profile, we should change
+// this define to be UNITY_AOT. for now though, we'll take the AOT-friendly code path in all profiles.
+#if !FULL_AOT_RUNTIME && !UNITY
 				if (cached_getter == null) {
 					MethodInfo method = GetGetMethod (true);
 					if (!DeclaringType.IsValueType && !method.ContainsGenericParameters) { //FIXME find a way to build an invoke delegate for value types.


### PR DESCRIPTION
On AOT platforms, the GetValue method won't work with the normal
implementation. To make this work, fall back to the slower AOT-friendly
implementation.

Once we have AOT platforms using only the unityaot profile in Unity, we
will make this change only for AOT platforms. For now though, let's fix
it everywhere.

These changes correct case 1030427 in Unity.

Release notes:

IL2CPP: Prevent errors due to a missing AOT implementation for GetterAdapterFrame. (case 1030427)