### PR TITLE
Revert "Get underlying method in case wrapper method is exposed to us…

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1878,10 +1878,6 @@ ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info (MonoMethod *metho
 	MonoClass *klass = NULL;
 	if (!MONO_HANDLE_IS_NULL (reftype))
 		klass = mono_class_from_mono_type (MONO_HANDLE_GETVAL (reftype, type));
-
-	/* UNITY: handle wrapper methods leaking into call stacks. case 1073634 */
-	method = mono_marshal_method_from_wrapper (method);
-
 	return mono_param_get_objects_internal (domain, method, klass, error);
 }
 


### PR DESCRIPTION
…er code (case 1073634)"

This reverts commit 32ff312d2bcd3e6f6a3f01ecee46184d5b94c2a1.

This sometimes returns NULL and causes a crash.