### PR TITLE
[Memory Snapshot][Legacy] Metadata crawling, use only initialized types

### DIFF
--- a/unity/unity_memory_info.c
+++ b/unity/unity_memory_info.c
@@ -32,7 +32,7 @@ static void ContextRecurseClassData(CollectMetadataContext* context, MonoClass* 
 	* If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
 	* that 0 is a valid class index and was confusing our logic.
 	*/
-	if (!g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
+	if (klass->inited && !g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
 		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER(context->currentIndex++));
 
 		fieldCount = mono_class_num_fields(klass);
@@ -141,11 +141,8 @@ static void AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 			while ((field = mono_class_get_fields(klass, &iter))) {
 				MonoMetadataField *metaField = &type->fields[type->fieldCount];
 				MonoClass *typeKlass = mono_class_from_mono_type(field->type);
-
-				if (typeKlass->rank > 0)
-					metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(typeKlass));
-				else
-					metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
+				
+				metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
 
 				// This will happen if fields type is not initialized
 				// It's OK to skip it, because it means the field is guaranteed to be null on any object


### PR DESCRIPTION
*re-enabled filtering of uninitialized classes
*fixed incorrect display of array type fields missing '[]'