### PR TITLE
Scripting memory capture - static field byte reporting fix

### DIFF
--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -36,16 +36,18 @@ ContextRecurseClassData (CollectMetadataContext *context, MonoClass *klass)
 	* If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
 	* that 0 is a valid class index and was confusing our logic.
 	*/
-	if (!g_hash_table_lookup_extended (context->allTypes, klass, &orig_key, &value))
+	if (!g_hash_table_lookup_extended (context->allTypes, klass, &orig_key, &value)) {
 		g_hash_table_insert (context->allTypes, klass, GINT_TO_POINTER (context->currentIndex++));
 
-	fieldCount = mono_class_num_fields (klass);
-	if (fieldCount > 0) {
-		while ((field = mono_class_get_fields (klass, &iter))) {
-			MonoClass *fieldKlass = mono_class_from_mono_type (field->type);
+		fieldCount = mono_class_num_fields (klass);
+		
+		if (fieldCount > 0) {
+			while ((field = mono_class_get_fields (klass, &iter))) {
+				MonoClass *fieldKlass = mono_class_from_mono_type (field->type);
 
-			if (!g_hash_table_lookup_extended (context->allTypes, fieldKlass, &orig_key, &value))
-				ContextRecurseClassData (context, fieldKlass);
+				if (fieldKlass != klass)
+					ContextRecurseClassData (context, fieldKlass);
+			}
 		}
 	}
 }

--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -98,7 +98,7 @@ CollectImageMetaData (MonoImage *image, gpointer value, CollectMetadataContext *
 
 		while (g_hash_table_iter_next (&iter, &key, NULL)) {
 			MonoType *monoType = (MonoType *)key;
-			MonoClass *klass = mono_type_get_class (monoType);
+			MonoClass *klass = mono_class_from_mono_type (monoType);
 
 			if (klass)
 				ContextRecurseClassData (context, klass);


### PR DESCRIPTION
fix for [case 984330](https://fogbugz.unity3d.com/f/cases/984330/), static field bytes being reported without any static fields being reported as present when the static field would be one an array type or generic type instance.

* changed class crawling to be recursive and now store non initialized classes
* metadata type reporting will now also report uninitialized types
* metadata type reporting will now account for array types being fields inside a class