### PR TITLE
Expose incremental gc time slice 

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -422,19 +422,29 @@ mono_gc_get_heap_size (void)
 int64_t
 mono_gc_get_max_time_slice_ns()
 {
+#if HAVE_BDWGC_GC
     return GC_get_time_limit() * 1000000;
+#else
+	return 0;
+#endif		
 }
 
 void
 mono_gc_set_max_time_slice_ns(int64_t maxTimeSlice)
 {
+#if HAVE_BDWGC_GC
 	GC_set_time_limit(maxTimeSlice / 1000000);
+#endif	
 }
 
 MonoBoolean 
 mono_gc_is_incremental()
 {
+#if HAVE_BDWGC_GC
     return GC_is_incremental_mode();
+#else
+	return FALSE;
+#endif		
 }
 
 gboolean

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -420,15 +420,21 @@ mono_gc_get_heap_size (void)
 }
 
 int64_t
-mono_get_max_time_slice_ns()
+mono_gc_get_max_time_slice_ns()
 {
     return GC_get_time_limit() * 1000000;
 }
 
 void
-mono_set_max_time_slice_ns(int64_t maxTimeSlice)
+mono_gc_set_max_time_slice_ns(int64_t maxTimeSlice)
 {
 	GC_set_time_limit(maxTimeSlice / 1000000);
+}
+
+MonoBoolean 
+mono_gc_is_incremental()
+{
+    return GC_is_incremental_mode();
 }
 
 gboolean

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -419,6 +419,18 @@ mono_gc_get_heap_size (void)
 	return GC_get_heap_size ();
 }
 
+int64_t
+mono_get_max_time_slice_ns()
+{
+    return GC_get_time_limit() * 1000000;
+}
+
+void
+mono_set_max_time_slice_ns(int64_t maxTimeSlice)
+{
+	GC_set_time_limit(maxTimeSlice / 1000000);
+}
+
 gboolean
 mono_gc_is_gc_thread (void)
 {

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -109,6 +109,8 @@ MONO_API int    mono_gc_get_generation  (MonoObject *object);
 MONO_API int    mono_gc_collection_count (int generation);
 MONO_API int64_t mono_gc_get_used_size   (void);
 MONO_API int64_t mono_gc_get_heap_size   (void);
+MONO_API int64_t mono_get_max_time_slice_ns ();
+MONO_API void   mono_set_max_time_slice_ns (int64_t maxTimeSlice);
 MONO_API MonoBoolean mono_gc_pending_finalizers (void);
 MONO_API void     mono_gc_finalize_notify    (void);
 MONO_API int    mono_gc_invoke_finalizers (void);

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -109,9 +109,10 @@ MONO_API int    mono_gc_get_generation  (MonoObject *object);
 MONO_API int    mono_gc_collection_count (int generation);
 MONO_API int64_t mono_gc_get_used_size   (void);
 MONO_API int64_t mono_gc_get_heap_size   (void);
-MONO_API int64_t mono_get_max_time_slice_ns ();
-MONO_API void   mono_set_max_time_slice_ns (int64_t maxTimeSlice);
+MONO_API int64_t mono_gc_get_max_time_slice_ns ();
+MONO_API void   mono_gc_set_max_time_slice_ns (int64_t maxTimeSlice);
 MONO_API MonoBoolean mono_gc_pending_finalizers (void);
+MONO_API MonoBoolean mono_gc_is_incremental (void);
 MONO_API void     mono_gc_finalize_notify    (void);
 MONO_API int    mono_gc_invoke_finalizers (void);
 /* heap walking is only valid in the pre-stop-world event callback */

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -91,6 +91,17 @@ mono_gc_get_heap_size (void)
 	return 2*1024*1024;
 }
 
+int64_t
+mono_get_max_time_slice_ns()
+{
+	return 0;
+}
+
+void
+mono_set_max_time_slice_ns(int64_t maxTimeSlice)
+{
+}
+
 gboolean
 mono_gc_is_gc_thread (void)
 {

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -92,14 +92,20 @@ mono_gc_get_heap_size (void)
 }
 
 int64_t
-mono_get_max_time_slice_ns()
+mono_gc_get_max_time_slice_ns()
 {
 	return 0;
 }
 
 void
-mono_set_max_time_slice_ns(int64_t maxTimeSlice)
+mono_gc_set_max_time_slice_ns(int64_t maxTimeSlice)
 {
+}
+
+MonoBoolean 
+mono_gc_is_incremental()
+{
+    return FALSE;
 }
 
 gboolean

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2831,6 +2831,17 @@ mono_gc_get_heap_size (void)
 	return (int64_t)sgen_gc_get_total_heap_allocation ();
 }
 
+int64_t
+mono_get_max_time_slice_ns()
+{
+	return 0;
+}
+
+void
+mono_set_max_time_slice_ns(int64_t maxTimeSlice)
+{
+}
+
 MonoGCDescriptor
 mono_gc_make_root_descr_user (MonoGCRootMarkFunc marker)
 {

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2832,13 +2832,19 @@ mono_gc_get_heap_size (void)
 }
 
 int64_t
-mono_get_max_time_slice_ns()
+mono_gc_get_max_time_slice_ns()
 {
 	return 0;
 }
 
+MonoBoolean 
+mono_gc_is_incremental()
+{
+    return FALSE;
+}
+
 void
-mono_set_max_time_slice_ns(int64_t maxTimeSlice)
+mono_gc_set_max_time_slice_ns(int64_t maxTimeSlice)
 {
 }
 


### PR DESCRIPTION
This PR adds three new il2cpp APIs to control incremental GC.

`mono_gc_get_max_time_slice_ns` and `mono_gc_set_max_time_slice_ns`, to get and set the time slice length to use when incremental GC is enabled, and `mono_gc_is_incremental` to check if incremental GC is enabled.

I want to expose these to allow control over time slices. We can use this to expose user control, or to inject variable length GC slices in times where we know we need to wait a certain amount of time -- this would let us do GC when waiting for vsync for example, at "zero cost".

Matching il2cpp PR: https://gitlab.internal.unity3d.com/vm/il2cpp/merge_requests/877