### PR TITLE
Correct the base types for a new enum types

### DIFF
--- a/mcs/class/System.Xaml/System.Xaml.Schema/XamlCollectionKind.cs
+++ b/mcs/class/System.Xaml/System.Xaml.Schema/XamlCollectionKind.cs
@@ -25,7 +25,7 @@ using System.Collections.Generic;
 
 namespace System.Xaml.Schema
 {
-	public enum XamlCollectionKind
+	public enum XamlCollectionKind : byte
 	{
 		None,
 		Collection,

--- a/mcs/class/System.Xaml/System.Xaml/XamlNodeType.cs
+++ b/mcs/class/System.Xaml/System.Xaml/XamlNodeType.cs
@@ -28,7 +28,7 @@ using System.Windows.Markup;
 
 namespace System.Xaml
 {
-	public enum XamlNodeType
+	public enum XamlNodeType : byte
 	{
 		None,
 		StartObject,

--- a/mcs/class/corlib/System.Runtime.InteropServices/LIBFLAGS.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/LIBFLAGS.cs
@@ -34,7 +34,7 @@ namespace System.Runtime.InteropServices
 {
 	[Obsolete]
 	[Flags, Serializable]
-	public enum LIBFLAGS
+	public enum LIBFLAGS : short
 	{
 		LIBFLAG_FRESTRICTED = 1,
 		LIBFLAG_FCONTROL = 2,


### PR DESCRIPTION
To match the .NET 4.7.1 profile, these enum types should have special
base types.

I'm planning to make this change upstream as well.