### PR TITLE
Don't call sa_sigaction when it is NULL

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -133,7 +133,8 @@ SIG_HANDLER_SIGNATURE (mono_chain_signal)
 			saved_handler->sa_handler (signal);
 		} else {
 #ifdef MONO_ARCH_USE_SIGACTION
-			saved_handler->sa_sigaction (signal, info, ctx);
+			if (saved_handler->sa_sigaction != NULL)
+			    saved_handler->sa_sigaction (signal, info, ctx);
 #endif /* MONO_ARCH_USE_SIGACTION */
 		}
 		return TRUE;


### PR DESCRIPTION
It is possible for the sa_sigaction callback to be NULL. This happens
for abort signal. Calling a NULL method will cause the signal handler to
hang, which will cause Unity to hang, instead of crashing. This can be
unhelpful when tests are running, for example.

We noticed this while using the address sanitizer from clang, since it calls abort when it encounters an error.