### PR TITLE
Avoid access to /dev/shm on OSX (case 1035654)

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1205,6 +1205,7 @@ if ($build)
 
 		# Need to define because Apple's SIP gets in the way of us telling mono where to find this
 		push @configureparams, "--with-libgdiplus=$addtoresultsdistdir/lib/libgdiplus.dylib";
+		push @configureparams, "--enable-minimal=shared_perfcounters";
 
 		print "\n";
 		print ">>> Setting environment:\n";


### PR DESCRIPTION
case 1035654 - Fix Mac App store submission failures due to access of /dev/shm