### PR TITLE
[android] Update NDK to r18b.

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -700,7 +700,7 @@ if ($build)
 		if($^O eq "linux")
 		{
 			$ndkName = "android-ndk/android-ndk-$ndkVersion-linux-x86_64.zip";
-			$sevenZip = "$externalBuildDeps/7z/win64/7za.exe";
+			$sevenZip = "$externalBuildDeps/7z/linux64/7za";
 		}
 		elsif($^O eq "darwin")
 		{
@@ -710,7 +710,7 @@ if ($build)
 		else
 		{
 			$ndkName = "android-ndk/android-ndk-$ndkVersion-windows-x86.zip";
-			$sevenZip = "$externalBuildDeps/7z/linux64/7za";
+			$sevenZip = "$externalBuildDeps/7z/win64/7za.exe";
 		}
 
 		my $depsNdkArchive = "$externalBuildDeps/$ndkName";

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -652,7 +652,7 @@ if ($build)
 			die("mono build deps are required and the directory was not found : $externalBuildDeps\n");
 		}
 
-		my $ndkVersion = "r16b";
+		my $ndkVersion = "r18b";
 		my $apiLevel = 16;
 		my $hostTriple = "";
 		my $platformRootPostfix = "";
@@ -696,21 +696,26 @@ if ($build)
 		print(">>> Android NDK Version = $ndkVersion\n");
 
 		my $ndkName = "";
+		my $sevenZip = "";
 		if($^O eq "linux")
 		{
-			$ndkName = "android-ndk-$ndkVersion-linux/android-ndk-$ndkVersion-linux-x86_64.zip";
+			$ndkName = "android-ndk/android-ndk-$ndkVersion-linux-x86_64.zip";
+			$sevenZip = "$externalBuildDeps/7z/win64/7za.exe";
 		}
 		elsif($^O eq "darwin")
 		{
-			$ndkName = "android-ndk-$ndkVersion-darwin/android-ndk-$ndkVersion-darwin-x86_64.zip";
+			$ndkName = "android-ndk/android-ndk-$ndkVersion-darwin-x86_64.zip";
+			$sevenZip = "$externalBuildDeps/7z/osx/7za";
 		}
 		else
 		{
-			$ndkName = "android-$ndkVersion-r16b-windows/android-ndk-$ndkVersion-windows-x86.zip";
+			$ndkName = "android-ndk/android-ndk-$ndkVersion-windows-x86.zip";
+			$sevenZip = "$externalBuildDeps/7z/linux64/7za";
 		}
 
 		my $depsNdkArchive = "$externalBuildDeps/$ndkName";
-		my $depsNdkFinal = "$externalBuildDeps/android-ndk-$ndkVersion";
+		my $depsNdkDir = "$externalBuildDeps/android-ndk";
+		my $depsNdkFinal = "$depsNdkDir/android-ndk-$ndkVersion";
 
 		print(">>> Android NDK Archive = $depsNdkArchive\n");
 		print(">>> Android NDK Extraction Destination = $depsNdkFinal\n");
@@ -728,9 +733,8 @@ if ($build)
 
 			if ($runningOnWindows)
 			{
-				my $sevenZip = "$externalBuildDeps/7z/win64/7za.exe";
 				my $winDepsNdkArchive = `cygpath -w $depsNdkArchive`;
-				my $winDepsNdkExtract = `cygpath -w $externalBuildDeps`;
+				my $winDepsNdkExtract = `cygpath -w $depsNdkDir`;
 
 				# clean up trailing new lines that end up in the output from cygpath.  If left, they cause problems down the line
 				# for 7zip
@@ -741,24 +745,7 @@ if ($build)
 			}
 			else
 			{
-				my ($name,$path,$suffix) = fileparse($depsNdkArchive, qr/\.[^.]*/);
-
-				print(">>> Android NDK Extension = $suffix\n");
-
-				# Versions after r11 use .zip extension.  Currently we use r10e, but let's support the .zip extension in case
-				# we upgrade down the road
-				if (lc $suffix eq '.zip')
-				{
-					system("unzip", "-q", $depsNdkArchive, "-d", $externalBuildDeps);
-				}
-				elsif (lc $suffix eq '.bin')
-				{	chmod(0755, $depsNdkArchive);
-					system($depsNdkArchive, "-o$externalBuildDeps");
-				}
-				else
-				{
-					die "Unknown file extension '" . $suffix . "'\n";
-				}
+				system($sevenZip, "x", "$depsNdkArchive", "-o$depsNdkDir");
 			}
 		}
 


### PR DESCRIPTION
Please don't merge this just yet as we are likely to end up using r18c or some other version.
Depends on: https://ono.unity3d.com/unity-extra/mono-build-deps/pull-request/78502/_/android-ndk-r18b-2
I've only done some simple testing in Unity but almost no changes had to be made so I think this should be fine. The reason for no changes is because Mono is not using standard C++ library.