### PR TITLE
fix issue where pal was not returning the right data

### DIFF
--- a/mono/utils/unity-time.c
+++ b/mono/utils/unity-time.c
@@ -26,7 +26,7 @@ mono_100ns_ticks (void)
 gint64
 mono_100ns_datetime (void)
 {
-	return (gint64) UnityPalGetTicks100NanosecondsDateTime();
+	return (gint64) UnityPalGetSystemTimeAsFileTime();
 }
 
 gint64


### PR DESCRIPTION
The function name is misleading, and it should return the systemtimeasfile time, not the 100nanosecondsdatetime (the same as the mono version)
gint64
mono_100ns_datetime (void)
{
    ULARGE_INTEGER ft;

    if (sizeof(ft) != sizeof(FILETIME))
        g_assert_not_reached ();

    GetSystemTimeAsFileTime ((FILETIME*) &ft);
    return ft.QuadPart;
}