### PR TITLE
Scripting memory snapshot crash fixes

### DIFF
--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -443,7 +443,7 @@ mono_mempool_foreach_block(MonoMemPool* pool, mono_mempool_block_proc callback, 
 	while (current)
 	{
 		gpointer start = (guint8*)current + SIZEOF_MEM_POOL;
-		gpointer end = (guint8*)start + current->size;
+		gpointer end = (guint8*)current + current->size;
 
 		callback(start, end, user_data);
 		current = current->next;

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -614,9 +614,7 @@ static void CollectMonoImageFromAssembly(MonoAssembly *assembly, void *user_data
 
 MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 {
-	int wasDisabled = GC_is_disabled();
-	if (!wasDisabled)
-		GC_disable();
+	GC_disable();
 
 	if (GC_collection_in_progress() == TRUE)
 		GC_wait_for_gc_completion();
@@ -641,10 +639,9 @@ MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 
 	g_hash_table_destroy(monoImages);
 
-	if (!wasDisabled)
-		GC_enable();
-
 	GC_start_world_external();
+	GC_enable();
+
 	return snapshot;
 }
 

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -615,9 +615,7 @@ static void CollectMonoImageFromAssembly(MonoAssembly *assembly, void *user_data
 MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 {
 	GC_disable();
-
-	if (GC_collection_in_progress() == TRUE)
-		GC_wait_for_gc_completion();
+	GC_wait_for_gc_completion(TRUE);
 
 	GC_stop_world_external();
 


### PR DESCRIPTION
PR reason: 
Fix the current crashes occurring during a scripting memory capture call and partially secure the current logic

Changes:
* fixed incorrect offsetting in mono_mempool_foreach_block
* removed start/stop loop when capturing heap sections in order to prevent data inconsistencies
* moved stop/start world calls to the start/end of the capture function, we should always be stopped when collecting meta information
* added waiting for currently running GC operation
