### PR TITLE
Unity 2018.1 mbe backports

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1218,6 +1218,7 @@ if ($build)
 
 		# Need to define because Apple's SIP gets in the way of us telling mono where to find this
 		push @configureparams, "--with-libgdiplus=$addtoresultsdistdir/lib/libgdiplus.dylib";
+		push @configureparams, "--enable-minimal=shared_perfcounters";
 
 		print "\n";
 		print ">>> Setting environment:\n";

--- a/mcs/class/corlib/System/Debug.cs
+++ b/mcs/class/corlib/System/Debug.cs
@@ -1,0 +1,13 @@
+//Stubs for Assert used by CharUnicodeInfo pulled in from corert
+namespace System.Globalization
+{
+	public static partial class CharUnicodeInfo
+	{
+		internal static class Debug
+		{
+			internal static void Assert(bool condition, string message)
+			{
+			}
+		}
+	}
+}

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1111,7 +1111,9 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/globalization/CalendricalCalculationsHelper.cs
 ../referencesource/mscorlib/system/globalization/calendardata.cs
 ../referencesource/mscorlib/system/globalization/calendarweekrule.cs
-../referencesource/mscorlib/system/globalization/charunicodeinfo.cs
+System/Debug.cs
+../../../external/corert/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+../../../external/corert/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfoData.cs
 ../referencesource/mscorlib/system/globalization/chineselunisolarcalendar.cs
 ../referencesource/mscorlib/system/globalization/compareinfo.cs
 ../referencesource/mscorlib/system/globalization/culturenotfoundexception.cs

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2072,12 +2072,18 @@ mono_domain_assembly_search (MonoAssemblyName *aname,
 	GSList *tmp;
 	MonoAssembly *ass;
 	gboolean refonly = GPOINTER_TO_UINT (user_data);
+	const gboolean strong_name = aname->public_key_token[0] != 0;
+	/* If it's not a strong name, any version that has the right simple
+	 * name is good enough to satisfy the request.  .NET Framework also
+	 * ignores case differences in this case. */
+	const MonoAssemblyNameEqFlags eq_flags = strong_name ? MONO_ANAME_EQ_IGNORE_CASE :
+	(MONO_ANAME_EQ_IGNORE_PUBKEY | MONO_ANAME_EQ_IGNORE_VERSION | MONO_ANAME_EQ_IGNORE_CASE);
 
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;
 		/* Dynamic assemblies can't match here in MS.NET */
-		if (assembly_is_dynamic (ass) || refonly != ass->ref_only || !mono_assembly_names_equal (aname, &ass->aname))
+		if (assembly_is_dynamic (ass) || refonly != ass->ref_only || !mono_assembly_names_equal_flags (aname, &ass->aname, eq_flags))
 			continue;
 
 		mono_domain_assemblies_unlock (domain);

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -9,6 +9,24 @@
 #include <glib.h>
 
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/metadata-internals.h>
+
+/* Flag bits for mono_assembly_names_equal_flags (). */
+typedef enum {
+		/* Default comparison: all fields must match */
+	MONO_ANAME_EQ_NONE = 0x0,
+		/* Don't compare public key token */
+	MONO_ANAME_EQ_IGNORE_PUBKEY = 0x1,
+		/* Don't compare the versions */
+	MONO_ANAME_EQ_IGNORE_VERSION = 0x2,
+		/* When comparing simple names, ignore case differences */
+	MONO_ANAME_EQ_IGNORE_CASE = 0x4,
+
+	MONO_ANAME_EQ_MASK = 0x7
+} MonoAssemblyNameEqFlags;
+
+gboolean
+mono_assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, MonoAssemblyNameEqFlags flags);
 
 MONO_API MonoImage*    mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -63,18 +63,6 @@ typedef struct  {
 	gboolean framework_facade_assembly;
 } AssemblyVersionMap;
 
-/* Flag bits for assembly_names_equal_flags (). */
-typedef enum {
-	/* Default comparison: all fields must match */
-	ANAME_EQ_NONE = 0x0,
-	/* Don't compare public key token */
-	ANAME_EQ_IGNORE_PUBKEY = 0x1,
-	/* Don't compare the versions */
-	ANAME_EQ_IGNORE_VERSION = 0x2,
-
-	ANAME_EQ_MASK = 0x3
-} AssemblyNameEqFlags;
-
 /* the default search path is empty, the first slot is replaced with the computed value */
 static const char*
 default_path [] = {
@@ -358,9 +346,6 @@ mono_assembly_is_in_gac (const gchar *filanem);
 
 static MonoAssembly*
 prevent_reference_assembly_from_running (MonoAssembly* candidate, gboolean refonly);
-
-static gboolean
-assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, AssemblyNameEqFlags flags);
 
 /* Assembly name matching */
 static gboolean
@@ -685,16 +670,32 @@ check_policy_versions (MonoAssemblyBindingInfo *info, MonoAssemblyName *name)
 gboolean
 mono_assembly_names_equal (MonoAssemblyName *l, MonoAssemblyName *r)
 {
-	return assembly_names_equal_flags (l, r, ANAME_EQ_NONE);
+	return mono_assembly_names_equal_flags (l, r, MONO_ANAME_EQ_NONE);
 }
 
+/**
+ * mono_assembly_names_equal_flags:
+ * \param l first assembly name
+ * \param r second assembly name
+ * \param flags flags that affect what is compared.
+ *
+ * Compares two \c MonoAssemblyName instances and returns whether they are equal.
+ *
+ * This compares the simple names and cultures and optionally the versions and
+ * public key tokens, depending on the \c flags.
+ *
+ * \returns TRUE if both assembly names are equal.
+ */
 gboolean
-assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, AssemblyNameEqFlags flags)
+mono_assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, MonoAssemblyNameEqFlags  flags)
 {
 	if (!l->name || !r->name)
 		return FALSE;
 
-	if (strcmp (l->name, r->name))
+	if ((flags & MONO_ANAME_EQ_IGNORE_CASE) != 0 && g_strcasecmp (l->name, r->name))
+		return FALSE;
+
+	if ((flags & MONO_ANAME_EQ_IGNORE_CASE) == 0 && strcmp (l->name, r->name))
 		return FALSE;
 
 	if (l->culture && r->culture && strcmp (l->culture, r->culture))
@@ -702,11 +703,11 @@ assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, AssemblyNa
 
 	if ((l->major != r->major || l->minor != r->minor ||
 	     l->build != r->build || l->revision != r->revision) &&
-	    (flags & ANAME_EQ_IGNORE_VERSION) == 0)
+	    (flags & MONO_ANAME_EQ_IGNORE_VERSION) == 0)
 		if (! ((l->major == 0 && l->minor == 0 && l->build == 0 && l->revision == 0) || (r->major == 0 && r->minor == 0 && r->build == 0 && r->revision == 0)))
 			return FALSE;
 
-	if (!l->public_key_token [0] || !r->public_key_token [0] || (flags & ANAME_EQ_IGNORE_PUBKEY) != 0)
+	if (!l->public_key_token [0] || !r->public_key_token [0] || (flags & MONO_ANAME_EQ_IGNORE_PUBKEY) != 0)
 		return TRUE;
 
 	if (!mono_public_tokens_are_equal (l->public_key_token, r->public_key_token))
@@ -3626,13 +3627,13 @@ framework_assembly_sn_match (MonoAssemblyName *wanted_name, MonoAssemblyName *ca
 	if (vmap) {
 		if (!vmap->framework_facade_assembly) {
 			/* If the wanted name is a framework assembly, it's enough for the name/version/culture to match.  If the assembly was remapped, the public key token is likely unrelated. */
-			gboolean result = assembly_names_equal_flags (wanted_name, candidate_name, ANAME_EQ_IGNORE_PUBKEY);
+			gboolean result = mono_assembly_names_equal_flags (wanted_name, candidate_name, MONO_ANAME_EQ_IGNORE_PUBKEY);
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Predicate: candidate and wanted names %s (ignoring the public key token)", result ? "match, returning TRUE" : "don't match, returning FALSE");
 			return result;
 		} else {
 			/* For facades, the name and public key token should
 			 * match, but the version doesn't matter. */
-			gboolean result = assembly_names_equal_flags (wanted_name, candidate_name, ANAME_EQ_IGNORE_VERSION);
+			gboolean result = mono_assembly_names_equal_flags (wanted_name, candidate_name, MONO_ANAME_EQ_IGNORE_VERSION);
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Predicate: candidate and wanted names %s (ignoring version)", result ? "match, returning TRUE" : "don't match, returning FALSE");
 			return result;
 		}


### PR DESCRIPTION
case 1035654 - Avoid accessing /dev/shm
case 996473 - Resolve reference assemblies correctly from any folder in project
case 1034134 - WebGL: Correct an error that can occur when BestHTTP is used - "The type initializer for 'System.Globalization.CharUnicodeInfo' threw an exception."