### PR TITLE
fix potential unitytls marshalling issue with size t

### DIFF
--- a/mcs/class/System/Mono.UnityTls/CertHelper.cs
+++ b/mcs/class/System/Mono.UnityTls/CertHelper.cs
@@ -1,6 +1,8 @@
 #if SECURITY_DEP
 using System.Security.Cryptography.X509Certificates;
 
+using size_t = System.IntPtr;
+
 namespace Mono.Unity
 {
 	internal unsafe static class CertHelper
@@ -16,7 +18,7 @@ namespace Mono.Unity
 		{
 			byte[] certDer = certificate.GetRawCertData ();
 			fixed(byte* certDerPtr = certDer) {
-				UnityTls.NativeInterface.unitytls_x509list_append_der (nativeCertificateChain, certDerPtr, certDer.Length, errorState);
+				UnityTls.NativeInterface.unitytls_x509list_append_der (nativeCertificateChain, certDerPtr, (size_t)certDer.Length, errorState);
 			}
 
 			var certificateImpl2 = certificate.Impl as X509Certificate2Impl;
@@ -34,16 +36,16 @@ namespace Mono.Unity
 		{
 			X509CertificateCollection certificates = new X509CertificateCollection ();
 
-			var cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, 0, errorState);
+			var cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)0, errorState);
 			for (int i = 0; cert.handle != UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE; ++i) {
-				size_t certBufferSize = UnityTls.NativeInterface.unitytls_x509_export_der (cert, null, 0, errorState);
-				var certBuffer = new byte[certBufferSize];	// Need to reallocate every time since X509Certificate constructor takes no length but only a byte array.
+				size_t certBufferSize = UnityTls.NativeInterface.unitytls_x509_export_der (cert, null, (size_t)0, errorState);
+				var certBuffer = new byte[(int)certBufferSize];	// Need to reallocate every time since X509Certificate constructor takes no length but only a byte array.
 				fixed(byte* certBufferPtr = certBuffer) {
 					UnityTls.NativeInterface.unitytls_x509_export_der (cert, certBufferPtr, certBufferSize, errorState);
 				}
 				certificates.Add (new X509Certificate (certBuffer));
 
-				cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, i, errorState);
+				cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)i, errorState);
 			}
 
 			return certificates;

--- a/mcs/class/System/Mono.UnityTls/UnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTls.cs
@@ -9,23 +9,7 @@ namespace Mono.Unity
     // The aliases here are just there to keep the semantic in the interface and make it more similar to the c original.
     using UInt8 = Byte;
     using Int8 = Byte;
-
-    [StructLayout (LayoutKind.Sequential)]
-    internal struct size_t
-    {
-        public size_t(uint i) {
-            value = new IntPtr(i);
-        }
-
-        public static implicit operator size_t(int d) {
-            return new size_t((uint)d);
-        }
-        public static implicit operator int(size_t s) {
-            return s.value.ToInt32();
-        }
-
-        public IntPtr value;
-    }
+    using size_t = IntPtr;
 
     unsafe internal static partial class UnityTls
     {

--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -17,6 +17,8 @@ using MonoSecurity::Mono.Security.Interface;
 using Mono.Security.Interface;
 #endif
 
+using size_t = System.IntPtr;
+
 namespace Mono.Unity
 {
 	unsafe internal class UnityTlsProvider : MonoTlsProvider
@@ -93,13 +95,13 @@ namespace Mono.Unity
 					var trustCAnativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (certificatesNative, &errorState);
 
 					fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
-						result = UnityTls.NativeInterface.unitytls_x509verify_explicit_ca (certificatesNativeRef, trustCAnativeRef, targetHostUtf8Ptr, targetHostUtf8.Length, null, null, &errorState);
+						result = UnityTls.NativeInterface.unitytls_x509verify_explicit_ca (certificatesNativeRef, trustCAnativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
 					}
 
 					UnityTls.NativeInterface.unitytls_x509list_free (trustCAnative);
 				} else {
 					fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
-						result = UnityTls.NativeInterface.unitytls_x509verify_default_ca (certificatesNativeRef, targetHostUtf8Ptr, targetHostUtf8.Length, null, null, &errorState);
+						result = UnityTls.NativeInterface.unitytls_x509verify_default_ca (certificatesNativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
 					}
 				}
 			}


### PR DESCRIPTION
Since compiler handle structs differently on function calls this may have caused issues when passing arguments between managed and native code.
Even if not, we're clearly safer with the explicit casts now.

Ran the unity playmode tls tests to verify that this doesn't break anything