### PR TITLE
Add Gitlab CI configs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,10 @@ build_osx_classlibs:
   - perl external/buildscripts/build_classlibs_osx.pl
   - mkdir -p incomingbuilds/classlibs
   - cp -r ZippedClasslibs.tar.gz incomingbuilds/classlibs/
+  - cd incomingbuilds/classlibs
+  - tar -pzxf ZippedClasslibs.tar.gz
+  - rm -f ZippedClasslibs.tar.gz
+  - cd ../..
   artifacts:
     paths:
     - incomingbuilds/classlibs
@@ -72,7 +76,7 @@ build_android:
   - cd ../..
   - bash external/buildscripts/build_runtime_android.sh
   - mkdir -p incomingbuilds/android/
-  - cp -r builds/ incomingbuilds/android/
+  - cp -r builds/* incomingbuilds/android/
   artifacts:
     paths:
     - incomingbuilds/android
@@ -156,8 +160,8 @@ build_linux_x64:
   - ./bee
   - cd ../..
   - perl external/buildscripts/build_runtime_linux.pl -build64=1
-  - mkdir incomingbuilds/linux64
-  - cp -r builds/ incomingbuilds/linux64/
+  - mkdir -p incomingbuilds/linux64
+  - cp -r builds/* incomingbuilds/linux64/
   artifacts:
     paths:
     - incomingbuilds/linux64
@@ -179,7 +183,7 @@ build_linux_x86:
   - cd ../..
   - perl external/buildscripts/build_runtime_linux.pl
   - mkdir -p incomingbuilds/linux32
-  - cp -r builds/ incomingbuilds/linux32/
+  - cp -r builds/* incomingbuilds/linux32/
   artifacts:
     paths:
     - incomingbuilds/linux32
@@ -192,6 +196,7 @@ collate_builds:
   image: ubuntu:latest
   stage: collate
   dependencies:
+  - build_android
   - build_osx_runtime
   - build_osx_classlibs
   - build_win
@@ -203,5 +208,12 @@ collate_builds:
   - apt-get update -qy && apt-get -qy upgrade
   - apt-get install -qy perl
   - apt-get install -qy zip unzip
+  - apt-get install -qy p7zip-full p7zip-rar
   script:
   - perl external/buildscripts/collect_allbuilds.pl
+  - pwd
+  - ls -al 
+  artifacts:
+    paths:
+    - collectedbuilds/builds.7z
+    expire_in: 1 week

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,209 @@
+stages:
+- build
+- collate
+
+# Build
+build_osx_runtime:
+  stage: build
+  tags:
+    - buildfarm
+    - darwin
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
+  - chmod +x external/buildscripts/bee
+  - cd external/buildscripts
+  - ./bee
+  - cd ../..
+  - perl external/buildscripts/build_runtime_osx.pl
+  - mkdir -p incomingbuilds/osx-i386
+  - cp -r builds/ incomingbuilds/osx-i386/
+  artifacts:
+    paths:
+    - incomingbuilds/osx-i386
+    expire_in: 1 week
+# Important! Do not remove this after_script!!  
+  after_script:
+    - /opt/post_build_script.sh
+
+build_osx_classlibs:
+  stage: build
+  tags:
+    - buildfarm
+    - darwin
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
+  - chmod +x external/buildscripts/bee
+  - cd external/buildscripts
+  - ./bee
+  - cd ../..
+  - perl external/buildscripts/build_classlibs_osx.pl
+  - mkdir -p incomingbuilds/classlibs
+  - cp -r ZippedClasslibs.tar.gz incomingbuilds/classlibs/
+  artifacts:
+    paths:
+    - incomingbuilds/classlibs
+    expire_in: 1 week
+# Important! Do not remove this after_script!!  
+  after_script:
+    - /opt/post_build_script.sh
+
+build_android:
+  stage: build
+  tags:
+    - buildfarm
+    - darwin
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
+  - chmod +x external/buildscripts/bee
+  - cd external/buildscripts
+  - ./bee
+  - cd ../..
+  - bash external/buildscripts/build_runtime_android.sh
+  - mkdir -p incomingbuilds/android/
+  - cp -r builds/ incomingbuilds/android/
+  artifacts:
+    paths:
+    - incomingbuilds/android
+    expire_in: 1 week
+# Important! Do not remove this after_script!!  
+  after_script:
+    - /opt/post_build_script.sh
+
+build_win:
+  stage: build
+  tags:
+  - buildfarm
+  - windows
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - cd external/buildscripts
+  - ./bee.exe
+  - cd ../..
+  - perl external/buildscripts/build_runtime_win64.pl
+  - mkdir -p incomingbuilds/win64
+  - cp -r builds/* incomingbuilds/win64/
+  artifacts:
+    paths:
+    - incomingbuilds/win64
+    expire_in: 1 week
+# Important! Do not remove this after_script!!
+  after_script:
+    - C:\Users\builduser\post_build_script.bat
+
+build_win_x86:
+  stage: build
+  tags:
+  - buildfarm
+  - windows
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - cd external/buildscripts
+  - ./bee.exe
+  - cd ../..
+  - perl external/buildscripts/build_runtime_win.pl
+  - mkdir -p incomingbuilds/win32
+  - cp -r builds/* incomingbuilds/win32/
+  artifacts:
+    paths:
+    - incomingbuilds/win32
+    expire_in: 1 week
+# Important! Do not remove this after_script!!
+  after_script:
+    - C:\Users\builduser\post_build_script.bat
+
+build_win_bare_minimum:
+  stage: build
+  tags:
+  - buildfarm
+  - windows
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - cd external/buildscripts
+  - ./bee.exe
+  - cd ../..
+  - perl external/buildscripts/build_unityscript_bareminimum_win.pl
+  - mkdir -p incomingbuilds/bareminimum
+  - cp -r builds/* incomingbuilds/bareminimum/
+  artifacts:
+    paths:
+    - incomingbuilds/bareminimum
+    expire_in: 1 week
+# Important! Do not remove this after_script!!
+  after_script:
+    - C:\Users\builduser\post_build_script.bat
+
+build_linux_x64:
+  stage: build
+  tags:
+  - buildfarm
+  - linux
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
+  - chmod +x external/buildscripts/bee
+  - cd external/buildscripts
+  - ./bee
+  - cd ../..
+  - perl external/buildscripts/build_runtime_linux.pl -build64=1
+  - mkdir incomingbuilds/linux64
+  - cp -r builds/ incomingbuilds/linux64/
+  artifacts:
+    paths:
+    - incomingbuilds/linux64
+    expire_in: 1 week
+# Important! Do not remove this after_script!!  
+  after_script:
+    - /opt/post_build_script.sh
+
+build_linux_x86:
+  stage: build
+  tags:
+  - buildfarm
+  - linux
+  when: manual
+  script:
+  - git submodule update --init --recursive
+  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
+  - chmod +x external/buildscripts/bee
+  - cd external/buildscripts
+  - ./bee
+  - cd ../..
+  - perl external/buildscripts/build_runtime_linux.pl
+  - mkdir -p incomingbuilds/linux32
+  - cp -r builds/ incomingbuilds/linux32/
+  artifacts:
+    paths:
+    - incomingbuilds/linux32
+    expire_in: 1 week
+# Important! Do not remove this after_script!!  
+  after_script:
+    - /opt/post_build_script.sh
+
+collate_builds:
+  image: ubuntu:latest
+  stage: collate
+  when: manual
+  dependencies:
+  - build_osx_runtime
+  - build_osx_classlibs
+  - build_win
+  - build_win_x86
+  - build_win_bare_minimum
+  - build_linux_x86
+  - build_linux_x64
+  before_script:
+  - apt-get update -qy && apt-get -qy upgrade
+  - apt-get install -qy perl
+  - apt-get install -qy zip unzip
+  script:
+  - perl external/buildscripts/collect_allbuilds.pl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_osx_runtime:
     - darwin
   script:
   - git submodule update --init --recursive
-  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
@@ -45,7 +44,6 @@ build_osx_classlibs:
     - darwin
   script:
   - git submodule update --init --recursive
-  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
@@ -68,7 +66,6 @@ build_android:
     - darwin
   script:
   - git submodule update --init --recursive
-  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
@@ -154,7 +151,6 @@ build_linux_x64:
   - linux
   script:
   - git submodule update --init --recursive
-  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
@@ -177,7 +173,6 @@ build_linux_x86:
   - linux
   script:
   - git submodule update --init --recursive
-  - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,18 @@
 stages:
+- runall
 - build
 - collate
+
+# This is just a config to help trigger rest of the builds
+run_all_builds:
+  image: ubuntu:latest
+  stage: runall
+  variables:
+    GIT_STRATEGY: none
+  script:
+  - pwd
+  when: manual
+  allow_failure: false
 
 # Build
 build_osx_runtime:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,6 @@ build_osx_runtime:
   tags:
     - buildfarm
     - darwin
-  when: manual
   script:
   - git submodule update --init --recursive
   - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
@@ -44,7 +43,6 @@ build_osx_classlibs:
   tags:
     - buildfarm
     - darwin
-  when: manual
   script:
   - git submodule update --init --recursive
   - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
@@ -68,7 +66,6 @@ build_android:
   tags:
     - buildfarm
     - darwin
-  when: manual
   script:
   - git submodule update --init --recursive
   - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
@@ -92,7 +89,6 @@ build_win:
   tags:
   - buildfarm
   - windows
-  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
@@ -114,7 +110,6 @@ build_win_x86:
   tags:
   - buildfarm
   - windows
-  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
@@ -136,7 +131,6 @@ build_win_bare_minimum:
   tags:
   - buildfarm
   - windows
-  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
@@ -158,7 +152,6 @@ build_linux_x64:
   tags:
   - buildfarm
   - linux
-  when: manual
   script:
   - git submodule update --init --recursive
   - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
@@ -182,7 +175,6 @@ build_linux_x86:
   tags:
   - buildfarm
   - linux
-  when: manual
   script:
   - git submodule update --init --recursive
   - echo -e "[auth]\nono.schemes=https\nono.prefix=ono.unity3d.com\nono.username=$GITLAB_UNITY_META_ONO_USER\nono.password=$GITLAB_UNITY_META_ONO_PASS\n" >> ~/.hgrc
@@ -204,7 +196,6 @@ build_linux_x86:
 collate_builds:
   image: ubuntu:latest
   stage: collate
-  when: manual
   dependencies:
   - build_osx_runtime
   - build_osx_classlibs

--- a/external/buildscripts/collect_allbuilds.pl
+++ b/external/buildscripts/collect_allbuilds.pl
@@ -51,13 +51,19 @@ close(MYFILE);
 
 system("zip -r builds.zip *") eq 0 or die("failed zipping up builds");
 
-if($^O eq "linux")
+my $externalzip = "$monoroot/../../mono-build-deps/build/7z/linux64/7za";
+
+if($^O eq "linux" || $^O eq 'darwin')
 {
-	system("$monoroot/../../mono-build-deps/build/7z/linux64/7za a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
-}
-elsif($^O eq 'darwin')
-{
-	system("$monoroot/../../mono-build-deps/build/7z/osx/7za a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
+	if(-f $externalzip)
+	{
+		system("$externalzip a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
+	}
+	else
+	{
+		#Use 7z installed on the machine. If its not installed, please install it.
+		system("7z a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
+	}
 }
 else
 {


### PR DESCRIPTION
- Adds build configs for required platforms
- Adds a run_all build trigger
- Uses bee to get artifacts from stevedore instead of closing mono-build-deps in ono (this seems significantly faster!) 

I want to get this out to review. I will only merge after pipeline succeeds and after I test the builds.zip in Unity.

This is branched from @joncham's original gitlab ci changes on `unity-master-gitlab-ci` branch.





