### PR TITLE
Don't try to access metadata for dynamic method added to non-dynamic …

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2159,6 +2159,10 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 		return;
 	}
 
+	/* dynamic method added to non-dynamic image */
+	if (method->dynamic)
+		return;
+
 	mono_class_init (klass);
 
 	methodt = &klass->image->tables [MONO_TABLE_METHOD];


### PR DESCRIPTION
…image. Fixes issue #10201.

case 1065895 - Fix crash when DynamicMethod is constructed into non-dynamic image

Backport of upstream https://github.com/mono/mono/pull/10202


