### PR TITLE
 UnityTls server no longer throws an exception if there is no client cert during client authentication

### DIFF
--- a/mcs/class/System/Mono.UnityTls/UnityTlsContext.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsContext.cs
@@ -304,18 +304,17 @@ namespace Mono.Unity
 			if (lastException != null)
 				throw lastException;
 
-			// Not done is not an error if we are server and don't ask for ClientCertificate
-			if (result == UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE && IsServer && !AskForClientCertificate)
+			// Not done is only an error if we are a client. Even servers with AskForClientCertificate should ignore it since .Net client authentification is always optional.
+			if (IsServer && result == UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE) {
 				Unity.Debug.CheckAndThrow (errorState, "Handshake failed", AlertDescription.HandshakeFailure);
-			else
-				Unity.Debug.CheckAndThrow (errorState, result, "Handshake failed", AlertDescription.HandshakeFailure);
-
-			// .Net implementation gives the server a verification callback (with null cert) even if AskForClientCertificate is false.
-			// We stick to this behavior here.
-			if (IsServer && !AskForClientCertificate) {
+				
+				// .Net implementation gives the server a verification callback (with null cert) even if AskForClientCertificate is false.
+				// We stick to this behavior here.
 				if (!ValidateCertificate (null, null))
 					throw new TlsException (AlertDescription.HandshakeFailure, "Verification failure during handshake");
 			}
+			else
+				Unity.Debug.CheckAndThrow (errorState, result, "Handshake failed", AlertDescription.HandshakeFailure);
 
 			return true;
 		}


### PR DESCRIPTION
This is a fix for a border case I had lying around for a while, not something a user ever hit.
What I got wrong earlier here is a tricky nuance in the way .Net behaves with client authentication: Even if a server requires authentication, not being provided a certificate is not automatically an error!

Landing this change to unity-trunk the test fix prepared in `platform/foundation/tls/fix-test-clientauth-no-error-on-missing-cert`
Please merge this along side the next mono update.