### PR TITLE
Unity Memory Snapshot Support for .NET 4.x

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -26,6 +26,7 @@ typedef struct _MonoAppDomain MonoAppDomain;
 typedef struct _MonoJitInfo MonoJitInfo;
 
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
+typedef void(*MonoDomainAssemblyFunc) (MonoAssembly *assembly, void* user_data);
 
 MONO_API MonoDomain*
 mono_init                  (const char *filename);
@@ -107,6 +108,9 @@ mono_domain_from_appdomain (MonoAppDomain *appdomain);
 
 MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);
+
+MONO_API void
+mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, void* user_data);
 
 MONO_API MonoAssembly *
 mono_domain_assembly_open  (MonoDomain *domain, const char *name);

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -26,7 +26,7 @@ typedef struct _MonoAppDomain MonoAppDomain;
 typedef struct _MonoJitInfo MonoJitInfo;
 
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
-typedef void(*MonoDomainAssemblyFunc) (MonoAssembly *assembly, void* user_data);
+typedef void (*MonoDomainAssemblyFunc) (MonoAssembly *assembly, void* user_data);
 
 MONO_API MonoDomain*
 mono_init                  (const char *filename);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -2058,6 +2058,30 @@ mono_gc_register_obj_with_weak_fields (void *obj)
 	g_error ("Weak fields not supported by boehm gc");
 }
 
+void
+mono_gc_strong_handle_foreach(GFunc func, gpointer user_data)
+{
+	int gcHandleTypeIndex;
+	uint32_t i;
+
+	lock_handles(handles);
+
+	for (gcHandleTypeIndex = HANDLE_NORMAL; gcHandleTypeIndex <= HANDLE_PINNED; gcHandleTypeIndex++)
+	{
+		HandleData* handles = &gc_handles[gcHandleTypeIndex];
+
+		for (i = 0; i < handles->size; i++)
+		{			
+			if (!slot_occupied(handles, i))
+				continue;
+			if (handles->entries[i] != NULL)
+				func(handles->entries[i], user_data);
+		}
+	}
+
+	unlock_handles(handles);
+}
+
 #else
 
 MONO_EMPTY_SOURCE_FILE (boehm_gc);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -2027,7 +2027,7 @@ mono_gchandle_free_domain (MonoDomain *domain)
 {
 	guint type;
 
-	for (type = HANDLE_TYPE_MIN; type < HANDLE_PINNED; ++type) {
+	for (type = HANDLE_TYPE_MIN; type <= HANDLE_PINNED; ++type) {
 		guint slot;
 		HandleData *handles = &gc_handles [type];
 		lock_handles (handles);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -982,6 +982,27 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 	gc_free_fixed_non_heap_list (copy);
 }
 
+MONO_API void
+mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainFunc func, void* user_data)
+{
+	MonoAssembly* assembly;
+	GSList *iter;
+
+	/* Skipping internal assembly builders created by remoting,
+	   as it is done in ves_icall_System_AppDomain_GetAssemblies
+	*/
+	mono_domain_assemblies_lock(domain);
+	for (iter = domain->domain_assemblies; iter; iter = iter->next) 
+	{
+		assembly = (MonoAssembly *)iter->data;
+		if (assembly->corlib_internal)
+			continue;
+
+		func(assembly, user_data);
+	}
+	mono_domain_assemblies_unlock(domain);
+}
+
 /* FIXME: maybe we should integrate this with mono_assembly_open? */
 /**
  * mono_domain_assembly_open:

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -983,7 +983,7 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 }
 
 MONO_API void
-mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainFunc func, void* user_data)
+mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, void* user_data)
 {
 	MonoAssembly* assembly;
 	GSList *iter;

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -140,6 +140,8 @@ MonoGCDescriptor mono_gc_make_descr_for_string (gsize *bitmap, int numbits);
 
 void mono_gc_register_obj_with_weak_fields (void *obj);
 
+void mono_gc_strong_handle_foreach(GFunc func, gpointer user_data);
+
 void  mono_gc_register_for_finalization (MonoObject *obj, void *user_data);
 void  mono_gc_add_memory_pressure (gint64 value);
 MONO_API int   mono_gc_register_root (char *start, size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg);

--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -434,3 +434,21 @@ mono_mempool_get_bytes_allocated (void)
 {
 	return UnlockedRead64 (&total_bytes_allocated);
 }
+
+void 
+mono_mempool_foreach_block(MonoMemPool* pool, mono_mempool_block_proc callback, void* user_data)
+{
+	MonoMemPool *current = pool;
+
+	while (current)
+	{
+		gpointer start = (guint8*)current + SIZEOF_MEM_POOL;
+		gpointer end = (guint8*)start + current->size;
+
+		callback(start, end, user_data);
+		current = current->next;
+	}
+}
+
+
+

--- a/mono/metadata/mempool.h
+++ b/mono/metadata/mempool.h
@@ -41,6 +41,11 @@ mono_mempool_strdup        (MonoMemPool *pool, const char *s);
 MONO_API uint32_t
 mono_mempool_get_allocated (MonoMemPool *pool);
 
+typedef void(*mono_mempool_block_proc)(void* start, void* end, void* user_data);
+
+MONO_API void
+mono_mempool_foreach_block(MonoMemPool* pool, mono_mempool_block_proc callback, void* user_data);
+
 MONO_END_DECLS
 
 #endif

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -621,6 +621,8 @@ typedef struct {
 	char *aot_options;
 } MonoAotCacheConfig;
 
+typedef void(*MonoImageSetFunc) (MonoImageSet *imageSet, void* user_data);
+
 #define MONO_SIZEOF_METHOD_SIGNATURE (sizeof (struct _MonoMethodSignature) - MONO_ZERO_LEN_ARRAY * SIZEOF_VOID_P)
 
 static inline gboolean
@@ -721,6 +723,8 @@ mono_image_set_unlock (MonoImageSet *set);
 
 char*
 mono_image_set_strdup (MonoImageSet *set, const char *s);
+
+void mono_metadata_image_set_foreach(MonoImageSetFunc func, gpointer user_data);
 
 #define mono_image_set_new0(image,type,size) ((type *) mono_image_set_alloc0 (image, sizeof (type)* (size)))
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5118,6 +5118,28 @@ mono_metadata_generic_class_foreach(GFunc func, gpointer user_data)
 	}
 }
 
+void
+mono_metadata_image_set_foreach(GFunc func, gpointer user_data)
+{
+	GenericClassForeachData data;
+	guint i;
+
+	data.func = func;
+	data.user_data = user_data;
+
+	for (i = 0; i < HASH_TABLE_SIZE; ++i)
+	{
+		MonoImageSet* imageSet = img_set_cache[i];
+
+		if (imageSet == NULL)
+			continue;
+
+		mono_image_set_lock(imageSet);
+		func(imageSet, user_data);
+		mono_image_set_unlock(imageSet);
+	}
+}
+
 static gboolean
 _mono_metadata_generic_class_equal (const MonoGenericClass *g1, const MonoGenericClass *g2, gboolean signature_only)
 {

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5080,6 +5080,44 @@ mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass)
 	return gclass->container_class->valuetype;
 }
 
+typedef struct
+{
+	GFunc func;
+	gpointer user_data;
+} GenericClassForeachData;
+
+
+static void
+generic_class_foreach_callback(gpointer key, gpointer value, gpointer user_data)
+{
+	GenericClassForeachData* data = (GenericClassForeachData*)user_data;
+	data->func(key, data->user_data);
+}
+
+void
+mono_metadata_generic_class_foreach(GFunc func, gpointer user_data)
+{
+	GenericClassForeachData data;
+	guint i;
+
+	data.func = func;
+	data.user_data = user_data;
+
+	for(i = 0; i < HASH_TABLE_SIZE; ++i)
+	{ 
+		MonoImageSet* imageSet = img_set_cache[i];
+
+		if (imageSet == NULL || imageSet->gclass_cache == NULL)
+			continue;
+
+		mono_image_set_lock(imageSet);
+
+		mono_conc_hashtable_foreach(imageSet->gclass_cache, generic_class_foreach_callback, &data);
+
+		mono_image_set_unlock(imageSet);
+	}
+}
+
 static gboolean
 _mono_metadata_generic_class_equal (const MonoGenericClass *g1, const MonoGenericClass *g2, gboolean signature_only)
 {

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5082,7 +5082,7 @@ mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass)
 
 typedef struct
 {
-	GFunc func;
+	MonoGenericClassFunc func;
 	gpointer user_data;
 } GenericClassForeachData;
 
@@ -5095,7 +5095,7 @@ generic_class_foreach_callback(gpointer key, gpointer value, gpointer user_data)
 }
 
 void
-mono_metadata_generic_class_foreach(GFunc func, gpointer user_data)
+mono_metadata_generic_class_foreach(MonoGenericClassFunc func, void* user_data)
 {
 	GenericClassForeachData data;
 	guint i;
@@ -5119,7 +5119,7 @@ mono_metadata_generic_class_foreach(GFunc func, gpointer user_data)
 }
 
 void
-mono_metadata_image_set_foreach(GFunc func, gpointer user_data)
+mono_metadata_image_set_foreach(MonoImageSetFunc func, gpointer user_data)
 {
 	GenericClassForeachData data;
 	guint i;

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -10,7 +10,6 @@
 #include <mono/metadata/blob.h>
 #include <mono/metadata/row-indexes.h>
 #include <mono/metadata/image.h>
-#include <glib.h>
 
 MONO_BEGIN_DECLS
 
@@ -333,6 +332,8 @@ typedef enum {
 	MONO_PARSE_FIELD
 } MonoParseTypeMode;
 
+typedef void(*MonoGenericClassFunc) (MonoGenericClass *genericClass, void* user_data);
+
 MONO_API mono_bool
 mono_type_is_byref       (MonoType *type);
 
@@ -424,8 +425,7 @@ MONO_API int            mono_type_stack_size            (MonoType        *type,
 
 MONO_API mono_bool       mono_type_generic_inst_is_valuetype      (MonoType *type);
 MONO_API mono_bool       mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass);
-MONO_API void            mono_metadata_image_set_foreach(GFunc func, gpointer user_data);
-MONO_API void            mono_metadata_generic_class_foreach(GFunc func, gpointer user_data);
+MONO_API void            mono_metadata_generic_class_foreach(MonoGenericClassFunc func, void* user_data);
 
 MONO_API unsigned int          mono_metadata_type_hash         (MonoType *t1);
 MONO_API mono_bool       mono_metadata_type_equal        (MonoType *t1, MonoType *t2);

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -424,8 +424,8 @@ MONO_API int            mono_type_stack_size            (MonoType        *type,
 
 MONO_API mono_bool       mono_type_generic_inst_is_valuetype      (MonoType *type);
 MONO_API mono_bool       mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass);
+MONO_API void            mono_metadata_image_set_foreach(GFunc func, gpointer user_data);
 MONO_API void            mono_metadata_generic_class_foreach(GFunc func, gpointer user_data);
-
 
 MONO_API unsigned int          mono_metadata_type_hash         (MonoType *t1);
 MONO_API mono_bool       mono_metadata_type_equal        (MonoType *t1, MonoType *t2);

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -10,6 +10,7 @@
 #include <mono/metadata/blob.h>
 #include <mono/metadata/row-indexes.h>
 #include <mono/metadata/image.h>
+#include <glib.h>
 
 MONO_BEGIN_DECLS
 
@@ -423,6 +424,8 @@ MONO_API int            mono_type_stack_size            (MonoType        *type,
 
 MONO_API mono_bool       mono_type_generic_inst_is_valuetype      (MonoType *type);
 MONO_API mono_bool       mono_metadata_generic_class_is_valuetype (MonoGenericClass *gclass);
+MONO_API void            mono_metadata_generic_class_foreach(GFunc func, gpointer user_data);
+
 
 MONO_API unsigned int          mono_metadata_type_hash         (MonoType *t1);
 MONO_API mono_bool       mono_metadata_type_equal        (MonoType *t1, MonoType *t2);

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -1,15 +1,456 @@
 #include <config.h>
 #include <mono/utils/mono-publib.h>
 #include "unity-memory-info.h"
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/class.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/image.h>
+#include <mono/metadata/metadata-internals.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/tabledefs.h>
+#include <mono/metadata/tokentype.h>
+#include <mono/metadata/gc-internals.h>
+#include <glib.h>
+#include <stdlib.h>
+
+typedef struct CollectMetadataContext
+{
+	GHashTable *allTypes;
+	int currentIndex;
+	MonoMetadataSnapshot* metadata;
+} CollectMetadataContext;
+
+static void ContextInsertClass(CollectMetadataContext* context, MonoClass* klass)
+{
+	if (klass->inited && g_hash_table_lookup(context->allTypes, klass) == NULL)
+		g_hash_table_insert(context->allTypes, klass, (gpointer)(context->currentIndex++));
+}
+
+static void CollectHashMapClass(gpointer key, gpointer value, gpointer user_data)
+{
+	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
+	MonoClass* klass = (MonoClass*)value;
+	ContextInsertClass(context, klass);
+}
+
+static void CollectHashMapListClasses(gpointer key, gpointer value, gpointer user_data)
+{
+	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
+	GSList* list = (GSList*)value;
+
+	while (list != NULL)
+	{
+		MonoClass* klass = (MonoClass*)list->data;
+		ContextInsertClass(context, klass);
+
+		list = g_slist_next(list);
+	}
+}
+
+static void CollectGenericClass(gpointer value, gpointer user_data)
+{
+	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
+	MonoGenericClass* genericClass = (MonoGenericClass*)value;
+
+	if (genericClass->cached_class != NULL)
+		ContextInsertClass(context, genericClass->cached_class);
+}
+
+static void CollectAssemblyMetaData(MonoAssembly *assembly, void *user_data)
+{
+	int i;
+	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
+	MonoImage* image = mono_assembly_get_image(assembly);
+	MonoTableInfo *tdef = &image->tables[MONO_TABLE_TYPEDEF];
+
+	for (i = 0; i < tdef->rows - 1; ++i)
+	{
+		MonoClass* klass = mono_class_get(image, (i + 2) | MONO_TOKEN_TYPE_DEF);
+		ContextInsertClass(context, klass);
+	}
+
+	if (image->array_cache)
+		g_hash_table_foreach(image->array_cache, CollectHashMapListClasses, user_data);
+
+	if (image->szarray_cache)
+		g_hash_table_foreach(image->szarray_cache, CollectHashMapClass, user_data);
+
+	if (image->ptr_cache)
+		g_hash_table_foreach(image->ptr_cache, CollectHashMapClass, user_data);
+}
+
+static int FindClassIndex(GHashTable* hashTable, MonoClass* klass)
+{
+	gpointer value = g_hash_table_lookup(hashTable, klass);
+
+	if (!value)
+		return -1;
+
+	return (int)value;
+}
+
+static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
+{
+	MonoClass* klass = (MonoClass*)key;
+	int index = (int)value;
+	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
+	MonoMetadataSnapshot* metadata = context->metadata;
+	MonoMetadataType* type = &metadata->types[index];
+
+	if (klass->rank > 0)
+	{
+		type->flags = (MonoMetadataTypeFlags)(kArray | (kArrayRankMask & (klass->rank << 16)));
+		type->baseOrElementTypeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(klass));
+	}
+	else
+	{
+		gpointer iter = NULL;
+		int fieldCount = 0;
+		MonoClassField* field;
+		MonoClass* baseClass;
+		MonoVTable* vtable;
+		void* statics_data;
+
+		type->flags = (klass->valuetype || klass->byval_arg.type == MONO_TYPE_PTR) ? kValueType : kNone;
+		type->fieldCount = 0;
+
+		if (mono_class_num_fields(klass) > 0)
+		{
+			type->fields = g_new(MonoMetadataField, mono_class_num_fields(klass));
+
+			while ((field = mono_class_get_fields(klass, &iter)))
+			{
+				MonoMetadataField* metaField = &type->fields[type->fieldCount];
+				metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_from_mono_type(field->type));
+
+				// This will happen if fields type is not initialized
+				// It's OK to skip it, because it means the field is guaranteed to be null on any object
+				if (metaField->typeIndex == -1)
+					continue;
+
+				// literals have no actual storage, and are not relevant in this context.
+				if ((field->type->attrs & FIELD_ATTRIBUTE_LITERAL) != 0)
+					continue;
+
+				metaField->isStatic = (field->type->attrs & FIELD_ATTRIBUTE_STATIC) != 0;
+				metaField->offset = field->offset;
+				metaField->name = field->name;
+				type->fieldCount++;
+			}
+		}
+
+		vtable = mono_class_try_get_vtable(mono_domain_get(), klass);
+		statics_data = vtable ? mono_vtable_get_static_field_data(vtable) : NULL;
+
+		type->staticsSize = statics_data ? mono_class_data_size(klass) : 0;
+		type->statics = NULL;
+
+		if (type->staticsSize > 0)
+		{
+			type->statics = g_new0(uint8_t, type->staticsSize);
+			memcpy(type->statics, statics_data, type->staticsSize);
+		}
+
+		baseClass = mono_class_get_parent(klass);
+		type->baseOrElementTypeIndex = baseClass ? FindClassIndex(context->allTypes, baseClass) : -1;
+	}
+
+	type->assemblyName = mono_class_get_image(klass)->assembly->aname.name;
+	type->name = mono_type_get_name_full(&klass->byval_arg, MONO_TYPE_NAME_FORMAT_IL);
+	type->typeInfoAddress = (uint64_t)klass;
+	type->size = (klass->valuetype) != 0 ? (mono_class_instance_size(klass) - sizeof(MonoObject)) : mono_class_instance_size(klass);
+}
+
+static void CollectMetadata(MonoMetadataSnapshot* metadata)
+{
+	CollectMetadataContext context;
+
+	context.allTypes = g_hash_table_new(NULL, NULL);
+	context.currentIndex = 0;
+	context.metadata = metadata;
+
+	mono_assembly_foreach((GFunc)CollectAssemblyMetaData, &context);
+
+	mono_metadata_generic_class_foreach(CollectGenericClass, &context);
+
+	metadata->typeCount = g_hash_table_size(context.allTypes);
+	metadata->types = g_new0(MonoMetadataType, metadata->typeCount);
+
+	g_hash_table_foreach(context.allTypes, AddMetadataType, &context);
+
+	g_hash_table_destroy(context.allTypes);
+}
+
+static void MonoMemPoolNumChunksCallback(void* start, void* end, void* user_data)
+{
+	int* count = (int*)user_data;
+	(*count)++;
+}
+
+static int MonoMemPoolNumChunks(MonoMemPool* pool)
+{
+	int count = 0;
+	mono_mempool_foreach_block(pool, MonoMemPoolNumChunksCallback, &count);
+	return count;
+}
+
+typedef struct SectionIterationContext
+{
+	MonoManagedMemorySection* currentSection;
+} SectionIterationContext;
+
+static void AllocateMemoryForSection(void* context, void* sectionStart, void* sectionEnd)
+{
+	ptrdiff_t sectionSize;
+
+	SectionIterationContext* ctx = (SectionIterationContext*)context;
+	MonoManagedMemorySection* section = ctx->currentSection;
+
+	section->sectionStartAddress = (uint64_t)sectionStart;
+	sectionSize = (uint8_t*)(sectionEnd)-(uint8_t*)(sectionStart);
+
+	section->sectionSize = (uint32_t)(sectionSize);
+	section->sectionBytes = g_new(uint8_t, section->sectionSize);
+
+	ctx->currentSection++;
+}
+
+static void AllocateMemoryForMemPoolChunk(void* chunkStart, void* chunkEnd, void* context)
+{
+	AllocateMemoryForSection(context, chunkStart, chunkEnd);
+}
+
+static void CopyHeapSection(void* context, void* sectionStart, void* sectionEnd)
+{
+	SectionIterationContext* ctx = (SectionIterationContext*)(context);
+	MonoManagedMemorySection* section = ctx->currentSection;
+
+	g_assert(section->sectionStartAddress == (uint64_t)(sectionStart));
+	g_assert(section->sectionSize == (uint8_t*)(sectionEnd)-(uint8_t*)(sectionStart));
+	memcpy(section->sectionBytes, sectionStart, section->sectionSize);
+
+	ctx->currentSection++;
+}
+
+static void CopyMemPoolChunk(void* chunkStart, void* chunkEnd, void* context)
+{
+	CopyHeapSection(context, chunkStart, chunkEnd);
+}
+
+static void AddImageMemoryPoolChunkCount(MonoAssembly *assembly, MonoManagedHeap* heap)
+{
+	heap->sectionCount += MonoMemPoolNumChunks(assembly->image->mempool);
+}
+
+static void IncrementCountForImageMemPoolNumChunks(MonoAssembly *assembly, void *user_data)
+{
+	int* count = (int*)user_data;
+	(*count) += MonoMemPoolNumChunks(assembly->image->mempool);
+}
+
+static int MonoImagesMemPoolNumChunks()
+{
+	int count = 0;
+	mono_assembly_foreach((GFunc)IncrementCountForImageMemPoolNumChunks, &count);
+	return count;
+}
+
+static void AllocateMemoryForImageMemPool(MonoAssembly *assembly, void *user_data)
+{
+	MonoImage* image = assembly->image;
+
+	mono_image_lock(image);
+	mono_mempool_foreach_block(image->mempool, AllocateMemoryForMemPoolChunk, user_data);
+	mono_image_unlock(image);
+}
+
+static void* CaptureHeapInfo(void* monoManagedHeap)
+{
+	MonoManagedHeap* heap = (MonoManagedHeap*)monoManagedHeap;
+	MonoDomain* domain = mono_domain_get();
+	SectionIterationContext iterationContext;
+
+	// Increment count for each heap section
+	heap->sectionCount = GC_get_heap_section_count();
+	// Increment count for the domain mem pool chunk
+	heap->sectionCount += MonoMemPoolNumChunks(domain->mp);
+	// Increment count for each image mem pool chunk
+	heap->sectionCount += MonoImagesMemPoolNumChunks();
+
+	heap->sections = g_new0(MonoManagedMemorySection, heap->sectionCount);
+
+	iterationContext.currentSection = heap->sections;
+
+	// Allocate memory for each heap section
+	GC_foreach_heap_section(&iterationContext, AllocateMemoryForSection);
+	// Allocate memory for the domain mem pool chunk
+	mono_domain_lock(domain);
+	mono_mempool_foreach_block(domain->mp, AllocateMemoryForMemPoolChunk, &iterationContext);
+	mono_domain_unlock(domain);
+	// Allocate memory for each image mem pool chunk
+	mono_assembly_foreach((GFunc)AllocateMemoryForImageMemPool, &iterationContext);
+
+	return NULL;
+}
+
+static void FreeMonoManagedHeap(MonoManagedHeap* heap)
+{
+	uint32_t i;
+
+	for (i = 0; i < heap->sectionCount; i++)
+	{
+		g_free(heap->sections[i].sectionBytes);
+	}
+
+	g_free(heap->sections);
+}
+
+typedef struct VerifyHeapSectionStillValidIterationContext
+{
+	MonoManagedMemorySection* currentSection;
+	gboolean wasValid;
+} VerifyHeapSectionStillValidIterationContext;
+
+static void VerifyHeapSectionIsStillValid(void* context, void* sectionStart, void* sectionEnd)
+{
+	VerifyHeapSectionStillValidIterationContext* iterationContext = (VerifyHeapSectionStillValidIterationContext*)context;
+	if (iterationContext->currentSection->sectionSize != (uint8_t*)(sectionEnd)-(uint8_t*)(sectionStart))
+		iterationContext->wasValid = FALSE;
+	else if (iterationContext->currentSection->sectionStartAddress != (uint64_t)(sectionStart))
+		iterationContext->wasValid = FALSE;
+
+	iterationContext->currentSection++;
+}
+
+static gboolean MonoManagedHeapStillValid(MonoManagedHeap* heap)
+{
+	MonoDomain* domain = mono_domain_get();
+	VerifyHeapSectionStillValidIterationContext iterationContext;
+	int currentSectionCount;
+
+	currentSectionCount = GC_get_heap_section_count();
+	currentSectionCount += MonoMemPoolNumChunks(domain->mp);
+	currentSectionCount += MonoImagesMemPoolNumChunks();
+
+	if (heap->sectionCount != currentSectionCount)
+		return FALSE;
+
+	iterationContext.currentSection = heap->sections;
+	iterationContext.wasValid = TRUE;
+
+	GC_foreach_heap_section(&iterationContext, VerifyHeapSectionIsStillValid);
+
+	return iterationContext.wasValid;
+}
+
+// The difficulty in capturing the managed snapshot is that we need to do quite some work with the world stopped,
+// to make sure that our snapshot is "valid", and didn't change as we were copying it. However, stopping the world,
+// makes it so you cannot take any lock or allocations. We deal with it like this:
+//
+// 1) We take note of the amount of heap sections and their sizes, and we allocate memory to copy them into.
+// 2) We stop the world.
+// 3) We check if the amount of heapsections and their sizes didn't change in the mean time. If they did, try again.
+// 4) Now, with the world still stopped, we memcpy() the memory from the real heapsections, into the memory that we
+//    allocated for their copies.
+// 5) Start the world again.
+
+static void CaptureManagedHeap(MonoManagedHeap* heap)
+{
+	MonoDomain* domain = mono_domain_get();
+	SectionIterationContext iterationContext;
+
+	while (TRUE)
+	{
+		GC_call_with_alloc_lock(CaptureHeapInfo, heap);
+		GC_stop_world_external();
+
+		if (MonoManagedHeapStillValid(heap))
+			break;
+
+		GC_start_world_external();
+
+		FreeMonoManagedHeap(heap);
+	}
+
+	iterationContext.currentSection = heap->sections;
+	GC_foreach_heap_section(&iterationContext, CopyHeapSection);
+
+	mono_mempool_foreach_block(domain->mp, CopyMemPoolChunk, &iterationContext);
+
+	GC_start_world_external();
+}
+
+static void GCHandleIterationCallback(MonoObject* managedObject, GList** managedObjects)
+{
+	*managedObjects = g_list_append(*managedObjects, managedObject);
+}
+
+static inline void CaptureGCHandleTargets(MonoGCHandles* gcHandles)
+{
+	uint32_t i;
+	GList* trackedObjects, *trackedObject;
+
+	trackedObjects = NULL;
+
+	mono_gc_strong_handle_foreach((GFunc)GCHandleIterationCallback, &trackedObjects);
+
+	gcHandles->trackedObjectCount = (uint32_t)g_list_length(trackedObjects);
+	gcHandles->pointersToObjects = (uint64_t*)g_new0(uint64_t, gcHandles->trackedObjectCount);
+
+	trackedObject = trackedObjects;
+
+	for (i = 0; i < gcHandles->trackedObjectCount; i++)
+	{
+		gcHandles->pointersToObjects[i] = (uint64_t)trackedObject->data;
+		trackedObject = g_list_next(trackedObject);
+	}
+
+	g_list_free(trackedObjects);
+}
+
+static void FillRuntimeInformation(MonoRuntimeInformation* runtimeInfo)
+{
+	runtimeInfo->pointerSize = (uint32_t)(sizeof(void*));
+	runtimeInfo->objectHeaderSize = (uint32_t)(sizeof(MonoObject));
+	runtimeInfo->arrayHeaderSize = offsetof(MonoArray, vector);
+	runtimeInfo->arraySizeOffsetInHeader = offsetof(MonoArray, max_length);
+	runtimeInfo->arrayBoundsOffsetInHeader = offsetof(MonoArray, bounds);
+	runtimeInfo->allocationGranularity = (uint32_t)(2 * sizeof(void*));
+}
 
 MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 {
 	MonoManagedMemorySnapshot* snapshot;
 	snapshot = g_new0(MonoManagedMemorySnapshot, 1);
+
+	CollectMetadata(&snapshot->metadata);
+	CaptureManagedHeap(&snapshot->heap);
+	CaptureGCHandleTargets(&snapshot->gcHandles);
+	FillRuntimeInformation(&snapshot->runtimeInformation);
+
 	return snapshot;
 }
 
 void mono_unity_free_captured_memory_snapshot(MonoManagedMemorySnapshot* snapshot)
 {
+	uint32_t i;
+	MonoMetadataSnapshot* metadata = &snapshot->metadata;
+
+	FreeMonoManagedHeap(&snapshot->heap);
+
+	g_free(snapshot->gcHandles.pointersToObjects);
+
+	for (i = 0; i < metadata->typeCount; i++)
+	{
+		if ((metadata->types[i].flags & kArray) == 0)
+		{
+			g_free(metadata->types[i].fields);
+			g_free(metadata->types[i].statics);
+		}
+
+		g_free(metadata->types[i].name);
+	}
+
+	g_free(metadata->types);
 	g_free(snapshot);
 }

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -13,6 +13,10 @@
 #include <glib.h>
 #include <stdlib.h>
 
+#if HAVE_BDWGC_GC
+
+#include "external/bdwgc/include/gc.h"
+
 typedef struct CollectMetadataContext
 {
 	GHashTable *allTypes;
@@ -648,7 +652,7 @@ MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 	FillRuntimeInformation(&snapshot->runtimeInformation);
 
 #if _DEBUG
-	VerifySnapshot(snapshot, monoImages);
+//	VerifySnapshot(snapshot, monoImages);
 #endif
 
 	g_hash_table_destroy(monoImages);
@@ -679,3 +683,20 @@ void mono_unity_free_captured_memory_snapshot(MonoManagedMemorySnapshot* snapsho
 	g_free(metadata->types);
 	g_free(snapshot);
 }
+
+#else
+
+MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
+{
+	MonoManagedMemorySnapshot* snapshot;
+	snapshot = g_new0(MonoManagedMemorySnapshot, 1);
+
+	return snapshot;
+}
+
+void mono_unity_free_captured_memory_snapshot(MonoManagedMemorySnapshot* snapshot)
+{
+	g_free(snapshot);
+}
+
+#endif

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -56,10 +56,9 @@ static void CollectHashMapListClasses(gpointer key, gpointer value, gpointer use
 	}
 }
 
-static void CollectGenericClass(gpointer value, gpointer user_data)
+static void CollectGenericClass(MonoGenericClass* genericClass, gpointer user_data)
 {
 	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
-	MonoGenericClass* genericClass = (MonoGenericClass*)value;
 
 	if (genericClass->cached_class != NULL)
 		ContextInsertClass(context, genericClass->cached_class);
@@ -349,7 +348,7 @@ static void IncrementCountForImageSetMemPoolNumChunks(MonoImageSet *imageSet, vo
 static int MonoImageSetsMemPoolNumChunks()
 {
 	int count = 0;	
-	mono_metadata_image_set_foreach((GFunc)IncrementCountForImageSetMemPoolNumChunks, &count);
+	mono_metadata_image_set_foreach(IncrementCountForImageSetMemPoolNumChunks, &count);
 	return count;
 }
 
@@ -410,7 +409,7 @@ static void* CaptureHeapInfo(void* user)
 	// Allocate memory for each image->class_cache hash table.
 	g_hash_table_foreach(monoImages, (GHFunc)AllocateMemoryForImageClassCache, &iterationContext);
 	// Allocate memory for each image->class_cache hash table.
-	mono_metadata_image_set_foreach((GFunc)AllocateMemoryForImageSetMemPool, &iterationContext);
+	mono_metadata_image_set_foreach(AllocateMemoryForImageSetMemPool, &iterationContext);
 
 	return NULL;
 }
@@ -512,7 +511,7 @@ static void CaptureManagedHeap(MonoManagedHeap* heap, GHashTable* monoImages)
 	mono_mempool_foreach_block(domain->mp, CopyMemPoolChunk, &iterationContext);
 	g_hash_table_foreach(monoImages, (GHFunc)CopyImageMemPool, &iterationContext);
 	g_hash_table_foreach(monoImages, (GHFunc)CopyImageClassCache, &iterationContext);
-	mono_metadata_image_set_foreach((GFunc)CopyImageSetMemPool, &iterationContext);
+	mono_metadata_image_set_foreach(CopyImageSetMemPool, &iterationContext);
 
 	GC_start_world_external();
 }

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -63,13 +63,15 @@ static void CollectImageMetaData(MonoImage* image, gpointer value, CollectMetada
 
 	if (image->dynamic)
 	{
+		GHashTableIter iter;
+		gpointer key;
 		MonoDynamicImage* dynamicImage = (MonoDynamicImage*)image;
-		GList* types = g_hash_table_get_keys(dynamicImage->typeref);
-		GList* type;
 
-		for (type = types; type != NULL; type = type->next)
+		g_hash_table_iter_init(&iter, dynamicImage->typeref);
+
+		while (g_hash_table_iter_next(&iter, &key, NULL))
 		{
-			MonoType* monoType = (MonoType*)type->data;
+			MonoType* monoType = (MonoType*)key;
 			MonoClass* klass = mono_type_get_class(monoType);
 
 			if (klass)


### PR DESCRIPTION
This PR implements the following API that already exists in .NET 3.5 Mono.

mono_unity_capture_memory_snapshot
mono_unity_free_captured_memory_snapshot

It also includes the bug fixes that were made to .NET 3.5. Mono version.

I will be moving this code into a git submodule in a separate PR, so we can use the same version of this code across all Unity versions.

Also requires the following bdwgc change to be used to avoid crashes:

https://github.com/Unity-Technologies/bdwgc/pull/8