### PR TITLE
Add check for a generic method when invoking in debugger

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4396,5 +4396,17 @@ public class DebuggerTests
 		AssertValue (3.0, f);
 
 	}
+
+	[Test]
+    public void InvokeGenericMethod () {
+        Event e = run_until ("bp1");
+        StackFrame frame = e.Thread.GetFrames()[0];
+        TypeMirror t = frame.Method.DeclaringType;
+        MethodMirror m;
+        m = t.GetMethod ("generic_method");
+        AssertThrows<ArgumentException> (delegate {
+        	t.InvokeMethod (e.Thread, m, null);
+        	});      
+    }
 } // class DebuggerTests
 } // namespace

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8181,7 +8181,11 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		this_buf = (guint8 *)g_alloca (mono_class_instance_size (m->klass));
 	else
 		this_buf = (guint8 *)g_alloca (sizeof (MonoObject*));
-	if (m->klass->valuetype && (m->flags & METHOD_ATTRIBUTE_STATIC)) {
+
+	if (m->is_generic) {
+        DEBUG_PRINTF (1, "[%p] Error: Attemtping to invoke uninflated generic method %s.\n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (m, TRUE));
+        return ERR_INVALID_ARGUMENT;
+    } else if (m->klass->valuetype && (m->flags & METHOD_ATTRIBUTE_STATIC)) {
 		/* Should be null */
 		int type = decode_byte (p, &p, end);
 		if (type != VALUE_TYPE_ID_NULL) {


### PR DESCRIPTION
Fix for Unity case 1049288.  VSTU will try to invoke a generic
(uninflated) method in certain situations, which was causing the
Mono debugger to assert and crash Unity.  Added a check for this
situation before the invoke and returning an error to the client.
Previously, this case wasn't caught until the method was in JIT
compilation, which will assert.

Release Notes: Fixes an issue in the Mono debugger when the debugger client tries to invoke an uninflated generic method.