### PR TITLE
Incremental boehm strict mode

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -712,7 +712,7 @@ mono_gc_finalize_notify (void)
 	g_message ( "%s: prodding finalizer", __func__);
 #endif
 
-	if (mono_gc_is_null ())
+	if (mono_gc_is_null () || mono_gc_is_disabled())
 		return;
 
 #ifdef HOST_WASM

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1402,6 +1402,7 @@ ves_icall_System_Threading_Thread_ConstructInternalThread (MonoThread *this_obj)
 	internal->state = ThreadState_Unstarted;
 
 	mono_atomic_cas_ptr ((volatile gpointer *)&this_obj->internal_thread, internal, NULL);
+	mono_gc_wbarrier_generic_nostore (&this_obj->internal_thread);
 }
 
 MonoThread *


### PR DESCRIPTION
1. Add another write barrier needed for validation to pass
2. Add a fix for running with gc disabled, which would deadlock in mono_gc_finalize_notify. This was already disabled for running with null gc, but not with running with a gc which is disabled (needed for write barrier validation).