### PR TITLE
2018.2 Backports

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -299,16 +299,16 @@ gc_alloc_fixed_non_heap_list (size_t size)
 	if (mono_gc_is_moving ())
 		return g_malloc0 (size);
 	else
-		return mono_gc_alloc_fixed (appdomain_list_size * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain List");
+		return mono_gc_alloc_fixed (size, MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain List");
 }
 
 static void
 gc_free_fixed_non_heap_list (void *ptr)
 {
 	if (mono_gc_is_moving ())
-		return g_free (ptr);
+		g_free (ptr);
 	else
-		return mono_gc_free_fixed (ptr);
+		mono_gc_free_fixed (ptr);
 }
 /*
  * Allocate an id for domain and set domain->domain_id.


### PR DESCRIPTION
case 1062676: Fix crash on exit when domains are created
case 1062514: Fix random crash during GC thread suspend on OSX