### PR TITLE
scripting memory capture crash fixes backport to 2018.3-mbe

### DIFF
--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -443,7 +443,7 @@ mono_mempool_foreach_block(MonoMemPool* pool, mono_mempool_block_proc callback, 
 	while (current)
 	{
 		gpointer start = (guint8*)current + SIZEOF_MEM_POOL;
-		gpointer end = (guint8*)start + current->size;
+		gpointer end = (guint8*)current + current->size;
 
 		callback(start, end, user_data);
 		current = current->next;

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -305,9 +305,7 @@ static void AllocateMemoryForMemPool(MonoMemPool* pool, void *user_data)
 
 static void AllocateMemoryForImageMemPool(MonoImage *image, gpointer value, void *user_data)
 {
-	mono_image_lock(image);
 	AllocateMemoryForMemPool(image->mempool, user_data);
-	mono_image_unlock(image);
 }
 
 static void CopyMemPool(MonoMemPool *pool, SectionIterationContext *context)
@@ -317,26 +315,17 @@ static void CopyMemPool(MonoMemPool *pool, SectionIterationContext *context)
 
 static void CopyImageMemPool(MonoImage *image, gpointer value, SectionIterationContext *context)
 {
-	mono_image_lock(image);
 	CopyMemPool(image->mempool, context);
-	mono_image_unlock(image);
 }
 
 static void AllocateMemoryForImageClassCache(MonoImage *image, gpointer *value, void *user_data)
 {
-	mono_image_lock(image);
-
 	AllocateMemoryForSection(user_data, image->class_cache.table, ((uint8_t*)image->class_cache.table) + image->class_cache.size);
-	mono_image_unlock(image);
 }
 
 static void CopyImageClassCache(MonoImage *image, gpointer value, SectionIterationContext *context)
 {
-	mono_image_lock(image);
-
 	CopyHeapSection(context, image->class_cache.table, ((uint8_t*)image->class_cache.table) + image->class_cache.size);
-
-	mono_image_unlock(image);
 }
 
 static void IncrementCountForImageSetMemPoolNumChunks(MonoImageSet *imageSet, void *user_data)
@@ -491,18 +480,7 @@ static void CaptureManagedHeap(MonoManagedHeap* heap, GHashTable* monoImages)
 	data.heap = heap;
 	data.monoImages = monoImages;
 
-	while (TRUE)
-	{
-		GC_call_with_alloc_lock(CaptureHeapInfo, &data);
-		GC_stop_world_external();
-
-		if (MonoManagedHeapStillValid(heap, monoImages))
-			break;
-
-		GC_start_world_external();
-
-		FreeMonoManagedHeap(heap);
-	}
+	CaptureHeapInfo(&data);
 
 	iterationContext.currentSection = heap->sections;
 
@@ -512,8 +490,6 @@ static void CaptureManagedHeap(MonoManagedHeap* heap, GHashTable* monoImages)
 	g_hash_table_foreach(monoImages, (GHFunc)CopyImageMemPool, &iterationContext);
 	g_hash_table_foreach(monoImages, (GHFunc)CopyImageClassCache, &iterationContext);
 	mono_metadata_image_set_foreach(CopyImageSetMemPool, &iterationContext);
-
-	GC_start_world_external();
 }
 
 static void GCHandleIterationCallback(MonoObject* managedObject, GList** managedObjects)
@@ -638,6 +614,9 @@ static void CollectMonoImageFromAssembly(MonoAssembly *assembly, void *user_data
 
 MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 {
+	GC_disable();
+	GC_stop_world_external();
+
 	MonoManagedMemorySnapshot* snapshot;
 	snapshot = g_new0(MonoManagedMemorySnapshot, 1);
 
@@ -655,6 +634,9 @@ MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 #endif
 
 	g_hash_table_destroy(monoImages);
+
+	GC_start_world_external();
+	GC_enable();
 
 	return snapshot;
 }


### PR DESCRIPTION
backport of prs:
https://github.com/Unity-Technologies/mono/pull/1052
and
https://github.com/Unity-Technologies/mono/pull/1047

*fixed incorrect offsetting in mono_mempool_foreach_block
*removed start/stop loop when capturing heap sections in order to prevent data inconsistencies
*moved stop/start world calls to the start/end of the capture function, we should always be stopped when collecting meta information

fb case: https://fogbugz.unity3d.com/f/cases/1081890/