### PR TITLE
Fix monoTODO where driveinfo.IsReady is unimplemented

### DIFF
--- a/mcs/class/corlib/System.IO/DriveInfo.cs
+++ b/mcs/class/corlib/System.IO/DriveInfo.cs
@@ -140,10 +140,9 @@ namespace System.IO {
 			}
 		}
 
-		[MonoTODO("It always returns true")]
 		public bool IsReady {
 			get {
-				return true;
+				return Directory.Exists (Name);
 			}
 		}
 		


### PR DESCRIPTION
(Scripting Upgrade) Fixes an issue with DriveInfo.IsReady returning true when there was no disc in the cd drive (case 1028143)