### PR TITLE
Remove resources/charinfo.nlp from mscrolib since we are using CoreRT…

### DIFF
--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -42,7 +42,6 @@ MODULE_DEPS = $(IL_REPLACE)
 endif
 
 RESOURCE_FILES = \
-	resources/charinfo.nlp \
 	resources/collation.core.bin \
 	resources/collation.tailoring.bin \
 	resources/collation.cjkCHS.bin \


### PR DESCRIPTION
… implementation of CharUnicodeInfo with managed data

Saves 32kb in size on mscorlib.