### PR TITLE
Add ability to redirect mono stdout logging to unity's vprintf function.

### DIFF
--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -279,13 +279,13 @@ g_set_printerr_handler (GPrintFunc func)
 static void
 unity_vprintf_GPrintFunc_adapter (const gchar *string)
 {
-	our_vprintf(string, NULL);
+	our_vprintf("%s", string);
 }
 
 static void
 unity_vprintf_GLogFunc_adapter (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data)
 {
-	our_vprintf(message, NULL);
+	our_vprintf("%s", message);
 }
 
 // Redirect all stdout output to unity vprintf function

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -276,23 +276,31 @@ g_set_printerr_handler (GPrintFunc func)
 	return old;
 }
 
+void wrap_our_vprintf(const gchar *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+	our_vprintf (format, args);
+	va_end (args);
+}
+
 static void
 unity_vprintf_GPrintFunc_adapter (const gchar *string)
 {
-	our_vprintf("%s", string);
+	wrap_our_vprintf ("%s", string);
 }
 
 static void
 unity_vprintf_GLogFunc_adapter (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data)
 {
-	our_vprintf("%s", message);
+	wrap_our_vprintf ("%s", message);
 }
 
 // Redirect all stdout output to unity vprintf function
 void set_vprintf_func(vprintf_func func)
 {
 	our_vprintf = func;
-	g_set_print_handler(unity_vprintf_GPrintFunc_adapter);
-	g_log_set_default_handler(unity_vprintf_GLogFunc_adapter, NULL);
+	g_set_print_handler (unity_vprintf_GPrintFunc_adapter);
+	g_log_set_default_handler (unity_vprintf_GLogFunc_adapter, NULL);
 }
 

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -82,7 +82,7 @@ mono_unity_socket_security_enabled_set (gboolean enabled)
 
 void mono_unity_set_vprintf_func (vprintf_func func)
 {
-	//set_vprintf_func (func);
+	set_vprintf_func (func);
 }
 
 MONO_API gboolean


### PR DESCRIPTION
Resolves bug: https://fogbugz.unity3d.com/f/cases/1075947/