### PR TITLE
Remove two methods with incorrect arguments

### DIFF
--- a/mcs/class/System.Web/System.Web.UI.WebControls.WebParts/IPersonalizable.cs
+++ b/mcs/class/System.Web/System.Web.UI.WebControls.WebParts/IPersonalizable.cs
@@ -35,9 +35,6 @@ namespace System.Web.UI.WebControls.WebParts
 {
 	public interface IPersonalizable
 	{
-		void Load (IDictionary sharedState, IDictionary userState);
-		void Save (IDictionary state);
-		
 		bool IsDirty { get; }
 	}
 }


### PR DESCRIPTION
These two methods on `IPersonalizable` don't match the .NET 4.7.1 API.
In both cases the methods should take one `PersonalizableDictionary`
argument, but _that_ type does not exist.

Since nothing in the current class library code is using these methods,
just remove them.

I'm planning to upstream this change.