### PR TITLE
[Memory Snapshot][2018.2] Scripting memory capture cumulative improvements

### DIFF
--- a/mono/metadata/mempool.c
+++ b/mono/metadata/mempool.c
@@ -474,7 +474,7 @@ void mono_mempool_foreach_chunk(MonoMemPool* pool, mono_mempool_chunk_proc callb
 	while (current)
 	{
 		gpointer start = (guint8*)current + sizeof(MonoMemPool);
-		gpointer end = (guint8*)start + current->size;
+		gpointer end = (guint8*)current + current->size;
 
 		callback(start, end, user_data);
 		current = current->next;

--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -32,7 +32,7 @@ static void ContextRecurseClassData(CollectMetadataContext* context, MonoClass* 
 	* If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
 	* that 0 is a valid class index and was confusing our logic.
 	*/
-	if (!g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
+	if (klass->inited && !g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
 		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER(context->currentIndex++));
 
 		fieldCount = mono_class_num_fields(klass);
@@ -141,11 +141,8 @@ static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 			while ((field = mono_class_get_fields(klass, &iter))) {
 				MonoMetadataField *metaField = &type->fields[type->fieldCount];
 				MonoClass *typeKlass = mono_class_from_mono_type(field->type);
-
-				if (typeKlass->rank > 0)
-					metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(typeKlass));
-				else
-					metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
+				
+				metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
 
 				// This will happen if fields type is not initialized
 				// It's OK to skip it, because it means the field is guaranteed to be null on any object

--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -11,7 +11,7 @@
 #include <libgc/include/gc.h>
 #include <libgc/include/private/gc_priv.h>
 #include <mono/metadata/gc-internal.h>
-
+#include <mono/metadata/mono-debug-debugger.h>
 #include <glib.h>
 
 typedef struct CollectMetadataContext
@@ -21,22 +21,38 @@ typedef struct CollectMetadataContext
 	MonoMetadataSnapshot* metadata;
 } CollectMetadataContext;
 
-static void ContextInsertClass(CollectMetadataContext* context, MonoClass* klass)
+static void ContextRecurseClassData(CollectMetadataContext* context, MonoClass* klass)
 {
 	gpointer orig_key, value;
+	gpointer iter = NULL;
+	MonoClassField *field = NULL;
+	int fieldCount;
+
 	/* use g_hash_table_lookup_extended as it returns boolean to indicate if value was found.
-	 * If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
-	 * that 0 is a valid class index and was confusing our logic.
+	* If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
+	* that 0 is a valid class index and was confusing our logic.
 	*/
-	if (klass->inited && !g_hash_table_lookup_extended (context->allTypes, klass, &orig_key, &value))
-		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER (context->currentIndex++));
+	if (!g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
+		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER(context->currentIndex++));
+
+		fieldCount = mono_class_num_fields(klass);
+
+		if (fieldCount > 0) {
+			while ((field = mono_class_get_fields(klass, &iter))) {
+				MonoClass *fieldKlass = mono_class_from_mono_type(field->type);
+
+				if (fieldKlass != klass)
+					ContextRecurseClassData(context, fieldKlass);
+			}
+		}
+	}
 }
 
 static void CollectHashMapClass(gpointer key, gpointer value, gpointer user_data)
 {
 	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
 	MonoClass* klass = (MonoClass*)value;
-	ContextInsertClass(context, klass);
+	ContextRecurseClassData(context, klass);
 }
 
 static void CollectHashMapListClasses(gpointer key, gpointer value, gpointer user_data)
@@ -44,10 +60,10 @@ static void CollectHashMapListClasses(gpointer key, gpointer value, gpointer use
 	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
 	GSList* list = (GSList*)value;
 
-	while (list != NULL) 
+	while (list != NULL)
 	{
 		MonoClass* klass = (MonoClass*)list->data;
-		ContextInsertClass(context, klass);
+		ContextRecurseClassData(context, klass);
 
 		list = g_slist_next(list);
 	}
@@ -58,86 +74,91 @@ static void CollectGenericClass(gpointer value, gpointer user_data)
 	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
 	MonoGenericClass* genericClass = (MonoGenericClass*)value;
 
-	if(genericClass->cached_class != NULL)
-		ContextInsertClass(context, genericClass->cached_class);
+	if (genericClass->cached_class != NULL)
+		ContextRecurseClassData(context, genericClass->cached_class);
 }
 
-static void CollectAssemblyMetaData (MonoAssembly *assembly, void *user_data)
+static void CollectAssemblyMetaData(MonoAssembly *assembly, void *user_data)
 {
 	int i;
 	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
 	MonoImage* image = mono_assembly_get_image(assembly);
-	MonoTableInfo *tdef = &image->tables [MONO_TABLE_TYPEDEF];
+	MonoTableInfo *tdef = &image->tables[MONO_TABLE_TYPEDEF];
 
-	for(i = 0; i < tdef->rows-1; ++i)
+	for (i = 0; i < tdef->rows - 1; ++i)
 	{
-		MonoClass* klass = mono_class_get (image, (i + 2) | MONO_TOKEN_TYPE_DEF);
-		ContextInsertClass(context, klass);
+		MonoClass* klass = mono_class_get(image, (i + 2) | MONO_TOKEN_TYPE_DEF);
+		ContextRecurseClassData(context, klass);
 	}
 
-    if(image->array_cache)
-        g_hash_table_foreach(image->array_cache, CollectHashMapListClasses, user_data);
+	if (image->array_cache)
+		g_hash_table_foreach(image->array_cache, CollectHashMapListClasses, user_data);
 
-    if(image->szarray_cache)
-        g_hash_table_foreach(image->szarray_cache, CollectHashMapClass, user_data);
+	if (image->szarray_cache)
+		g_hash_table_foreach(image->szarray_cache, CollectHashMapClass, user_data);
 
-    if(image->ptr_cache)
-        g_hash_table_foreach(image->ptr_cache, CollectHashMapClass, user_data);
+	if (image->ptr_cache)
+		g_hash_table_foreach(image->ptr_cache, CollectHashMapClass, user_data);
 }
 
 static int FindClassIndex(GHashTable* hashTable, MonoClass* klass)
 {
 	gpointer orig_key, value;
 
-	if(!g_hash_table_lookup_extended (hashTable, klass, &orig_key, &value))
+	if (!g_hash_table_lookup_extended(hashTable, klass, &orig_key, &value))
 		return -1;
 
 	return GPOINTER_TO_INT(value);
 }
 
-static void AddMetadataType (gpointer key, gpointer value, gpointer user_data)
+static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 {
-	MonoClass* klass = (MonoClass*)key;
-	int index = GPOINTER_TO_INT(value);
-	CollectMetadataContext* context = (CollectMetadataContext*)user_data;
-	MonoMetadataSnapshot* metadata = context->metadata;
-	MonoMetadataType* type = &metadata->types[index];
+	MonoClass *klass = (MonoClass *)key;
 
-	if(klass->rank > 0)
-	{
+	int index = GPOINTER_TO_INT(value);
+	CollectMetadataContext *context = (CollectMetadataContext *)user_data;
+	MonoMetadataSnapshot *metadata = context->metadata;
+	MonoMetadataType *type = &metadata->types[index];
+
+	if (klass->rank > 0) {
 		type->flags = (MonoMetadataTypeFlags)(kArray | (kArrayRankMask & (klass->rank << 16)));
 		type->baseOrElementTypeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(klass));
 	}
-	else
-	{
+	else {
 		gpointer iter = NULL;
 		int fieldCount = 0;
-		MonoClassField* field;
-		MonoClass* baseClass;
-		MonoVTable* vtable;
+		MonoClassField *field;
+		MonoClass *baseClass;
+		MonoVTable *vtable;
+		void *statics_data;
 
 		type->flags = (klass->valuetype || klass->byval_arg.type == MONO_TYPE_PTR) ? kValueType : kNone;
 		type->fieldCount = 0;
+		fieldCount = mono_class_num_fields(klass);
+		if (fieldCount > 0) {
+			type->fields = g_new(MonoMetadataField, fieldCount);
 
-		if(mono_class_num_fields(klass) > 0)
-		{
-			type->fields = g_new(MonoMetadataField, mono_class_num_fields(klass));
+			while ((field = mono_class_get_fields(klass, &iter))) {
+				MonoMetadataField *metaField = &type->fields[type->fieldCount];
+				MonoClass *typeKlass = mono_class_from_mono_type(field->type);
 
-			while ((field = mono_class_get_fields (klass, &iter))) 
-			{
-				MonoMetadataField* metaField = &type->fields[type->fieldCount];
-				metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_from_mono_type(field->type));
+				if (typeKlass->rank > 0)
+					metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(typeKlass));
+				else
+					metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
 
 				// This will happen if fields type is not initialized
 				// It's OK to skip it, because it means the field is guaranteed to be null on any object
-				if (metaField->typeIndex == -1)
+				if (metaField->typeIndex == -1) {
 					continue;
+				}
 
 				// literals have no actual storage, and are not relevant in this context.
-				if((field->type->attrs & FIELD_ATTRIBUTE_LITERAL) != 0)
+				if ((field->type->attrs & FIELD_ATTRIBUTE_LITERAL) != 0)
 					continue;
 
 				metaField->isStatic = (field->type->attrs & FIELD_ATTRIBUTE_STATIC) != 0;
+
 				metaField->offset = field->offset;
 				metaField->name = field->name;
 				type->fieldCount++;
@@ -145,14 +166,14 @@ static void AddMetadataType (gpointer key, gpointer value, gpointer user_data)
 		}
 
 		vtable = mono_class_try_get_vtable(mono_domain_get(), klass);
+		statics_data = vtable ? mono_vtable_get_static_field_data(vtable) : NULL;
 
-		type->staticsSize = vtable ? mono_class_data_size(klass) : 0; // Correct?
+		type->staticsSize = statics_data ? mono_class_data_size(klass) : 0;
 		type->statics = NULL;
 
-		if (type->staticsSize > 0 && vtable && vtable->data)
-		{
+		if (type->staticsSize > 0) {
 			type->statics = g_new0(uint8_t, type->staticsSize);
-			memcpy(type->statics, vtable->data, type->staticsSize);
+			memcpy(type->statics, statics_data, type->staticsSize);
 		}
 
 		baseClass = mono_class_get_parent(klass);
@@ -165,7 +186,6 @@ static void AddMetadataType (gpointer key, gpointer value, gpointer user_data)
 	type->size = (klass->valuetype) != 0 ? (mono_class_instance_size(klass) - sizeof(MonoObject)) : mono_class_instance_size(klass);
 }
 
-
 static void CollectMetadata(MonoMetadataSnapshot* metadata)
 {
 	CollectMetadataContext context;
@@ -173,7 +193,7 @@ static void CollectMetadata(MonoMetadataSnapshot* metadata)
 	context.allTypes = g_hash_table_new(NULL, NULL);
 	context.currentIndex = 0;
 	context.metadata = metadata;
-	
+
 	mono_assembly_foreach((GFunc)CollectAssemblyMetaData, &context);
 
 	mono_metadata_generic_class_foreach(CollectGenericClass, &context);
@@ -212,7 +232,7 @@ static void AllocateMemoryForSection(void* context, void* sectionStart, void* se
 	MonoManagedMemorySection* section = ctx->currentSection;
 
 	section->sectionStartAddress = (uint64_t)sectionStart;
-	sectionSize = (uint8_t*)(sectionEnd) - (uint8_t*)(sectionStart);
+	sectionSize = (uint8_t*)(sectionEnd)-(uint8_t*)(sectionStart);
 
 	section->sectionSize = (uint32_t)(sectionSize);
 	section->sectionBytes = g_new(uint8_t, section->sectionSize);
@@ -231,7 +251,7 @@ static void CopyHeapSection(void* context, void* sectionStart, void* sectionEnd)
 	MonoManagedMemorySection* section = ctx->currentSection;
 
 	g_assert(section->sectionStartAddress == (uint64_t)(sectionStart));
-	g_assert(section->sectionSize == (uint8_t*)(sectionEnd) - (uint8_t*)(sectionStart));
+	g_assert(section->sectionSize == (uint8_t*)(sectionEnd)-(uint8_t*)(sectionStart));
 	memcpy(section->sectionBytes, sectionStart, section->sectionSize);
 
 	ctx->currentSection++;
@@ -242,7 +262,7 @@ static void CopyMemPoolChunk(void* chunkStart, void* chunkEnd, void* context)
 	CopyHeapSection(context, chunkStart, chunkEnd);
 }
 
-static void AddImageMemoryPoolChunkCount (MonoAssembly *assembly, MonoManagedHeap* heap)
+static void AddImageMemoryPoolChunkCount(MonoAssembly *assembly, MonoManagedHeap* heap)
 {
 	heap->sectionCount += MonoMemPoolNumChunks(assembly->image->mempool);
 }
@@ -264,12 +284,10 @@ static void AllocateMemoryForImageMemPool(MonoAssembly *assembly, void *user_dat
 {
 	MonoImage* image = assembly->image;
 
-	mono_image_lock (image);
 	mono_mempool_foreach_chunk(image->mempool, AllocateMemoryForMemPoolChunk, user_data);
-	mono_image_unlock (image);
 }
 
-static void* CaptureHeapInfo(void* monoManagedHeap)
+static void CaptureHeapInfo(void* monoManagedHeap)
 {
 	MonoManagedHeap* heap = (MonoManagedHeap*)monoManagedHeap;
 	MonoDomain* domain = mono_domain_get();
@@ -289,13 +307,10 @@ static void* CaptureHeapInfo(void* monoManagedHeap)
 	// Allocate memory for each heap section
 	GC_foreach_heap_section(&iterationContext, AllocateMemoryForSection);
 	// Allocate memory for the domain mem pool chunk
-	mono_domain_lock (domain);
 	mono_mempool_foreach_chunk(domain->mp, AllocateMemoryForMemPoolChunk, &iterationContext);
-	mono_domain_unlock(domain);
 	// Allocate memory for each image mem pool chunk
-	mono_assembly_foreach((GFunc)AllocateMemoryForImageMemPool,  &iterationContext);
+	mono_assembly_foreach((GFunc)AllocateMemoryForImageMemPool, &iterationContext);
 
-	return NULL;
 }
 
 static void FreeMonoManagedHeap(MonoManagedHeap* heap)
@@ -319,7 +334,7 @@ typedef struct VerifyHeapSectionStillValidIterationContext
 static void VerifyHeapSectionIsStillValid(void* context, void* sectionStart, void* sectionEnd)
 {
 	VerifyHeapSectionStillValidIterationContext* iterationContext = (VerifyHeapSectionStillValidIterationContext*)context;
-	if (iterationContext->currentSection->sectionSize != (uint8_t*)(sectionEnd) - (uint8_t*)(sectionStart))
+	if (iterationContext->currentSection->sectionSize != (uint8_t*)(sectionEnd)-(uint8_t*)(sectionStart))
 		iterationContext->wasValid = FALSE;
 	else if (iterationContext->currentSection->sectionStartAddress != (uint64_t)(sectionStart))
 		iterationContext->wasValid = FALSE;
@@ -344,7 +359,7 @@ static gboolean MonoManagedHeapStillValid(MonoManagedHeap* heap)
 	iterationContext.wasValid = TRUE;
 
 	GC_foreach_heap_section(&iterationContext, VerifyHeapSectionIsStillValid);
-	
+
 	return iterationContext.wasValid;
 }
 
@@ -364,25 +379,12 @@ static void CaptureManagedHeap(MonoManagedHeap* heap)
 	MonoDomain* domain = mono_domain_get();
 	SectionIterationContext iterationContext;
 
-	while(TRUE)
-	{
-		GC_call_with_alloc_lock(CaptureHeapInfo, heap);
-		GC_stop_world_external();
+	CaptureHeapInfo(heap);
 
-		if (MonoManagedHeapStillValid(heap))
-			break;
-
-		GC_start_world_external();
-
-		FreeMonoManagedHeap(heap);
-	}
-	
 	iterationContext.currentSection = heap->sections;
 	GC_foreach_heap_section(&iterationContext, CopyHeapSection);
 
 	mono_mempool_foreach_chunk(domain->mp, CopyMemPoolChunk, &iterationContext);
-
-	GC_start_world_external();
 }
 
 static void GCHandleIterationCallback(MonoObject* managedObject, GList** managedObjects)
@@ -426,12 +428,16 @@ static void FillRuntimeInformation(MonoRuntimeInformation* runtimeInfo)
 MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot()
 {
 	MonoManagedMemorySnapshot* snapshot;
+
+	GC_stop_world_external();
 	snapshot = g_new0(MonoManagedMemorySnapshot, 1);
 
 	CollectMetadata(&snapshot->metadata);
 	CaptureManagedHeap(&snapshot->heap);
 	CaptureGCHandleTargets(&snapshot->gcHandles);
 	FillRuntimeInformation(&snapshot->runtimeInformation);
+
+	GC_start_world_external();
 
 	return snapshot;
 }


### PR DESCRIPTION
*fixed incorrect offsetting when enumerating memory blocks
*improved snapshotting process by properly stopping the world before any collection will be done
*we now walk all class fields and report them
*fixed a crash where result of "mono_vtable_get_static_field_data(vtable)" would downcast a 64 bit pointer address to a 32 bit one due to the function's signature being treated as int.