### PR TITLE
Add option for strict write barriers

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -198,6 +198,7 @@ create_domain_objects (MonoDomain *domain)
 	mono_error_assert_ok (&error);
 	mono_field_static_set_value (string_vt, string_empty_fld, empty_str);
 	domain->empty_string = empty_str;
+	mono_gc_wbarrier_generic_nostore (&domain->empty_string);
 
 	/*
 	 * Create an instance early since we can't do it when there is no memory.
@@ -205,6 +206,7 @@ create_domain_objects (MonoDomain *domain)
 	arg = mono_string_new_checked (domain, "Out of memory", &error);
 	mono_error_assert_ok (&error);
 	domain->out_of_memory_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "OutOfMemoryException", arg, NULL, &error);
+    mono_gc_wbarrier_generic_nostore (&domain->out_of_memory_ex);	
 	mono_error_assert_ok (&error);
 
 	/* 
@@ -214,14 +216,17 @@ create_domain_objects (MonoDomain *domain)
 	arg = mono_string_new_checked (domain, "A null value was found where an object instance was required", &error);
 	mono_error_assert_ok (&error);
 	domain->null_reference_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "NullReferenceException", arg, NULL, &error);
+    mono_gc_wbarrier_generic_nostore (&domain->null_reference_ex);    
 	mono_error_assert_ok (&error);
 	arg = mono_string_new_checked (domain, "The requested operation caused a stack overflow.", &error);
 	mono_error_assert_ok (&error);
 	domain->stack_overflow_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "StackOverflowException", arg, NULL, &error);
+    mono_gc_wbarrier_generic_nostore (&domain->stack_overflow_ex);    
 	mono_error_assert_ok (&error);
 
 	/*The ephemeron tombstone i*/
 	domain->ephemeron_tombstone = mono_object_new_checked (domain, mono_defaults.object_class, &error);
+    mono_gc_wbarrier_generic_nostore (&domain->ephemeron_tombstone);    
 	mono_error_assert_ok (&error);
 
 	if (domain != old_domain) {
@@ -292,7 +297,9 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 
 	ad->data = domain;
 	domain->domain = ad;
+    mono_gc_wbarrier_generic_nostore (&domain->domain);	
 	domain->setup = setup;
+    mono_gc_wbarrier_generic_nostore (&domain->setup);	
 
 	mono_thread_attach (domain);
 

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -59,6 +59,7 @@ void *pthread_get_stackaddr_np(pthread_t);
 #define MIN_BOEHM_MAX_HEAP_SIZE (MIN_BOEHM_MAX_HEAP_SIZE_IN_MB << 20)
 
 static gboolean gc_initialized = FALSE;
+static gboolean gc_strict_wbarriers = FALSE;
 static mono_mutex_t mono_gc_lock;
 
 typedef void (*GC_push_other_roots_proc)(void);
@@ -247,7 +248,10 @@ mono_gc_base_init (void)
 			#endif					
 				}
 				continue;
-			} else {
+			} else if (g_str_has_prefix (opt, "strict-wbarriers")) {
+				gc_strict_wbarriers = TRUE;
+				continue;
+			}else {
 				/* Could be a parameter for sgen */
 				/*
 				fprintf (stderr, "MONO_GC_PARAMS must be a comma-delimited list of one or more of the following:\n");
@@ -271,6 +275,24 @@ mono_gc_base_init (void)
 	GC_on_heap_resize = on_gc_heap_resize;
 
 	gc_initialized = TRUE;
+}
+
+void 
+mono_gc_dirty(void **ptr)
+{
+	GC_dirty (ptr);
+}
+
+void 
+mono_gc_dirty_range(void **ptr, size_t size)
+{
+	if (G_UNLIKELY(gc_strict_wbarriers))
+	{
+		for (int i = 0; i < size/sizeof(void*); i++)
+			GC_dirty(ptr + i);
+	}
+	else
+		GC_dirty (ptr);
 }
 
 void
@@ -647,7 +669,7 @@ mono_gc_weak_link_add (void **link_addr, MonoObject *obj, gboolean track)
 {
 	/* libgc requires that we use HIDE_POINTER... */
 	*link_addr = (void*)HIDE_POINTER (obj);
-	GC_dirty (link_addr);
+	mono_gc_dirty (link_addr);
 	if (track)
 		GC_REGISTER_LONG_LINK (link_addr, obj);
 	else
@@ -892,57 +914,60 @@ void
 mono_gc_wbarrier_set_field (MonoObject *obj, gpointer field_ptr, MonoObject* value)
 {
 	*(void**)field_ptr = value;
-	GC_dirty (field_ptr);
+	mono_gc_dirty (field_ptr);
 }
 
 void
 mono_gc_wbarrier_set_arrayref (MonoArray *arr, gpointer slot_ptr, MonoObject* value)
 {
 	*(void**)slot_ptr = value;
-	GC_dirty (slot_ptr);
+	mono_gc_dirty (slot_ptr);
 }
 
 void
 mono_gc_wbarrier_arrayref_copy (gpointer dest_ptr, gpointer src_ptr, int count)
 {
 	mono_gc_memmove_aligned (dest_ptr, src_ptr, count * sizeof (gpointer));
-	GC_dirty (dest_ptr);
+	mono_gc_dirty_range (dest_ptr, count * sizeof(gpointer));
 }
 
 void
 mono_gc_wbarrier_generic_store (gpointer ptr, MonoObject* value)
 {
 	*(void**)ptr = value;
-	GC_dirty (ptr);
+	mono_gc_dirty (ptr);
 }
 
 void
 mono_gc_wbarrier_generic_store_atomic (gpointer ptr, MonoObject *value)
 {
 	mono_atomic_store_ptr ((volatile gpointer *)ptr, value);
-	GC_dirty (ptr);
+	mono_gc_dirty (ptr);
 }
 
 void
 mono_gc_wbarrier_generic_nostore (gpointer ptr)
 {
-	GC_dirty (ptr);
+	mono_gc_dirty (ptr);
 }
 
 void
 mono_gc_wbarrier_value_copy (gpointer dest, gpointer src, int count, MonoClass *klass)
 {
-	mono_gc_memmove_atomic (dest, src, count * mono_class_value_size (klass, NULL));
-	GC_dirty (dest);
+	size_t size = count * mono_class_value_size (klass, NULL);
+	mono_gc_memmove_atomic (dest, src, size);
+	mono_gc_dirty_range (dest, size);
 }
 
 void
 mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
 {
 	/* do not copy the sync state */
-	mono_gc_memmove_aligned ((char*)obj + sizeof (MonoObject), (char*)src + sizeof (MonoObject),
-			mono_object_class (obj)->instance_size - sizeof (MonoObject));
-	GC_dirty (obj);
+	size_t size = mono_object_class (obj)->instance_size - sizeof (MonoObject);
+	char * dstPtr = (char*)obj + sizeof (MonoObject);
+	mono_gc_memmove_aligned (dstPtr, (char*)src + sizeof (MonoObject),
+			size);
+	mono_gc_dirty_range ((void**)dstPtr, size);
 }
 
 void
@@ -1514,7 +1539,7 @@ void
 mono_gc_wbarrier_range_copy (gpointer _dest, gpointer _src, int size)
 {
 	memcpy (_dest, _src, size);
-	GC_dirty (_dest);
+	mono_gc_dirty_range (_dest, size);
 }
 
 void*
@@ -1875,7 +1900,7 @@ handle_data_grow (HandleData *handles, gboolean track)
 		gpointer *entries;
 		entries = (void **)mono_gc_alloc_fixed (sizeof (*handles->entries) * new_size, NULL, MONO_ROOT_SOURCE_GC_HANDLE, NULL, "GC Handle Table (Boehm)");
 		mono_gc_memmove_aligned (entries, handles->entries, sizeof (*handles->entries) * handles->size);
-		GC_dirty (entries);
+		mono_gc_dirty_range (entries, new_size * sizeof (*handles->entries));
 		mono_gc_free_fixed (handles->entries);
 		handles->entries = entries;
 	}
@@ -1908,7 +1933,7 @@ alloc_handle (HandleData *handles, MonoObject *obj, gboolean track)
 			mono_gc_weak_link_add (&(handles->entries [slot]), obj, track);
 	} else {
 		handles->entries [slot] = obj;
-		GC_dirty (handles->entries + slot);
+		mono_gc_dirty (handles->entries + slot);
 	}
 
 #ifndef DISABLE_PERFCOUNTERS
@@ -2026,7 +2051,7 @@ mono_gchandle_set_target (guint32 gchandle, MonoObject *obj)
 			handles->domain_ids [slot] = (obj ? mono_object_get_domain (obj) : mono_domain_get ())->domain_id;
 		} else {
 			handles->entries [slot] = obj;
-			GC_dirty (handles->entries + slot);
+			mono_gc_dirty (handles->entries + slot);
 		}
 	} else {
 		/* print a warning? */
@@ -2105,7 +2130,7 @@ mono_gchandle_free (guint32 gchandle)
 				mono_gc_weak_link_remove (&handles->entries [slot], handles->type == HANDLE_WEAK_TRACK);
 		} else {
 			handles->entries [slot] = NULL;
-			GC_dirty (handles->entries + slot);
+			mono_gc_dirty (handles->entries + slot);
 		}
 		vacate_slot (handles, slot);
 	} else {
@@ -2148,7 +2173,7 @@ mono_gchandle_free_domain (MonoDomain *domain)
 				if (handles->entries [slot] && mono_object_domain (handles->entries [slot]) == domain) {
 					vacate_slot (handles, slot);
 					handles->entries [slot] = NULL;
-					GC_dirty (handles->entries + slot);
+					mono_gc_dirty (handles->entries + slot);
 				}
 			}
 		}

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -923,6 +923,7 @@ mono_domain_set_internal_with_options (MonoDomain *domain, gboolean migrate_exce
 
 	SET_APPDOMAIN (domain);
 	SET_APPCONTEXT (domain->default_context);
+    mono_gc_wbarrier_generic_nostore (&domain->default_context);	
 
 	if (migrate_exception) {
 		thread = mono_thread_internal_current ();

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2479,6 +2479,7 @@ ves_icall_RuntimeType_GetInterfaces (MonoReflectionTypeHandle ref_type, MonoErro
 		g_hash_table_destroy (iface_hash);
 		if (!domain->empty_types) {
 			domain->empty_types = mono_array_new_cached (domain, mono_defaults.runtimetype_class, 0, error);
+            mono_gc_wbarrier_generic_nostore (&domain->empty_types);			
 			goto_if_nok (error, fail);
 		}
 		return MONO_HANDLE_NEW (MonoArray, domain->empty_types);

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -534,7 +534,10 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	mono_g_hash_table_insert (domain->type_hash, type, res);
 
 	if (type->type == MONO_TYPE_VOID)
+	{
 		domain->typeof_void = (MonoObject*)res;
+		mono_gc_wbarrier_generic_nostore (&domain->typeof_void);
+	}
 
 	mono_domain_unlock (domain);
 	mono_loader_unlock ();


### PR DESCRIPTION
https://github.com/Unity-Technologies/mono/pull/958 added support for incremental Boehm GC by adding write barriers to mono. 

Incremental Boehm requires only one write barrier call on any pointer within an object even if multiple references in the object have changed, as the object is then considered as dirty, and rescanned. 

However, our technique for validating correct use of write barriers (by verifying that all found references have been set through a write barrier call) is not that tolerant (And potentially, neither are future Boehm replacements). So, to get a good test coverage for write barrier use to work, we need an option to set write barriers on *all* reference writes. Mono has some functions which touch whole blocks of managed memory (which may contain references). This PR adds a "strict write barrier" mode, which will set write barriers for each potential reference in those functions. 

This needs to land in order to get test coverage on write barrier use in Unity to run.