### PR TITLE
Remove the 32-bit slice from the Mono runtime

### DIFF
--- a/external/buildscripts/build_runtime_osx_all.pl
+++ b/external/buildscripts/build_runtime_osx_all.pl
@@ -502,9 +502,8 @@ sub build_osx
 	mkpath ("$embeddir/$os");
 
 
-	# Create universal binaries
 	for my $file ('libmono.0.dylib','libmono.a','libMonoPosixHelper.dylib') {
-		system ('lipo', "$embeddir/$os-i386/$file", "$embeddir/$os-x86_64/$file", '-create', '-output', "$embeddir/$os/$file");
+		system ('cp', "$embeddir/$os-x86_64/$file", "$embeddir/$os/$file");
 	}
 
 	if (not $ENV{"UNITY_THISISABUILDMACHINE"})


### PR DESCRIPTION
Apple is not allowing Mac App Store submissions with 32-bit slices in
universal binaries any longer. We don't use the 32-bit slice in Mono, so
remove it.