### PR TITLE
Properly inflate pointer types in inflate_generic_type. 

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -817,6 +817,14 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		nt->data.generic_class = gclass;
 		return nt;
 	}
+	case MONO_TYPE_PTR: {
+		MonoType *nt, *inflated = inflate_generic_type (image, type->data.type, context, error);
+		if (!inflated || !mono_error_ok (error))
+			return NULL;
+		nt = mono_metadata_type_dup (image, type);
+		nt->data.type = inflated;
+		return nt;
+	}
 	default:
 		return NULL;
 	}

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -76,7 +76,7 @@ MCS_NO_UNSAFE = $(TOOLS_RUNTIME) $(CSC) -debug:portable \
 	-noconfig -nologo \
 	-nowarn:0162 -nowarn:0168 -nowarn:0219 -nowarn:0414 -nowarn:0618 \
 	-nowarn:0169 -nowarn:1690 -nowarn:0649 -nowarn:0612 -nowarn:3021 \
-	-nowarn:0197 $(PROFILE_MCS_FLAGS)
+	-nowarn:0197 -langversion:7.3 $(PROFILE_MCS_FLAGS)
 MCS_NO_LIB = $(MCS_NO_UNSAFE) -unsafe
 
 MCS = $(MCS_NO_LIB)
@@ -530,7 +530,8 @@ TESTS_CS_SRC=		\
 	bug-59281.cs	\
 	init_array_with_lazy_type.cs \
 	weak-fields.cs \
-	threads-leak.cs
+	threads-leak.cs \
+	generic-unmanaged-constraint.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/generic-unmanaged-constraint.cs
+++ b/mono/tests/generic-unmanaged-constraint.cs
@@ -1,0 +1,17 @@
+using System;
+  
+unsafe class Program
+{
+        public static int Main(string[] args)
+        {
+                return (int)(IntPtr)Generic<int>.GetPtr();
+        }
+}
+
+unsafe class Generic<T> where T : unmanaged
+{
+        public static T* GetPtr()
+        {
+                return (T*)null;
+        }
+}


### PR DESCRIPTION
Generic pointer types are encountered with 'unmanaged' constraint (case 1069236)

Backport of upstream https://github.com/mono/mono/pull/10145