### PR TITLE
Fix issue where loopback interface causes exception 1027045

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/IPAddressCollection.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPAddressCollection.cs
@@ -84,6 +84,25 @@ namespace System.Net.NetworkInformation {
 			return c;
 		}
 
+		public static Win32IPAddressCollection FromSocketAddress (Win32_SOCKET_ADDRESS addr)
+		{
+			Win32IPAddressCollection c = new Win32IPAddressCollection ();
+			if (addr.Sockaddr != IntPtr.Zero)
+				c.InternalAdd (addr.GetIPAddress ());
+			return c;
+		}
+
+		public static Win32IPAddressCollection FromWinsServer (IntPtr ptr)
+		{
+			Win32IPAddressCollection c = new Win32IPAddressCollection ();
+			Win32_IP_ADAPTER_WINS_SERVER_ADDRESS a;
+			for (IntPtr p = ptr; p != IntPtr.Zero; p = a.Next) {
+				a = (Win32_IP_ADAPTER_WINS_SERVER_ADDRESS) Marshal.PtrToStructure (p, typeof (Win32_IP_ADAPTER_WINS_SERVER_ADDRESS));
+				c.InternalAdd (a.Address.GetIPAddress ());
+			}
+			return c;
+		}
+
 		void AddSubsequentlyString (IntPtr head)
 		{
 			Win32_IP_ADDR_STRING a;

--- a/mcs/class/System/System.Net.NetworkInformation/IPInterfaceProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPInterfaceProperties.cs
@@ -341,13 +341,11 @@ namespace System.Net.NetworkInformation {
 
 		public override IPv4InterfaceProperties GetIPv4Properties ()
 		{
-			Win32_IP_ADAPTER_INFO v4info = Win32NetworkInterface2.GetAdapterInfoByIndex (mib4.Index);
-			return new Win32IPv4InterfaceProperties (v4info, mib4);
+			return new Win32IPv4InterfaceProperties (addr, mib4);
 		}
 
 		public override IPv6InterfaceProperties GetIPv6Properties ()
 		{
-			Win32_IP_ADAPTER_INFO v6info = Win32NetworkInterface2.GetAdapterInfoByIndex (mib6.Index);
 			return new Win32IPv6InterfaceProperties (mib6);
 		}
 
@@ -371,10 +369,9 @@ namespace System.Net.NetworkInformation {
 
 		public override IPAddressCollection DhcpServerAddresses {
 			get {
-				Win32_IP_ADAPTER_INFO v4info = Win32NetworkInterface2.GetAdapterInfoByIndex (mib4.Index);
 				// FIXME: should ipv6 DhcpServer be considered?
 				try {
-					return new Win32IPAddressCollection (v4info.DhcpServer);
+					return Win32IPAddressCollection.FromSocketAddress (addr.Dhcpv4Server);
 				} catch (IndexOutOfRangeException) {
 					return Win32IPAddressCollection.Empty;
 				}
@@ -393,25 +390,14 @@ namespace System.Net.NetworkInformation {
 			get {
 				var col = new GatewayIPAddressInformationCollection ();
 				try {
-					Win32_IP_ADAPTER_INFO v4info = Win32NetworkInterface2.GetAdapterInfoByIndex (mib4.Index);
 					// FIXME: should ipv6 DhcpServer be considered?
-
-					var a = v4info.GatewayList;
-					if (!String.IsNullOrEmpty (a.IpAddress)) {
-						col.InternalAdd(new SystemGatewayIPAddressInformation(IPAddress.Parse (a.IpAddress)));
-						AddSubsequently (a.Next, col);
+					Win32_IP_ADAPTER_GATEWAY_ADDRESS a;
+					for (IntPtr p = addr.FirstGatewayAddress; p != IntPtr.Zero; p = a.Next) {
+						a = (Win32_IP_ADAPTER_GATEWAY_ADDRESS) Marshal.PtrToStructure (p, typeof (Win32_IP_ADAPTER_GATEWAY_ADDRESS));
+						col.InternalAdd (new SystemGatewayIPAddressInformation (a.Address.GetIPAddress ()));
 					}
 				} catch (IndexOutOfRangeException) {}
 				return col;
-			}
-		}
-
-		static void AddSubsequently (IntPtr head, GatewayIPAddressInformationCollection col)
-		{
-			Win32_IP_ADDR_STRING a;
-			for (IntPtr p = head; p != IntPtr.Zero; p = a.Next) {
-				a = (Win32_IP_ADDR_STRING) Marshal.PtrToStructure (p, typeof (Win32_IP_ADDR_STRING));
-				col.InternalAdd (new SystemGatewayIPAddressInformation (IPAddress.Parse (a.IpAddress)));
 			}
 		}
 
@@ -444,7 +430,6 @@ namespace System.Net.NetworkInformation {
 		public override UnicastIPAddressInformationCollection UnicastAddresses {
 			get {
 				try {
-					Win32_IP_ADAPTER_INFO ai = Win32NetworkInterface2.GetAdapterInfoByIndex (mib4.Index);
 					// FIXME: should ipv6 DhcpServer be considered?
 					return Win32FromUnicast (addr.FirstUnicastAddress);
 				} catch (IndexOutOfRangeException) {
@@ -467,9 +452,7 @@ namespace System.Net.NetworkInformation {
 		public override IPAddressCollection WinsServersAddresses {
 			get {
 				try {
-					Win32_IP_ADAPTER_INFO v4info = Win32NetworkInterface2.GetAdapterInfoByIndex (mib4.Index);
-					// FIXME: should ipv6 DhcpServer be considered?
-					return new Win32IPAddressCollection (v4info.PrimaryWinsServer, v4info.SecondaryWinsServer);
+					return Win32IPAddressCollection.FromWinsServer (addr.FirstWinsServerAddress);
 				} catch (IndexOutOfRangeException) {
 					return Win32IPAddressCollection.Empty;
 				}

--- a/mcs/class/System/System.Net.NetworkInformation/IPv4InterfaceProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPv4InterfaceProperties.cs
@@ -129,13 +129,13 @@ namespace System.Net.NetworkInformation {
 		[DllImport ("iphlpapi.dll")]
 		static extern int GetPerAdapterInfo (int IfIndex, Win32_IP_PER_ADAPTER_INFO pPerAdapterInfo, ref int pOutBufLen);
 
-		Win32_IP_ADAPTER_INFO ainfo;
+		Win32_IP_ADAPTER_ADDRESSES addr;
 		Win32_IP_PER_ADAPTER_INFO painfo;
 		Win32_MIB_IFROW mib;
 
-		public Win32IPv4InterfaceProperties (Win32_IP_ADAPTER_INFO ainfo, Win32_MIB_IFROW mib)
+		public Win32IPv4InterfaceProperties (Win32_IP_ADAPTER_ADDRESSES addr, Win32_MIB_IFROW mib)
 		{
-			this.ainfo = ainfo;
+			this.addr = addr;
 			this.mib = mib;
 
 			// get per-adapter info.
@@ -160,7 +160,7 @@ namespace System.Net.NetworkInformation {
 		}
 
 		public override bool IsDhcpEnabled {
-			get { return ainfo.DhcpEnabled != 0; }
+			get { return addr.DhcpEnabled; }
 		}
 
 		public override bool IsForwardingEnabled {
@@ -173,7 +173,7 @@ namespace System.Net.NetworkInformation {
 		}
 
 		public override bool UsesWins {
-			get { return ainfo.HaveWins; }
+			get { return addr.FirstWinsServerAddress != IntPtr.Zero; }
 		}
 	}
 

--- a/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkInterface.cs
@@ -465,9 +465,13 @@ namespace System.Net.NetworkInformation {
 			{
 				IntPtr ptr = IntPtr.Zero;
 				int len = 0;
-				GetAdaptersAddresses (0, 0, IntPtr.Zero, ptr, ref len);
+				uint flags = Win32_IP_ADAPTER_ADDRESSES.GAA_FLAG_INCLUDE_WINS_INFO | Win32_IP_ADAPTER_ADDRESSES.GAA_FLAG_INCLUDE_GATEWAYS;
+				GetAdaptersAddresses (0, flags, IntPtr.Zero, ptr, ref len);
+				if (Marshal.SizeOf (typeof (Win32_IP_ADAPTER_ADDRESSES)) > len)
+					throw new NetworkInformationException ();
+
 				ptr = Marshal.AllocHGlobal(len);
-				int ret = GetAdaptersAddresses (0, 0, IntPtr.Zero, ptr, ref len);
+				int ret = GetAdaptersAddresses (0, flags, IntPtr.Zero, ptr, ref len);
 				if (ret != 0)
 					throw new NetworkInformationException (ret);
 
@@ -828,14 +832,6 @@ namespace System.Net.NetworkInformation {
 
 		[DllImport ("iphlpapi.dll", SetLastError = true)]
 		static extern int GetIfEntry (ref Win32_MIB_IFROW row);
-
-		public static Win32_IP_ADAPTER_INFO GetAdapterInfoByIndex (int index)
-		{
-			foreach (Win32_IP_ADAPTER_INFO info in GetAdaptersInfo ())
-				if (info.Index == index)
-					return info;
-			throw new IndexOutOfRangeException ("No adapter found for index " + index);
-		}
 
 		static Win32_IP_ADAPTER_INFO [] GetAdaptersInfo ()
 		{

--- a/mcs/class/System/System.Net.NetworkInformation/Win32NetworkInterfaceMarshal.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Win32NetworkInterfaceMarshal.cs
@@ -121,20 +121,46 @@ namespace System.Net.NetworkInformation
 		public NetworkInterfaceType IfType;
 		public OperationalStatus OperStatus;
 		public int Ipv6IfIndex;
-		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 16 * 4)]
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 16)]
 		public uint [] ZoneIndices;
+		public IntPtr FirstPrefix; // to PIP_ADAPTER_PREFIX
+		public UInt64 TransmitLinkSpeed;
+		public UInt64 ReceiveLinkSpeed;
+		public IntPtr FirstWinsServerAddress; // to PIP_ADAPTER_WINS_SERVER_ADDRESS_LH
+		public IntPtr FirstGatewayAddress; // to PIP_ADAPTER_GATEWAY_ADDRESS_LH
+		public uint Ipv4Metric;
+		public uint Ipv6Metric;
+		public UInt64 Luid;
+		public Win32_SOCKET_ADDRESS Dhcpv4Server;
+		public uint CompartmentId;
+		public UInt64 NetworkGuid;
+		public int ConnectionType;
+		public int TunnelType;
+		public Win32_SOCKET_ADDRESS Dhcpv6Server;
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = MAX_DHCPV6_DUID_LENGTH)]
+		public byte [] Dhcpv6ClientDuid;
+		public ulong Dhcpv6ClientDuidLength;
+		public ulong Dhcpv6Iaid;
+		public IntPtr FirstDnsSuffix; // to PIP_ADAPTER_DNS_SUFFIX
 
-		// Note that Vista-only members and XP-SP1-only member are
-		// omitted.
+		//Flags For GetAdapterAddresses
+		public const int GAA_FLAG_INCLUDE_WINS_INFO = 0x0040;
+		public const int GAA_FLAG_INCLUDE_GATEWAYS = 0x0080;
 
 		const int MAX_ADAPTER_ADDRESS_LENGTH = 8;
+		const int MAX_DHCPV6_DUID_LENGTH = 130;
 
 		const int IP_ADAPTER_DDNS_ENABLED = 1;
+		const int IP_ADAPTER_DHCP_ENABLED = 4;
 		const int IP_ADAPTER_RECEIVE_ONLY = 8;
 		const int IP_ADAPTER_NO_MULTICAST = 0x10;
 
 		public bool DdnsEnabled {
 			get { return (Flags & IP_ADAPTER_DDNS_ENABLED) != 0; }
+		}
+
+		public bool DhcpEnabled {
+			get { return (Flags & IP_ADAPTER_DHCP_ENABLED) != 0; }
 		}
 
 		public bool IsReceiveOnly {
@@ -264,6 +290,22 @@ namespace System.Net.NetworkInformation
 	{
 		public Win32LengthFlagsUnion LengthFlags;
 		public IntPtr Next; // to Win32_IP_ADAPTER_MULTICAST_ADDRESS
+		public Win32_SOCKET_ADDRESS Address;
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	struct Win32_IP_ADAPTER_GATEWAY_ADDRESS
+	{
+		public Win32LengthFlagsUnion LengthFlags;
+		public IntPtr Next; // to Win32_IP_ADAPTER_GATEWAY_ADDRESS
+		public Win32_SOCKET_ADDRESS Address;
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	struct Win32_IP_ADAPTER_WINS_SERVER_ADDRESS
+	{
+		public Win32LengthFlagsUnion LengthFlags;
+		public IntPtr Next; // to Win32_IP_ADAPTER_WINS_SERVER_ADDRESS
 		public Win32_SOCKET_ADDRESS Address;
 	}
 


### PR DESCRIPTION
Inital WIP commit. Still needs more changes, testing, etc.
we should probably upstream this once we're done.

manually tested output of this against .netFW

(Scripting Upgrade) Fixed an issue where GetIPv4Properties could throw an exception when called on the loopback network interface (case 1027045)
--------------------------------------------------
	public void Test()
	{
		var interfaces = NetworkInterface.GetAllNetworkInterfaces();
		foreach (NetworkInterface ni in interfaces)
		{
			var ipv4Properties = ni.GetIPProperties().GetIPv4Properties();
			UnityEngine.Debug.Log(ni.Name + " " + ipv4Properties.Index);
			var isDHCP = ipv4Properties.IsDhcpEnabled;
			UnityEngine.Debug.Log("isDHCP " + isDHCP);
			var iswins = ipv4Properties.UsesWins;
			UnityEngine.Debug.Log("UsesWins " + iswins);



			var dhcpserveraddrcol = ni.GetIPProperties().DhcpServerAddresses;
			foreach (var dhcp in dhcpserveraddrcol)
				UnityEngine.Debug.Log("dhcpserver " + dhcp.Address);
			var gatewayipaddressinformationcol = ni.GetIPProperties().GatewayAddresses;
			foreach (var gateway in gatewayipaddressinformationcol)
				UnityEngine.Debug.Log("gatewayserver " + gateway.Address);
			var unicastipaddresinformationcol = ni.GetIPProperties().UnicastAddresses;
			foreach (var unicast in unicastipaddresinformationcol)
				UnityEngine.Debug.Log("unicastserver " + unicast.Address);
			var winsipaddresscol = ni.GetIPProperties().WinsServersAddresses;
			foreach (var ftw in winsipaddresscol)
				UnityEngine.Debug.Log("winsserver " + ftw.Address);
		}
	}