### PR TITLE
Scripting memory capture fixes old mono

### DIFF
--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -474,7 +474,7 @@ void mono_mempool_foreach_chunk(MonoMemPool* pool, mono_mempool_chunk_proc callb
 	while (current)
 	{
 		gpointer start = (guint8*)current + sizeof(MonoMemPool);
-		gpointer end = (guint8*)start + current->size;
+		gpointer end = (guint8*)current + current->size;
 
 		callback(start, end, user_data);
 		current = current->next;


### PR DESCRIPTION
* removed unnecessary locks
* fixed incorrect offsetting during the iteration of mempool blocks
* enforced stopping the world before we walk any data inside the current domain
* enforced starting the world only after we've collected all snapshot data