### PR TITLE
Fix monoTODO where driveinfo.IsReady is unimplemented FB1028143

### DIFF
--- a/mcs/class/corlib/System.IO/DriveInfo.cs
+++ b/mcs/class/corlib/System.IO/DriveInfo.cs
@@ -140,10 +140,9 @@ namespace System.IO {
 			}
 		}
 
-		[MonoTODO("It always returns true")]
 		public bool IsReady {
 			get {
-				return true;
+				return Directory.Exists (Name);
 			}
 		}
 		


### PR DESCRIPTION
(Scripting Upgrade) Fixes an issue with DriveInfo.IsReady returning true when there was no disc in the cd drive (case 1028143)

I've implemented the function in the same way corefx and referencesource do, by checking that the base directory of the drive exists.

With this fix, the IsReady returns false when there is no disk in the drive, and true when there is a disk in the drive.

I will upstream this fix

https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.cs