### PR TITLE
Build the System.Data.DataSetExtensions assembly

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -345,6 +345,7 @@ net_4_x_parallel_dirs := \
 unityjit_dirs := \
 	$(net_4_x_dirs) \
 	System.ComponentModel.Composition.4.5 \
+	System.Data.DataSetExtensions \
 	I18N \
 	$(pcl_facade_dirs)
 
@@ -361,6 +362,7 @@ unityaot_dirs := \
 		System.Xml.Serialization \
 		System.Runtime.CompilerServices.Unsafe, $(mobile_common_dirs))	\
 	System.Drawing			\
+	System.Data.DataSetExtensions \
 	$(pcl_facade_dirs)
 
 xbuild_2_0_dirs := \


### PR DESCRIPTION
The unityjit and unityaot profiles should have this assembly. It exists
in the 2.0 profile for the old scripting runtime, and we don't see any
need to remove it for the new scripting runtime.

This corrects case 1071607 in Unity.