### PR TITLE
 Build Mono for Android with NDK r16b

### DIFF
--- a/external/buildscripts/build_runtime_android.pl
+++ b/external/buildscripts/build_runtime_android.pl
@@ -21,8 +21,6 @@ GetOptions(
 # By default, build runtime for all the variants we need.  But allow something to specify an individual variation to build
 if ($androidArch eq "")
 {
-	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=armv5", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for armv5\n");
-	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=armv6_vfp", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for armv6_vfp\n");
 	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=armv7a", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for armv7a\n");
 	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=x86", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for x86\n");
 }

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -178,7 +178,7 @@ typedef int32_t __mono_off32_t;
  * we must carefully declare the 32-bit mmap here without changing the ABI along the way. Carefully because
  * in this instance off_t is redeclared to be 64-bit and that's not what we want.
  */
-void* mmap (void*, size_t, int, int, int, __mono_off32_t);
+//void* mmap (void*, size_t, int, int, int, __mono_off32_t);
 #endif /* !mmap */
 
 #ifdef HAVE_SYS_SENDFILE_H

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -171,14 +171,14 @@ typedef int32_t __mono_off32_t;
 #include <sys/mman.h>
 #endif
 
-#if !defined(mmap)
+#if !defined(mmap) && !defined(__clang__)
 /* Unified headers before API 21 do not declare mmap when LARGE_FILES are used (via -D_FILE_OFFSET_BITS=64)
  * which is always the case when Mono build targets Android. The problem here is that the unified headers
  * map `mmap` to `mmap64` if large files are enabled but this api exists only in API21 onwards. Therefore
  * we must carefully declare the 32-bit mmap here without changing the ABI along the way. Carefully because
  * in this instance off_t is redeclared to be 64-bit and that's not what we want.
  */
-//void* mmap (void*, size_t, int, int, int, __mono_off32_t);
+void* mmap (void*, size_t, int, int, int, __mono_off32_t);
 #endif /* !mmap */
 
 #ifdef HAVE_SYS_SENDFILE_H


### PR DESCRIPTION
Change the compiler used to build Mono for Android from gcc to clang,
and update the NDK to version r16b.

Also, don't define mmap for the clang toolchain.
The `mmap` definition problem only occurs with the GCC toolchain. With the
clang toolchain we should not redefine `mmap`, and instead use the
definition from the NDK headers.

I'll plan to merge this PR after Unity branches for 2018.3. This PR depends on the changes from: https://github.com/Unity-Technologies/krait-signal-handler/pull/7