### PR TITLE
Scripting memory capture static field byte reporting legacy bugfix

### DIFF
--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -11,7 +11,7 @@
 #include <libgc/include/gc.h>
 #include <libgc/include/private/gc_priv.h>
 #include <mono/metadata/gc-internal.h>
-
+#include <mono/metadata/mono-debug-debugger.h>
 #include <glib.h>
 
 typedef struct CollectMetadataContext
@@ -166,7 +166,8 @@ static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 		}
 
 		vtable = mono_class_try_get_vtable(mono_domain_get(), klass);
-		statics_data = vtable ? vtable->data : NULL;
+		statics_data = vtable ? mono_vtable_get_static_field_data(vtable) : NULL;
+
 		type->staticsSize = statics_data ? mono_class_data_size(klass) : 0;
 		type->statics = NULL;
 

--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -166,8 +166,7 @@ static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 		}
 
 		vtable = mono_class_try_get_vtable(mono_domain_get(), klass);
-		statics_data = vtable ? mono_vtable_get_static_field_data(vtable) : NULL;
-
+		statics_data = vtable ? vtable->data : NULL;
 		type->staticsSize = statics_data ? mono_class_data_size(klass) : 0;
 		type->statics = NULL;
 

--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -21,22 +21,38 @@ typedef struct CollectMetadataContext
 	MonoMetadataSnapshot* metadata;
 } CollectMetadataContext;
 
-static void ContextInsertClass(CollectMetadataContext* context, MonoClass* klass)
+static void ContextRecurseClassData(CollectMetadataContext* context, MonoClass* klass)
 {
 	gpointer orig_key, value;
+	gpointer iter = NULL;
+	MonoClassField *field = NULL;
+	int fieldCount;
+
 	/* use g_hash_table_lookup_extended as it returns boolean to indicate if value was found.
-	 * If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
-	 * that 0 is a valid class index and was confusing our logic.
+	* If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
+	* that 0 is a valid class index and was confusing our logic.
 	*/
-	if (klass->inited && !g_hash_table_lookup_extended (context->allTypes, klass, &orig_key, &value))
-		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER (context->currentIndex++));
+	if (!g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
+		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER(context->currentIndex++));
+
+		fieldCount = mono_class_num_fields(klass);
+
+		if (fieldCount > 0) {
+			while ((field = mono_class_get_fields(klass, &iter))) {
+				MonoClass *fieldKlass = mono_class_from_mono_type(field->type);
+
+				if (fieldKlass != klass)
+					ContextRecurseClassData(context, fieldKlass);
+			}
+		}
+	}
 }
 
 static void CollectHashMapClass(gpointer key, gpointer value, gpointer user_data)
 {
 	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
 	MonoClass* klass = (MonoClass*)value;
-	ContextInsertClass(context, klass);
+	ContextRecurseClassData(context, klass);
 }
 
 static void CollectHashMapListClasses(gpointer key, gpointer value, gpointer user_data)
@@ -47,7 +63,7 @@ static void CollectHashMapListClasses(gpointer key, gpointer value, gpointer use
 	while (list != NULL) 
 	{
 		MonoClass* klass = (MonoClass*)list->data;
-		ContextInsertClass(context, klass);
+		ContextRecurseClassData(context, klass);
 
 		list = g_slist_next(list);
 	}
@@ -59,7 +75,7 @@ static void CollectGenericClass(gpointer value, gpointer user_data)
 	MonoGenericClass* genericClass = (MonoGenericClass*)value;
 
 	if(genericClass->cached_class != NULL)
-		ContextInsertClass(context, genericClass->cached_class);
+		ContextRecurseClassData(context, genericClass->cached_class);
 }
 
 static void CollectAssemblyMetaData (MonoAssembly *assembly, void *user_data)
@@ -72,7 +88,7 @@ static void CollectAssemblyMetaData (MonoAssembly *assembly, void *user_data)
 	for(i = 0; i < tdef->rows-1; ++i)
 	{
 		MonoClass* klass = mono_class_get (image, (i + 2) | MONO_TOKEN_TYPE_DEF);
-		ContextInsertClass(context, klass);
+		ContextRecurseClassData(context, klass);
 	}
 
     if(image->array_cache)
@@ -95,49 +111,54 @@ static int FindClassIndex(GHashTable* hashTable, MonoClass* klass)
 	return GPOINTER_TO_INT(value);
 }
 
-static void AddMetadataType (gpointer key, gpointer value, gpointer user_data)
+static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 {
-	MonoClass* klass = (MonoClass*)key;
-	int index = GPOINTER_TO_INT(value);
-	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
-	MonoMetadataSnapshot* metadata = context->metadata;
-	MonoMetadataType* type = &metadata->types[index];
+	MonoClass *klass = (MonoClass *)key;
 
-	if(klass->rank > 0)
-	{
+	int index = GPOINTER_TO_INT(value);
+	CollectMetadataContext *context = (CollectMetadataContext *)user_data;
+	MonoMetadataSnapshot *metadata = context->metadata;
+	MonoMetadataType *type = &metadata->types[index];
+
+	if (klass->rank > 0) {
 		type->flags = (MonoMetadataTypeFlags)(kArray | (kArrayRankMask & (klass->rank << 16)));
 		type->baseOrElementTypeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(klass));
 	}
-	else
-	{
+	else {
 		gpointer iter = NULL;
 		int fieldCount = 0;
-		MonoClassField* field;
-		MonoClass* baseClass;
-		MonoVTable* vtable;
+		MonoClassField *field;
+		MonoClass *baseClass;
+		MonoVTable *vtable;
+		void *statics_data;
 
 		type->flags = (klass->valuetype || klass->byval_arg.type == MONO_TYPE_PTR) ? kValueType : kNone;
 		type->fieldCount = 0;
+		fieldCount = mono_class_num_fields(klass);
+		if (fieldCount > 0) {
+			type->fields = g_new(MonoMetadataField, fieldCount);
 
-		if(mono_class_num_fields(klass) > 0)
-		{
-			type->fields = g_new(MonoMetadataField, mono_class_num_fields(klass));
+			while ((field = mono_class_get_fields(klass, &iter))) {
+				MonoMetadataField *metaField = &type->fields[type->fieldCount];
+				MonoClass *typeKlass = mono_class_from_mono_type(field->type);
 
-			while ((field = mono_class_get_fields (klass, &iter))) 
-			{
-				MonoMetadataField* metaField = &type->fields[type->fieldCount];
-				metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_from_mono_type(field->type));
+				if (typeKlass->rank > 0)
+					metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(typeKlass));
+				else
+					metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
 
 				// This will happen if fields type is not initialized
 				// It's OK to skip it, because it means the field is guaranteed to be null on any object
-				if (metaField->typeIndex == -1)
+				if (metaField->typeIndex == -1) {
 					continue;
+				}
 
 				// literals have no actual storage, and are not relevant in this context.
-				if((field->type->attrs & FIELD_ATTRIBUTE_LITERAL) != 0)
+				if ((field->type->attrs & FIELD_ATTRIBUTE_LITERAL) != 0)
 					continue;
 
 				metaField->isStatic = (field->type->attrs & FIELD_ATTRIBUTE_STATIC) != 0;
+
 				metaField->offset = field->offset;
 				metaField->name = field->name;
 				type->fieldCount++;
@@ -145,14 +166,14 @@ static void AddMetadataType (gpointer key, gpointer value, gpointer user_data)
 		}
 
 		vtable = mono_class_try_get_vtable(mono_domain_get(), klass);
+		statics_data = vtable ? mono_vtable_get_static_field_data(vtable) : NULL;
 
-		type->staticsSize = vtable ? mono_class_data_size(klass) : 0; // Correct?
+		type->staticsSize = statics_data ? mono_class_data_size(klass) : 0;
 		type->statics = NULL;
 
-		if (type->staticsSize > 0 && vtable && vtable->data)
-		{
+		if (type->staticsSize > 0) {
 			type->statics = g_new0(uint8_t, type->staticsSize);
-			memcpy(type->statics, vtable->data, type->staticsSize);
+			memcpy(type->statics, statics_data, type->staticsSize);
 		}
 
 		baseClass = mono_class_get_parent(klass);
@@ -164,7 +185,6 @@ static void AddMetadataType (gpointer key, gpointer value, gpointer user_data)
 	type->typeInfoAddress = (uint64_t)klass;
 	type->size = (klass->valuetype) != 0 ? (mono_class_instance_size(klass) - sizeof(MonoObject)) : mono_class_instance_size(klass);
 }
-
 
 static void CollectMetadata(MonoMetadataSnapshot* metadata)
 {


### PR DESCRIPTION
*mirrored walking of all class fields from Mono 4.0 pr (#1065)
*added missing include which caused the function signature to be int for mono_vtable_get_static_field_data  thus down casting the pointer from 64 bit to 32 bit and causing crashes (there might be some fog bugz cases related to this...I'll add them to the unity repo PR as I verify)