### PR TITLE
Make gc params work for Boehm

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -117,6 +117,8 @@ void
 mono_gc_base_init (void)
 {
 	char *env;
+	char *params_opts = NULL;
+	char *debug_opts = NULL;
 
 	if (gc_initialized)
 		return;
@@ -189,19 +191,21 @@ mono_gc_base_init (void)
 	/* If GC_no_dls is set to true, GC_find_limit is not called. This causes a seg fault on Android With Mono's Older Boehm. */
 	GC_no_dls = TRUE;
 #endif
+
+	debug_opts = mono_gc_debug_get();
+	if (debug_opts)
 	{
-		if ((env = g_getenv ("MONO_GC_DEBUG"))) {
-			char **opts = g_strsplit (env, ",", -1);
-			for (char **ptr = opts; ptr && *ptr; ptr ++) {
-				char *opt = *ptr;
-				if (!strcmp (opt, "do-not-finalize")) {
-					mono_do_not_finalize = 1;
-				} else if (!strcmp (opt, "log-finalizers")) {
-					log_finalizers = 1;
-				}
+		char **opts = g_strsplit (debug_opts, ",", -1);
+		for (char **ptr = opts; ptr && *ptr; ptr ++) {
+			char *opt = *ptr;
+			if (!strcmp (opt, "do-not-finalize")) {
+				mono_do_not_finalize = 1;
+			} else if (!strcmp (opt, "log-finalizers")) {
+				log_finalizers = 1;
 			}
-			g_free (env);
 		}
+		g_strfreev (opts);
+		g_free (debug_opts);
 	}
 
 	GC_init ();
@@ -213,10 +217,12 @@ mono_gc_base_init (void)
 	GC_init_gcj_malloc (5, NULL);
 	GC_allow_register_threads ();
 
-	if ((env = g_getenv ("MONO_GC_PARAMS"))) {
-		char **ptr, **opts = g_strsplit (env, ",", -1);
+	params_opts = mono_gc_params_get();
+	if (params_opts) {
+		char **ptr, **opts = g_strsplit (params_opts, ",", -1);
 		for (ptr = opts; *ptr; ++ptr) {
 			char *opt = *ptr;
+
 			if (g_str_has_prefix (opt, "max-heap-size=")) {
 				size_t max_heap;
 
@@ -260,8 +266,8 @@ mono_gc_base_init (void)
 				*/
 			}
 		}
-		g_free (env);
 		g_strfreev (opts);
+		g_free (params_opts);
 	}
 
 	mono_thread_callbacks_init ();
@@ -763,6 +769,10 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj;
 
+	if (strcmp(vtable->klass->name, "RuntimeTestInfo") == 0)
+	{
+		printf("hello");
+	}
 	if (!vtable->klass->has_references) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);
 		if (G_UNLIKELY (!obj))
@@ -1577,16 +1587,6 @@ FILE *
 mono_gc_get_logfile (void)
 {
 	return NULL;
-}
-
-void
-mono_gc_params_set (const char* options)
-{
-}
-
-void
-mono_gc_debug_set (const char* options)
-{
 }
 
 void

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -87,6 +87,12 @@ static MonoCoopCond pending_done_cond;
 static MonoCoopMutex pending_done_mutex;
 #endif
 
+static char* gc_params_options;
+static char* gc_debug_options;
+
+#define MONO_GC_PARAMS_NAME	"MONO_GC_PARAMS"
+#define MONO_GC_DEBUG_NAME	"MONO_GC_DEBUG"
+
 static void object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*));
 
 static void reference_queue_proccess_all (void);
@@ -159,6 +165,48 @@ coop_cond_timedwait_alertable (MonoCoopCond *cond, MonoCoopMutex *mutex, guint32
 		}
 	}
 	return res;
+}
+
+void
+mono_gc_params_set (const char* options)
+{
+	if (gc_params_options)
+		g_free (gc_params_options);
+
+	gc_params_options = g_strdup (options);
+}
+
+char *
+mono_gc_params_get ()
+{
+	char *env;
+	if ((env = g_getenv (MONO_GC_PARAMS_NAME)) || gc_params_options) {
+		char *params_opts = g_strdup_printf ("%s,%s", gc_params_options ? gc_params_options  : "", env ? env : "");
+		g_free (env);
+		return params_opts;
+	}
+	return NULL;	
+}
+
+void
+mono_gc_debug_set (const char* options)
+{
+	if (gc_debug_options)
+		g_free (gc_debug_options);
+
+	gc_debug_options = g_strdup (options);
+}
+
+char *
+mono_gc_debug_get ()
+{
+	char *env;
+	if ((env = g_getenv (MONO_GC_DEBUG_NAME)) || gc_debug_options) {
+		char *debug_opts = g_strdup_printf ("%s,%s", gc_debug_options ? gc_debug_options  : "", env ? env : "");
+		g_free (env);
+		return debug_opts;
+	}
+	return NULL;
 }
 
 /* 

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -459,16 +459,6 @@ mono_gc_get_logfile (void)
 }
 
 void
-mono_gc_params_set (const char* options)
-{
-}
-
-void
-mono_gc_debug_set (const char* options)
-{
-}
-
-void
 mono_gc_conservatively_scan_area (void *start, void *end)
 {
 	g_assert_not_reached ();

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -117,7 +117,9 @@ FILE *mono_gc_get_logfile (void);
 
 /* equivalent to options set via MONO_GC_PARAMS */
 void mono_gc_params_set (const char* options);
+char* mono_gc_params_get();
 /* equivalent to options set via MONO_GC_DEBUG */
 void mono_gc_debug_set (const char* options);
+char *mono_gc_debug_get();
 
 #endif

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -302,8 +302,6 @@ static SGEN_TV_DECLARE (time_major_conc_collection_end);
 
 int gc_debug_level = 0;
 FILE* gc_debug_file;
-static char* gc_params_options;
-static char* gc_debug_options;
 
 /*
 void
@@ -1020,24 +1018,6 @@ FILE *
 mono_gc_get_logfile (void)
 {
 	return gc_debug_file;
-}
-
-void
-mono_gc_params_set (const char* options)
-{
-	if (gc_params_options)
-		g_free (gc_params_options);
-
-	gc_params_options = g_strdup (options);
-}
-
-void
-mono_gc_debug_set (const char* options)
-{
-	if (gc_debug_options)
-		g_free (gc_debug_options);
-
-	gc_debug_options = g_strdup (options);
 }
 
 static void
@@ -3326,11 +3306,7 @@ sgen_gc_init (void)
 
 	mono_coop_mutex_init (&sgen_interruption_mutex);
 
-	if ((env = g_getenv (MONO_GC_PARAMS_NAME)) || gc_params_options) {
-		params_opts = g_strdup_printf ("%s,%s", gc_params_options ? gc_params_options : "", env ? env : "");
-		g_free (env);
-	}
-
+	params_opts = mono_gc_params_get();
 	if (params_opts) {
 		opts = g_strsplit (params_opts, ",", -1);
 		for (ptr = opts; *ptr; ++ptr) {
@@ -3541,11 +3517,7 @@ sgen_gc_init (void)
 	sgen_pinning_init ();
 	sgen_cement_init (cement_enabled);
 
-	if ((env = g_getenv (MONO_GC_DEBUG_NAME)) || gc_debug_options) {
-		debug_opts = g_strdup_printf ("%s,%s", gc_debug_options ? gc_debug_options  : "", env ? env : "");
-		g_free (env);
-	}
-
+	debug_opts = mono_gc_debug_get();
 	if (debug_opts) {
 		gboolean usage_printed = FALSE;
 


### PR DESCRIPTION
In order to control Boehm gc behavior to turn on incremental mode, and to turn on "strict write barrier mode" for write barrier validation, we use the GC parameters in mono. These can be either supplied through an environment variable, or by mono command line (which we pass to mono on initialization in the embedded case). We would rather use the command line, as that is easier to control by unity, but that was only supported in sgen. This PR unifies the parameter querying code between sgen and boehm to use the same code path, and to support getting parameters from the command line.