### PR TITLE
expose GC_collect_a_little

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -332,6 +332,13 @@ mono_gc_collect (int generation)
 	GC_gcollect ();
 }
 
+
+int
+mono_gc_collect_a_little()
+{
+	return GC_collect_a_little();
+}
+
 /**
  * mono_gc_max_generation:
  *

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -104,6 +104,7 @@ typedef enum {
 } MonoGCHandleType;
 
 MONO_API void   mono_gc_collect         (int generation);
+MONO_API int    mono_gc_collect_a_little ();
 MONO_API int    mono_gc_max_generation  (void);
 MONO_API int    mono_gc_get_generation  (MonoObject *object);
 MONO_API int    mono_gc_collection_count (int generation);


### PR DESCRIPTION
For dynamically invoking incremental GC from Unity, we need to expose GC_collect_a_little to mono API. Il2cpp already does this, il2cpp_gc_collect_a_little, this adds a matching mono API: mono_gc_collect_a_little

This allows us to do stuff like this: https://docs.google.com/document/d/1OElci1Y57JFbLSzARllvhygwsc1DyLgmgUXphJelUvk/edit#heading=h.tr4583y53hhy