### PR TITLE
Use mono_mb_emit_op for CEE_LDOBJ to ensure wrapper data is added for…

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -1755,6 +1755,11 @@ public class Tests : TestsBase, ITest2
 	public static ref string get_ref_string() {
 		return ref ref_return_string;
 	}
+
+	static BlittableStruct ref_return_struct = new BlittableStruct () { i = 1, d = 2.0 };
+	public static ref BlittableStruct get_ref_struct () {
+		return ref ref_return_struct;
+	}
 }
 
 public class SentinelClass : MarshalByRefObject {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4423,6 +4423,13 @@ public class DebuggerTests
 		m = t.GetMethod ("get_ref_string");
 		v = t.InvokeMethod (e.Thread, m, null);
 		AssertValue ("byref", v);
+
+		m = t.GetMethod ("get_ref_struct");
+		v = t.InvokeMethod (e.Thread, m, null);
+		Assert.IsTrue(v is StructMirror);
+ 		var mirror = (StructMirror)v;
+		AssertValue (1, mirror["i"]);
+		AssertValue (2.0, mirror["d"]);
 	}
 } // class DebuggerTests
 } // namespace


### PR DESCRIPTION
… indirect load of a ref return value. (case 1096820)

The `mono_mb_emit_op ` call caches the type data to be used later by method-to-ir