### PR TITLE
cleanup the threadinfo before shutdown

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -853,6 +853,8 @@ mono_cleanup (void)
 {
 	mono_close_exe_image ();
 
+	mono_thread_info_cleanup ();
+
 	mono_defaults.corlib = NULL;
 
 	mono_config_cleanup ();

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -739,6 +739,13 @@ thread_info_key_dtor (void *arg)
 #endif
 
 void
+mono_thread_info_cleanup ()
+{
+	mono_native_tls_free (thread_info_key);
+	mono_native_tls_free (thread_exited_key);
+}
+
+void
 mono_thread_info_init (size_t info_size)
 {
 	gboolean res;

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -310,6 +310,9 @@ mono_thread_info_set_tid (THREAD_INFO_TYPE *info, MonoNativeThreadId tid)
 	((MonoThreadInfo*) info)->node.key = (uintptr_t) MONO_NATIVE_THREAD_ID_TO_UINT (tid);
 }
 
+void
+mono_thread_info_cleanup (void);
+
 /*
  * @thread_info_size is sizeof (GcThreadInfo), a struct the GC defines to make it possible to have
  * a single block with info from both camps. 


### PR DESCRIPTION
Fixes crash in pthread_key_clean_all

(Scripting Upgrade) Fixes an issue where using Application.Unload may cause a crash when using mono 4.x on android (case 1060891)
