### PR TITLE
Update external build-deps tools paths (MBE)

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -351,17 +351,17 @@ if ($build)
 		my $texinfoVersion = "4.8";
 		my $automakeVersion = "1.15";
 		my $libtoolVersion = "2.4.6";
-		my $autoconfDir = "$externalBuildDeps/autoconf-$autoconfVersion";
-		my $texinfoDir = "$externalBuildDeps/texinfo-$texinfoVersion";
-		my $automakeDir = "$externalBuildDeps/automake-$automakeVersion";
-		my $libtoolDir = "$externalBuildDeps/libtool-$libtoolVersion";
+		my $autoconfDir = "$externalBuildDeps/autoconf-2-69/autoconf-$autoconfVersion";
+		my $texinfoDir = "$externalBuildDeps/texinfo-4-8/texinfo-$texinfoVersion";
+		my $automakeDir = "$externalBuildDeps/automake-1-15/automake-$automakeVersion";
+		my $libtoolDir = "$externalBuildDeps/libtool-2-4-6/libtool-$libtoolVersion";
 		my $builtToolsDir = "$externalBuildDeps/built-tools";
 
 		$ENV{PATH} = "$builtToolsDir/bin:$ENV{PATH}";
 
 		if (!(-d "$autoconfDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/autoconf-2-69") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf autoconf-$autoconfVersion.tar.gz") eq 0  or die ("failed to extract autoconf\n");
 
 			chdir("$autoconfDir") eq 1 or die ("failed to chdir to autoconf directory\n");
@@ -374,7 +374,7 @@ if ($build)
 
 		if (!(-d "$texinfoDir") and $windowsSubsystemForLinux)
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/texinfo-4-8") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf texinfo-$texinfoVersion.tar.gz") eq 0 or die ("failed to extract texinfo\n");
 
 			chdir($texinfoDir) eq 1 or die ("failed to chdir to texinfo directory\n");
@@ -388,7 +388,7 @@ if ($build)
 		if (!(-d "$automakeDir"))
 		{
 			my $automakeMakeFlags = "";
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/automake-1-15") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
 			chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
@@ -406,7 +406,7 @@ if ($build)
 
 		if (!(-d "$libtoolDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/libtool-2-4-6") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf libtool-$libtoolVersion.tar.gz") eq 0  or die ("failed to extract libtool\n");
 
 			chdir("$libtoolDir") eq 1 or die ("failed to chdir to libtool directory\n");
@@ -1096,8 +1096,8 @@ if ($build)
 			print(">>> Linux SDK Version = $sdkVersion\n");
 
 			my $sdkName = "linux-sdk-$sdkVersion.tar.bz2";
-			my $depsSdkArchive = "$externalBuildDeps/$sdkName";
-			my $depsSdkFinal = "$externalBuildDeps/linux-sdk-$sdkVersion";
+			my $depsSdkArchive = "$externalBuildDeps/linux-sdk-$sdkVersion/$sdkName";
+			my $depsSdkFinal = "$externalBuildDeps/linux-sdk-$sdkVersion/linux-sdk-$sdkVersion";
 
 			print(">>> Linux SDK Archive = $depsSdkArchive\n");
 			print(">>> Linux SDK Extraction Destination = $depsSdkFinal\n");

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -436,7 +436,7 @@ if ($build)
 		if (! -d $macSdkPath)
 		{
 			print(">>> Unzipping mac build toolchain\n");
-			system("$externalBuildDeps/unzip", '-qd', "$macBuildEnvDir", "$macBuildEnvDir/builds.zip") eq 0 or die ("failed unzipping mac build toolchain\n");
+			system("unzip", '-qd', "$macBuildEnvDir", "$macBuildEnvDir/builds.zip") eq 0 or die ("failed unzipping mac build toolchain\n");
 		}
 	}
 
@@ -453,7 +453,7 @@ if ($build)
 		if (! -d "$iosBuildEnvDir/builds")
 		{
 			print(">>> Unzipping ios build toolchain\n");
-			system("$externalBuildDeps/unzip", '-qd', "$iosBuildEnvDir/builds", "$iosBuildEnvDir/builds.zip") eq 0 or die ("failed unzipping ios build toolchain\n");
+			system("unzip", '-qd', "$iosBuildEnvDir/builds", "$iosBuildEnvDir/builds.zip") eq 0 or die ("failed unzipping ios build toolchain\n");
 		}
 
 		$ENV{PATH} = "$iosXcodeDefaultToolchainRoot/usr/bin:$iosBuildEnvDir/builds/Xcode.app/Contents/Developer/usr/bin:$ENV{PATH}";

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -698,15 +698,15 @@ if ($build)
 		my $ndkName = "";
 		if($^O eq "linux")
 		{
-			$ndkName = "android-ndk-$ndkVersion-linux-x86_64.zip";
+			$ndkName = "android-ndk-$ndkVersion-linux/android-ndk-$ndkVersion-linux-x86_64.zip";
 		}
 		elsif($^O eq "darwin")
 		{
-			$ndkName = "android-ndk-$ndkVersion-darwin-x86_64.zip";
+			$ndkName = "android-ndk-$ndkVersion-darwin/android-ndk-$ndkVersion-darwin-x86_64.zip";
 		}
 		else
 		{
-			$ndkName = "android-ndk-$ndkVersion-windows-x86.zip";
+			$ndkName = "android-$ndkVersion-r16b-windows/android-ndk-$ndkVersion-windows-x86.zip";
 		}
 
 		my $depsNdkArchive = "$externalBuildDeps/$ndkName";

--- a/external/buildscripts/build_unityscript_bareminimum_win.pl
+++ b/external/buildscripts/build_unityscript_bareminimum_win.pl
@@ -65,19 +65,14 @@ sub UnityBooc
 
 sub BuildUnityScriptForUnity
 {	
-	# Build system is handling this
-	if (!$ENV{UNITY_THISISABUILDMACHINE}) {
-		GitClone("git://github.com/Unity-Technologies/boo.git", $booCheckout);
-	}
+	GitClone("git://github.com/Unity-Technologies/boo.git", $booCheckout);
 
 	my $commonDefines = "NO_SERIALIZATION_INFO,NO_SYSTEM_PROCESS,NO_ICLONEABLE,MSBUILD,IGNOREKEYFILE";
 
 	Build("$booCheckout/src/booc/Booc.csproj", undef, "/property:TargetFrameworkVersion=4.0 /property:DefineConstants=\"" . $commonDefines . "\" /property:OutputPath=$output/wp8");
 	Build("$booCheckout/src/booc/Booc.csproj", undef, "/property:TargetFrameworkVersion=4.0 /property:DefineConstants=\"" . $commonDefines . ",NO_SYSTEM_REFLECTION_EMIT\" /property:OutputPath=$output/wsa");
 	
-	if (!$ENV{UNITY_THISISABUILDMACHINE}) {
-		GitClone("git://github.com/Unity-Technologies/unityscript.git", $usCheckout);
-	}
+	GitClone("git://github.com/Unity-Technologies/unityscript.git", $usCheckout);
 	
 	UnityBooc("-out:$output/wsa/Boo.Lang.Extensions.dll -srcdir:$booCheckout/src/Boo.Lang.Extensions -r:$output/wsa/Boo.Lang.dll -r:$output/wsa/Boo.Lang.Compiler.dll");
 	UnityBooc("-out:$output/wsa/Boo.Lang.Useful.dll -srcdir:$booCheckout/src/Boo.Lang.Useful -r:$output/wsa/Boo.Lang.Parser");

--- a/external/buildscripts/build_us_and_boo.pl
+++ b/external/buildscripts/build_us_and_boo.pl
@@ -49,24 +49,17 @@ sub BuildUnityScriptFor45
 	my $booCheckout = "$monoroot/../../boo/build";
 	print(">>> Using mono prefix $monoprefix45\n");
 	
-	# Build host is handling this
-	if (!$buildMachine)
+	if (!(-d "$booCheckout"))
 	{
-		if (!(-d "$booCheckout"))
-		{
-			print(">>> Checking out boo\n");
-			GitClone("git://github.com/Unity-Technologies/boo.git", $booCheckout, "unity-trunk");
-		}
+		print(">>> Checking out boo\n");
+		GitClone("git://github.com/Unity-Technologies/boo.git", $booCheckout, "unity-trunk");
 	}
 	
 	my $usCheckout = "$monoroot/../../unityscript/build";
-	if (!$buildMachine)
+	if (!(-d "$usCheckout"))
 	{
-		if (!(-d "$usCheckout"))
-		{
-			print(">>> Checking out unity script\n");
-			GitClone("git://github.com/Unity-Technologies/unityscript.git", $usCheckout, "unity-trunk");
-		}
+		print(">>> Checking out unity script\n");
+		GitClone("git://github.com/Unity-Technologies/unityscript.git", $usCheckout, "unity-trunk");
 	}
 	
 	my $boocCsproj = "$booCheckout/src/booc/booc.csproj";


### PR DESCRIPTION
To support external repo mono-build-deps PR: https://ono.unity3d.com/unity-extra/mono-build-deps/pull-request/77510/_/scripting/move-zip-files-into-folders-hgmove

Katana:
https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?boo_branch=unity-trunk&cecil_branch=unity-master&krait-signal-handler_branch=master&mono_branch=support-rearranged-mono-build-deps&mono-build-tools-extra_branch=master&mono-build-deps_branch=scripting%2Fmove-zip-files-into-folders&unityscript_branch=unity-trunk

