### PR TITLE
Additional constructor preservations

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -19,7 +19,10 @@
 		</type>
 
 		<!-- appdomain.c: mono_runtime_init -->
-		<type fullname="System.AppDomainSetup" preserve="fields" />
+		<type fullname="System.AppDomainSetup" preserve="fields" >
+			<!-- appdomain.c mono_object_new_checked in mono_domain_create_appdomain_checked -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		
 		<!-- exception.c: mono_get_exception_appdomain_unloaded (used in several places), threadpool.c -->
 		<type fullname="System.AppDomainUnloadedException">
@@ -122,7 +125,10 @@
 		
 		<!-- domain.c: mono_defaults.stack_frame_class -->
 		<!-- used in mini-exceptions.c to create array and MonoStackFrame instance, i.e. only fields are required to be preserved -->
-		<type fullname="System.Diagnostics.StackFrame" preserve="fields" />
+		<type fullname="System.Diagnostics.StackFrame" preserve="fields" >
+			<!-- threads.c mono_object_new_checked in mono_threads_get_thread_dump -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		
 		<!-- domain.c: mono_defaults.stack_trace_class -->
 		<!-- does not seems used outside the g_assert in domain.c (maybe it could be removed) -->
@@ -254,7 +260,10 @@
 		</type>
 		
 		<!-- threadpool.c: mono_thread_pool_init (assert) -->
-		<type fullname="System.MonoAsyncCall" preserve="fields" />
+		<type fullname="System.MonoAsyncCall" preserve="fields" >
+			<!-- threadpool.c mono_object_new_checked in mono_threadpool_begin_invoke -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		<!-- mono-mlist.c (managed list): used in threadpool.c and gc.c -->
 		<type fullname="System.MonoListItem" preserve="fields" />
 		
@@ -303,6 +312,8 @@
 			<!-- TransparentProxy.cs, RemotingServices.cs -->
 			<method name="FieldGetter" feature="remoting" />
 			<method name="FieldSetter" feature="remoting" />
+			<!-- appdomain.c mono_object_new_checked in create_domain_objects -->
+			<method signature="System.Void .ctor()" />
 		</type>
 		
 		<!-- appdomain.c (create_domain_objects) domain->out_of_memory_ex -->
@@ -524,16 +535,25 @@
 		</type>
 		
 		<!-- reflection.c: mono_method_body_get_object -->
-		<type fullname="System.Reflection.ExceptionHandlingClause" preserve="fields" />
+		<type fullname="System.Reflection.ExceptionHandlingClause" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in add_exception_handling_clause_to_array -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		
 		<!-- domain.c: mono_defaults.field_info_class -->
 		<type fullname="System.Reflection.FieldInfo" preserve="fields" />
 		
 		<!-- reflection.c: mono_method_body_get_object -->
-		<type fullname="System.Reflection.LocalVariableInfo" preserve="fields" />
+		<type fullname="System.Reflection.LocalVariableInfo" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in add_local_var_info_to_array -->
+			<method signature="System.Void .ctor()" />
+		</type>
 
 		<!-- reflection.c: mono_method_body_get_object -->
-		<type fullname="System.Reflection.MethodBody" preserve="fields" />
+		<type fullname="System.Reflection.MethodBody" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in method_body_object_construct -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		<!-- domain.c: mono_defaults.method_info_class -->
 		<type fullname="System.Reflection.MethodInfo" preserve="fields" />
 
@@ -544,26 +564,42 @@
 		<type fullname="System.Reflection.MonoModule" preserve="fields" >
 			<method name=".ctor" />
 		</type>
-		<type fullname="System.Reflection.MonoCMethod" preserve="fields" />
+		<type fullname="System.Reflection.MonoCMethod" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in method_object_construct -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		<type fullname="System.Reflection.MonoEvent" preserve="fields" />
-		<type fullname="System.Reflection.MonoEventInfo" preserve="fields" />
-		<type fullname="System.Reflection.MonoField" preserve="fields" />
-		
+		<type fullname="System.Reflection.MonoEventInfo" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in event_object_construct -->
+			<method signature="System.Void .ctor()" />
+		</type>
+		<type fullname="System.Reflection.MonoField" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in field_object_construct -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		<!-- reflection.c: mono_method_get_object uses both MonoGeneric[C]Method / will crash for ves_icall_Type_GetConstructors_internal -->
 		<type fullname="System.Reflection.MonoGenericMethod" preserve="fields" />
 		<type fullname="System.Reflection.MonoGenericCMethod" preserve="fields" />
 		
-		<type fullname="System.Reflection.MonoMethod" preserve="fields" />
+		<type fullname="System.Reflection.MonoMethod" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in method_object_construct -->
+			<method signature="System.Void .ctor()" />
+		</type>
 		<type fullname="System.Reflection.MonoMethodInfo" preserve="fields" />
 		<type fullname="System.Reflection.MonoPropertyInfo" preserve="fields" />
 		
 		<type fullname="System.Reflection.MonoProperty" preserve="fields">
 			<method name="GetterAdapterFrame" />
 			<method name="StaticGetterAdapterFrame" />
+			<!-- reflection.c mono_object_new_checked in add_parameter_object_to_array -->
+			<method signature="System.Void .ctor()" />
 		</type>
 		<type fullname="System.Reflection.ParameterInfo" preserve="fields" />
 		<!-- reflection.c: ves_icall_get_parameter_info -->
-		<type fullname="System.Reflection.MonoParameterInfo" preserve="fields" />
+		<type fullname="System.Reflection.MonoParameterInfo" preserve="fields" >
+			<!-- reflection.c mono_object_new_checked in event_object_construct -->
+			<method signature="System.Void .ctor()" />
+		</type>
 
 		<!-- object.c: mono_field_get_value_object and mono_runtime_invoke_array -->
 		<type fullname="System.Reflection.Pointer" >
@@ -708,7 +744,10 @@
 		<!-- domain.c: mono_defaults.asyncresult_class (Stubify can't be applied on this type) -->
 		<!-- object.c MONO_OBJECT_SETREF in mono_async_result_new -->
 		<!-- threadpool.c: MONO_OBJECT_SETREF in create_simple_asyncresult -->
-		<type fullname="System.Runtime.Remoting.Messaging.AsyncResult" preserve="fields" />
+		<type fullname="System.Runtime.Remoting.Messaging.AsyncResult" preserve="fields" >
+			<!-- object.c mono_object_new_checked in mono_async_result_new -->
+			<method signature="System.Void .ctor()" />
+		</type>
 
 		<!-- marshal.c: mono_remoting_marshal_init / removed with DISABLE_REMOTING -->
 		<type fullname="System.Runtime.Remoting.Messaging.CallContext" feature="remoting" >
@@ -719,16 +758,22 @@
 		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields" feature="remoting" >
 			<!-- object.c: mono_message_init -->
 			<method name="InitMessage" />
+			<!-- marshal.c mono_object_new_checked in mono_delegate_end_invoke-->
+			<method name=".ctor" feature="remoting" />
 		</type>
 		<!-- domain.c: mono_defaults.real_proxy_class / removed with DISABLE_REMOTING -->
 		<type fullname="System.Runtime.Remoting.Proxies.RealProxy" preserve="fields" feature="remoting" >
 			<method name="PrivateInvoke" />
 			<method name="GetAppDomainTarget" />
+			<!-- object.c mono_object_new_checked in make_transparent_proxy-->
+			<method name=".ctor" feature="remoting" />
 		</type>
 		<!-- domain.c: mono_defaults.transparent_proxy_class / removed with DISABLE_REMOTING -->
 		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy" preserve="fields" feature="remoting" >
 			<method name="LoadRemoteFieldNew" />
 			<method name="StoreRemoteField" />
+			<!-- icall.c mono_object_new_checked in ves_icall_Remoting_RealProxy_GetTransparentProxy -->
+			<method signature="System.Void .ctor()" feature="remoting" />
 		</type>
 		<type fullname="System.Runtime.Remoting.RemotingServices" feature="remoting" >
 			<method name="SerializeCallData" />


### PR DESCRIPTION
Upcoming changes to monolinker will make additional optimizations when no instance ctors are marked.

To be safe, add preservations for the ctor's of types that are created in the runtime.

The change to preserve the .ctor() of`System.Runtime.Remoting.Messaging.AsyncResult`  was made for more than out of caution.  We have a simple delegate test that hung without this.

This change has already landed upstream.  https://github.com/mono/mono/pull/11459

We need to get this into our mono builds before I can land interface sweeping in UnityLinker.  Otherwise Experimental mode il2cpp integration tests will hang.