### PR TITLE
Update external build-deps tools paths (2017.4 MBE)

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -328,17 +328,17 @@ if ($build)
 		my $texinfoVersion = "4.8";
 		my $automakeVersion = "1.15";
 		my $libtoolVersion = "2.4.6";
-		my $autoconfDir = "$externalBuildDeps/autoconf-$autoconfVersion";
-		my $texinfoDir = "$externalBuildDeps/texinfo-$texinfoVersion";
-		my $automakeDir = "$externalBuildDeps/automake-$automakeVersion";
-		my $libtoolDir = "$externalBuildDeps/libtool-$libtoolVersion";
+		my $autoconfDir = "$externalBuildDeps/autoconf-2-69/autoconf-$autoconfVersion";
+		my $texinfoDir = "$externalBuildDeps/texinfo-4-8/texinfo-$texinfoVersion";
+		my $automakeDir = "$externalBuildDeps/automake-1-15/automake-$automakeVersion";
+		my $libtoolDir = "$externalBuildDeps/libtool-2-4-6/libtool-$libtoolVersion";
 		my $builtToolsDir = "$externalBuildDeps/built-tools";
 
 		$ENV{PATH} = "$builtToolsDir/bin:$ENV{PATH}";
 
 		if (!(-d "$autoconfDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/autoconf-2-69") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf autoconf-$autoconfVersion.tar.gz") eq 0  or die ("failed to extract autoconf\n");
 
 			chdir("$autoconfDir") eq 1 or die ("failed to chdir to autoconf directory\n");
@@ -351,7 +351,7 @@ if ($build)
 
 		if (!(-d "$texinfoDir") and $windowsSubsystemForLinux)
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/texinfo-4-8") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf texinfo-$texinfoVersion.tar.gz") eq 0 or die ("failed to extract texinfo\n");
 
 			chdir($texinfoDir) eq 1 or die ("failed to chdir to texinfo directory\n");
@@ -365,7 +365,7 @@ if ($build)
 		if (!(-d "$automakeDir"))
 		{
 			my $automakeMakeFlags = "";
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/automake-1-15") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
 			chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
@@ -383,7 +383,7 @@ if ($build)
 
 		if (!(-d "$libtoolDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/libtool-2-4-6") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf libtool-$libtoolVersion.tar.gz") eq 0  or die ("failed to extract libtool\n");
 
 			chdir("$libtoolDir") eq 1 or die ("failed to chdir to libtool directory\n");
@@ -1112,8 +1112,8 @@ if ($build)
 			print(">>> Linux SDK Version = $sdkVersion\n");
 
 			my $sdkName = "linux-sdk-$sdkVersion.tar.bz2";
-			my $depsSdkArchive = "$externalBuildDeps/$sdkName";
-			my $depsSdkFinal = "$externalBuildDeps/linux-sdk-$sdkVersion";
+			my $depsSdkArchive = "$externalBuildDeps/linux-sdk-$sdkVersion/$sdkName";
+			my $depsSdkFinal = "$externalBuildDeps/linux-sdk-$sdkVersion/linux-sdk-$sdkVersion";
 
 			print(">>> Linux SDK Archive = $depsSdkArchive\n");
 			print(">>> Linux SDK Extraction Destination = $depsSdkFinal\n");


### PR DESCRIPTION
To support external repo mono-build-deps PR: https://ono.unity3d.com/unity-extra/mono-build-deps/pull-request/77510/_/scripting/move-zip-files-into-folders-hgmove
Katana:
https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?boo_branch=unity-trunk&cecil_branch=unity-master&krait-signal-handler_branch=master&mono_branch=support-rearranged-mono-build-deps-2017.4-mbe&mono-build-tools-extra_branch=master&mono-build-deps_branch=scripting%2Fmove-zip-files-into-folders&unityscript_branch=unity-trunk