### PR TITLE
Update external build-deps tools paths (2018.2 mono)

### DIFF
--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -96,16 +96,16 @@ if (not $skipbuild)
 		my $autoconfVersion = "2.69";
 		my $automakeVersion = "1.15";
 		my $libtoolVersion = "2.4.6";
-		my $autoconfDir = "$externalBuildDeps/autoconf-$autoconfVersion";
-		my $automakeDir = "$externalBuildDeps/automake-$automakeVersion";
-		my $libtoolDir = "$externalBuildDeps/libtool-$libtoolVersion";
+		my $autoconfDir = "$externalBuildDeps/autoconf-2-69/autoconf-$autoconfVersion";
+		my $automakeDir = "$externalBuildDeps/automake-1-15/automake-$automakeVersion";
+		my $libtoolDir = "$externalBuildDeps/libtool-2-4-6/libtool-$libtoolVersion";
 		my $builtToolsDir = "$externalBuildDeps/built-tools";
 
 		$ENV{PATH} = "$builtToolsDir/bin:$ENV{PATH}";
 
 		if (!(-d "$autoconfDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/autoconf-2-69") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf autoconf-$autoconfVersion.tar.gz") eq 0  or die ("failed to extract autoconf\n");
 
 			chdir("$autoconfDir") eq 1 or die ("failed to chdir to autoconf directory\n");
@@ -120,7 +120,7 @@ if (not $skipbuild)
 
 		if (!(-d "$automakeDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/automake-1-15") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
 			chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
@@ -136,7 +136,7 @@ if (not $skipbuild)
 
 		if (!(-d "$libtoolDir"))
 		{
-			chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+			chdir("$externalBuildDeps/libtool-2-4-6") eq 1 or die ("failed to chdir to external directory\n");
 			system("tar xzf libtool-$libtoolVersion.tar.gz") eq 0  or die ("failed to extract libtool\n");
 		
 			chdir("$libtoolDir") eq 1 or die ("failed to chdir to libtool directory\n");

--- a/external/buildscripts/build_runtime_osx.pl
+++ b/external/buildscripts/build_runtime_osx.pl
@@ -64,9 +64,9 @@ if ($externalBuildDeps ne "")
 	my $autoconfVersion = "2.69";
 	my $automakeVersion = "1.15";
 	my $libtoolVersion = "2.4.6";
-	my $autoconfDir = "$externalBuildDeps/autoconf-$autoconfVersion";
-	my $automakeDir = "$externalBuildDeps/automake-$automakeVersion";
-	my $libtoolDir = "$externalBuildDeps/libtool-$libtoolVersion";
+	my $autoconfDir = "$externalBuildDeps/autoconf-2-69/autoconf-$autoconfVersion";
+	my $automakeDir = "$externalBuildDeps/automake-1-15/automake-$automakeVersion";
+	my $libtoolDir = "$externalBuildDeps/libtool-2-4-6/libtool-$libtoolVersion";
 
 	my $builtToolsDir = "$externalBuildDeps/built-tools";
 
@@ -74,7 +74,7 @@ if ($externalBuildDeps ne "")
 
 	if (!(-d "$autoconfDir"))
 	{
-		chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+		chdir("$externalBuildDeps/autoconf-2-69") eq 1 or die ("failed to chdir to external directory\n");
 		system("tar xzf autoconf-$autoconfVersion.tar.gz") eq 0  or die ("failed to extract autoconf\n");
 
 		chdir("$autoconfDir") eq 1 or die ("failed to chdir to autoconf directory\n");
@@ -89,7 +89,7 @@ if ($externalBuildDeps ne "")
 
 	if (!(-d "$automakeDir"))
 	{
-		chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+		chdir("$externalBuildDeps/automake-1-15") eq 1 or die ("failed to chdir to external directory\n");
 		system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
 		chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
@@ -104,7 +104,7 @@ if ($externalBuildDeps ne "")
 
 	if (!(-d "$libtoolDir"))
 	{
-		chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+		chdir("$externalBuildDeps/libtool-2-4-6") eq 1 or die ("failed to chdir to external directory\n");
 		system("tar xzf libtool-$libtoolVersion.tar.gz") eq 0  or die ("failed to extract libtool\n");
 	
 		chdir("$libtoolDir") eq 1 or die ("failed to chdir to libtool directory\n");

--- a/external/buildscripts/prepare_osx_build.pl
+++ b/external/buildscripts/prepare_osx_build.pl
@@ -10,9 +10,9 @@ if ($externalBuildDeps ne "")
 	my $autoconfVersion = "2.69";
 	my $automakeVersion = "1.15";
 	my $libtoolVersion = "2.4.6";
-	my $autoconfDir = "$externalBuildDeps/autoconf-$autoconfVersion";
-	my $automakeDir = "$externalBuildDeps/automake-$automakeVersion";
-	my $libtoolDir = "$externalBuildDeps/libtool-$libtoolVersion";
+	my $autoconfDir = "$externalBuildDeps/autoconf-2-69/autoconf-$autoconfVersion";
+	my $automakeDir = "$externalBuildDeps/automake-1-15/automake-$automakeVersion";
+	my $libtoolDir = "$externalBuildDeps/libtool-2-4-6/libtool-$libtoolVersion";
 
 	my $builtToolsDir = "$externalBuildDeps/built-tools";
 
@@ -20,7 +20,7 @@ if ($externalBuildDeps ne "")
 
 	if (!(-d "$autoconfDir"))
 	{
-		chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+		chdir("$externalBuildDeps/autoconf-2-69") eq 1 or die ("failed to chdir to external directory\n");
 		system("tar xzf autoconf-$autoconfVersion.tar.gz") eq 0  or die ("failed to extract autoconf\n");
 
 		chdir("$autoconfDir") eq 1 or die ("failed to chdir to autoconf directory\n");
@@ -35,7 +35,7 @@ if ($externalBuildDeps ne "")
 
 	if (!(-d "$automakeDir"))
 	{
-		chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+		chdir("$externalBuildDeps/automake-1-15") eq 1 or die ("failed to chdir to external directory\n");
 		system("tar xzf automake-$automakeVersion.tar.gz") eq 0  or die ("failed to extract automake\n");
 
 		chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
@@ -50,7 +50,7 @@ if ($externalBuildDeps ne "")
 
 	if (!(-d "$libtoolDir"))
 	{
-		chdir("$externalBuildDeps") eq 1 or die ("failed to chdir to external directory\n");
+		chdir("$externalBuildDeps/libtool-2-4-6") eq 1 or die ("failed to chdir to external directory\n");
 		system("tar xzf libtool-$libtoolVersion.tar.gz") eq 0  or die ("failed to extract libtool\n");
 	
 		chdir("$libtoolDir") eq 1 or die ("failed to chdir to libtool directory\n");


### PR DESCRIPTION
To support external repo mono-build-deps PR: https://ono.unity3d.com/unity-extra/mono-build-deps/pull-request/77510/_/scripting/move-zip-files-into-folders-hgmove

Katana:
https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?boo_branch=unity-trunk&cecil_branch=unity-master&krait-signal-handler_branch=unity-trunk&mono_branch=support-rearranged-mono-build-deps-unity-2018.2&mono-build-tools-extra_branch=master&mono-build-deps_branch=scripting%2Fmove-zip-files-into-folders&unityscript_branch=unity-trunk