### PR TITLE
Assume not having libc means this is not macOS

### DIFF
--- a/mcs/class/System/System/Platform.cs
+++ b/mcs/class/System/System/Platform.cs
@@ -59,26 +59,40 @@ namespace System {
 			}
 
 			IntPtr buf = Marshal.AllocHGlobal (8192);
-			if (uname (buf) == 0) {
-				string os = Marshal.PtrToStringAnsi (buf);
-				switch (os) {
-				case "Darwin":
-					isMacOS = true;
-					break;
-				case "FreeBSD":
-					isFreeBSD = true;
-					break;
+			try {
+				if (uname (buf) == 0) {
+					string os = Marshal.PtrToStringAnsi (buf);
+					switch (os) {
+					case "Darwin":
+						isMacOS = true;
+						break;
+					case "FreeBSD":
+						isFreeBSD = true;
+						break;
+					}
 				}
 			}
-			Marshal.FreeHGlobal (buf);
-			checkedOS = true;
+			finally {
+				Marshal.FreeHGlobal (buf);
+				checkedOS = true;
+			}
 		}
 #endif
 
 		public static bool IsMacOS {
 			get {
 				if (!checkedOS)
+#if UNITY
+					try {
+						CheckOS();
+					}
+					catch (DllNotFoundException e) {
+						// libc does not exist, so this is not MacOS
+						isMacOS = false;
+					}
+#else
 					CheckOS();
+#endif
 				return isMacOS;
 			}
 		}


### PR DESCRIPTION
We know that libc will always be present on macOS, so if it is not
there, we can assume this is not macOS.

More generally, use a try/finally to avoid leaking the allocated buffer
when libc is not found and set `checkOS` properly so we don't try to
check again.

This corrects Unity case 1038918, and in general helps our platform
story int he class libraries a little bit, until we get better platform
detection support at runtime.

Release notes:

Correct an exception that can occur when a web request is created on PS4 with the .NET 4.x Equivalent scripting runtime. (case 1038918)