### PR TITLE
Move implementations of some types out of facades

### DIFF
--- a/mcs/class/Facades/System.Runtime.Serialization.Primitives/System.Runtime.Serialization.Primitives.dll.sources
+++ b/mcs/class/Facades/System.Runtime.Serialization.Primitives/System.Runtime.Serialization.Primitives.dll.sources
@@ -1,4 +1,2 @@
 TypeForwarders.cs
 AssemblyInfo.cs
-
-../../../../external/corefx/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/ISerializationSurrogateProvider.cs

--- a/mcs/class/Facades/System.Runtime.Serialization.Primitives/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Runtime.Serialization.Primitives/TypeForwarders.cs
@@ -30,6 +30,7 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.IExtensibleDataObject))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.IgnoreDataMemberAttribute))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.InvalidDataContractException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.ISerializationSurrogateProvider))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.KnownTypeAttribute))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.OnDeserializedAttribute))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Runtime.Serialization.OnDeserializingAttribute))]

--- a/mcs/class/Facades/System.Security.Cryptography.Algorithms/System.Security.Cryptography.Algorithms.dll.sources
+++ b/mcs/class/Facades/System.Security.Cryptography.Algorithms/System.Security.Cryptography.Algorithms.dll.sources
@@ -1,4 +1,3 @@
 TypeForwarders.cs
 AssemblyInfo.cs
 SR.cs
-../../../../external/corefx/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.net46.cs

--- a/mcs/class/Facades/System.Security.Cryptography.Algorithms/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Security.Cryptography.Algorithms/TypeForwarders.cs
@@ -43,6 +43,7 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.HMACSHA256))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.HMACSHA384))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.HMACSHA512))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.IncrementalHash))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.MaskGenerationMethod))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.MD5))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.Cryptography.PKCS1MaskGenerationMethod))]

--- a/mcs/class/Facades/System.Security.SecureString/System.Security.SecureString.dll.sources
+++ b/mcs/class/Facades/System.Security.SecureString/System.Security.SecureString.dll.sources
@@ -1,3 +1,2 @@
 TypeForwarders.cs
 AssemblyInfo.cs
-../../../../external/corefx/src/System.Runtime.InteropServices/src/System/Security/SecureStringMarshal.cs

--- a/mcs/class/Facades/System.Security.SecureString/TypeForwarders.cs
+++ b/mcs/class/Facades/System.Security.SecureString/TypeForwarders.cs
@@ -21,3 +21,4 @@
 // 
 
 [assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.SecureString))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedToAttribute(typeof(System.Security.SecureStringMarshal))]

--- a/mcs/class/System.Core/common_System.Core.dll.sources
+++ b/mcs/class/System.Core/common_System.Core.dll.sources
@@ -289,3 +289,5 @@ System.Security.Cryptography/SHA512CryptoServiceProvider.cs
 
 ../../../external/corefx/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
 ../../../external/corefx/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+
+../../../external/corefx/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.net46.cs

--- a/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization.dll.sources
+++ b/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization.dll.sources
@@ -16,3 +16,5 @@ ReferenceSources/XmlDataContract_static.cs
 ReferenceSources/XmlFormatReaderGenerator_static.cs
 ReferenceSources/XmlFormatWriterGenerator_static.cs
 
+
+../../../external/corefx/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/ISerializationSurrogateProvider.cs

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -931,3 +931,5 @@ corefx/SR.cs
 ../../../external/corefx/src/System.Private.Uri/src/System/UriBuilder.cs
 
 ../../../external/corefx/src/System.Runtime.Extensions/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+
+../../../external/corefx/src/System.Runtime.InteropServices/src/System/Security/SecureStringMarshal.cs


### PR DESCRIPTION
These type implementations in facades are problematic, because they
don't match the .NET 4.7.1 API, where these type implementations are not
in facade assemblies.

So move them to the assemblies where they should be to match the .NET
4.7.1 API.

This change is part of the change from upstream Mono at:

https://github.com/mono/mono/commit/6e246cf6134b7496d0d1ac0a36df485c7d8b2f77

That changeset has other change in it, including changes to submodules
that we don't need now. So I've taken only the changes we need by hand
here.