### PR TITLE
Increasing sync for i2cpp debugger stack frames (case 1064723)

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1147,7 +1147,8 @@ mono_debugger_run_debugger_thread_func(void* arg)
 }
 
 typedef struct {
-	void(*il2cpp_debugger_save_thread_context)(Il2CppThreadUnwindState* context);
+	void(*il2cpp_debugger_save_thread_context)(Il2CppThreadUnwindState* context, int frameCountAdjust);
+    void(*il2cpp_debugger_free_thread_context)(Il2CppThreadUnwindState* context);
 } MonoDebuggerRuntimeCallbacks;
 
 static MonoDebuggerRuntimeCallbacks callbacks;
@@ -2677,7 +2678,7 @@ save_thread_context (MonoContext *ctx)
 	else
 		mono_thread_state_init_from_current (&tls->context);
 #else
-	callbacks.il2cpp_debugger_save_thread_context(&tls->il2cpp_context);
+	callbacks.il2cpp_debugger_save_thread_context(&tls->il2cpp_context, 0);
 #endif // !RUNTIME_IL2CPP
 }
 
@@ -4210,6 +4211,8 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 			/* Can't remove from tid_to_thread, as that would defeat the check in thread_start () */
 #ifndef RUNTIME_IL2CPP
 			MONO_GC_UNREGISTER_ROOT (tls->thread);
+#else
+            callbacks.il2cpp_debugger_free_thread_context(&tls->il2cpp_context);
 #endif
 			tls->thread = NULL;
 		}
@@ -12358,6 +12361,19 @@ gboolean unity_sequence_point_active(Il2CppSequencePoint *seqPoint)
 	}
 
 	return FALSE;
+}
+
+void il2cpp_save_current_thread_context_func_exit()
+{
+    DebuggerTlsData *tls;
+
+    MonoInternalThread *thread = mono_thread_internal_current();
+
+    mono_loader_lock();
+    tls = (DebuggerTlsData *)mono_g_hash_table_lookup(thread_to_tls, thread);
+    mono_loader_unlock();
+
+    callbacks.il2cpp_debugger_save_thread_context(&tls->il2cpp_context, -1);
 }
 
 #endif // RUNTIME_IL2CPP


### PR DESCRIPTION
The thread local storage of sequence points and method execution
contexts between IL2CPP and the mono debugger code was only being
synchronized at certain times, mainly when breakpoints were processed.
This could lead to a loss of synchronization after functions are exited
and debugger frame commands accessing invalid stack data.  This change
adds synchronization for these data structures right before any
managed method exit, when the method execution context for that method
is destroyed.  Also optimizing memory allocations by only allocating
when the stack grows and just reusing the memory otherwise.