### PR TITLE
Only use the AOT code path for the AOT profile

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoProperty.cs
+++ b/mcs/class/corlib/System.Reflection/MonoProperty.cs
@@ -378,9 +378,7 @@ namespace System.Reflection {
 		{
 			if (index == null || index.Length == 0) {
 				/*FIXME we should check if the number of arguments matches the expected one, otherwise the error message will be pretty criptic.*/
-// Once we ship the changes to make il2cpp always use the unityaot profile, we should change
-// this define to be UNITY_AOT. for now though, we'll take the AOT-friendly code path in all profiles.
-#if !FULL_AOT_RUNTIME && !UNITY
+#if !FULL_AOT_RUNTIME && !UNITY_AOT
 				if (cached_getter == null) {
 					MethodInfo method = GetGetMethod (true);
 					if (!DeclaringType.IsValueType && !method.ContainsGenericParameters) { //FIXME find a way to build an invoke delegate for value types.


### PR DESCRIPTION
In the Unity repo we now use only the AOT profile for IL2CPP, so there
is no need to take this AOT-friendly code path in the non_AOT profile.

Longer term: Do we want to define `FULL_AOT_RUNTIME` when building the unityaot profile?