### PR TITLE
[Memory Snapshot][2018.3] Metadata crawling, use only initialized types

### DIFF
--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -36,7 +36,7 @@ ContextRecurseClassData(CollectMetadataContext *context, MonoClass *klass)
 	* If we use g_hash_table_lookup it returns the value which we were comparing to NULL. The problem is
 	* that 0 is a valid class index and was confusing our logic.
 	*/
-	if (!g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
+	if (klass->inited && !g_hash_table_lookup_extended(context->allTypes, klass, &orig_key, &value)) {
 		g_hash_table_insert(context->allTypes, klass, GINT_TO_POINTER(context->currentIndex++));
 
 		fieldCount = mono_class_num_fields(klass);
@@ -184,10 +184,7 @@ AddMetadataType(gpointer key, gpointer value, gpointer user_data)
 				MonoMetadataField *metaField = &type->fields[type->fieldCount];
 				MonoClass *typeKlass = mono_class_from_mono_type(field->type);
 
-				if (typeKlass->rank > 0)
-					metaField->typeIndex = FindClassIndex(context->allTypes, mono_class_get_element_class(typeKlass));
-				else
-					metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
+				metaField->typeIndex = FindClassIndex(context->allTypes, typeKlass);
 
 				// This will happen if fields type is not initialized
 				// It's OK to skip it, because it means the field is guaranteed to be null on any object


### PR DESCRIPTION
backport of pr  #1086
*fix incorrect formatting for array fields missing '[]'
*revert to filtering uninitialized classes out*