### PR TITLE
[Backport 2018.2] Fix issue where get offset could return 0 when the type is uninited

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -9685,6 +9685,7 @@ mono_field_get_flags (MonoClassField *field)
 guint32
 mono_field_get_offset (MonoClassField *field)
 {
+	mono_class_setup_fields(field->parent);
 	return field->offset;
 }
 


### PR DESCRIPTION
(Scripting Upgrade) Fix an issue where UnsafeUtility.GetFieldOffset could return 0 when the type is not initialized (case 1059122)