### PR TITLE
Fix SetAttribute not respecting file mappings FB1061522

### DIFF
--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -481,6 +481,11 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (const gunichar2 *path, gint32 attr
 					      gint32 *error)
 {
 	gboolean ret;
+	const gunichar2 *path_remapped;
+
+	if (path_remapped = mono_unity_remap_path_utf16 (path))
+		path = path_remapped;
+
 	*error=ERROR_SUCCESS;
 	
 	ret=mono_w32file_set_attributes (path,
@@ -488,6 +493,9 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (const gunichar2 *path, gint32 attr
 	if(ret==FALSE) {
 		*error=mono_w32error_get_last ();
 	}
+
+	g_free (path_remapped);
+
 	return(ret);
 }
 


### PR DESCRIPTION
Fixes an issue where the call to File.GetAttributes() works but the call to File.SetAttributes() fails.

(Scripting) Fixes an issue where File.SetAttributes would not remap the path (case1061522)