### PR TITLE
Fix double gchandle free in thread detach logic (1062208)

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3054,8 +3054,6 @@ thread_detach (MonoThreadInfo *info)
 	internal = (MonoInternalThread*) mono_gchandle_get_target (gchandle);
 	g_assert (internal);
 
-	mono_gchandle_free (gchandle);
-
 	mono_thread_detach_internal (internal);
 }
 


### PR DESCRIPTION
thread_detach calls mono_gchandle_free and then calls mono_thread_detach_internal, which also calls mono_gchandle_free. This has caused instabilities on android