### PR TITLE
Add option to use stevedore or ono for external build deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,7 +165,6 @@ build_win_bare_minimum:
   tags:
   - buildfarm
   - windows
-  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,19 @@ run_all_builds:
 build_osx_runtime:
   stage: build
   tags:
-    - buildfarm
-    - darwin
+    - bokken-job
+  variables:
+    BOKKEN_VM: build_osx_runtime_vm
+    BOKKEN_JOB: |
+      resources:
+        - name: build_osx_runtime_vm
+          image: buildfarm/mac:latest
+          flavor: m1.mac
+          type: Unity::VM::osx
+          num_instances: 1
+          config:
+            env_vars:
+              - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   when: manual
   script:
   - git submodule update --init --recursive
@@ -41,8 +52,19 @@ build_osx_runtime:
 build_osx_classlibs:
   stage: build
   tags:
-    - buildfarm
-    - darwin
+    - bokken-job
+  variables:
+    BOKKEN_VM: build_osx_classlibs_vm
+    BOKKEN_JOB: |
+      resources:
+        - name: build_osx_classlibs_vm
+          image: buildfarm/mac:latest
+          flavor: m1.mac
+          type: Unity::VM::osx
+          num_instances: 1
+          config:
+            env_vars:
+              - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   when: manual
   script:
   - git submodule update --init --recursive
@@ -68,8 +90,19 @@ build_osx_classlibs:
 build_android:
   stage: build
   tags:
-    - buildfarm
-    - darwin
+    - bokken-job
+  variables:
+    BOKKEN_VM: build_android_vm
+    BOKKEN_JOB: |
+      resources:
+        - name: build_android_vm
+          image: buildfarm/mac:latest
+          flavor: m1.mac
+          type: Unity::VM::osx
+          num_instances: 1
+          config:
+            env_vars:
+              - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   when: manual
   script:
   - git submodule update --init --recursive

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,6 @@ build_osx_runtime:
           config:
             env_vars:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
-  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
@@ -65,7 +64,6 @@ build_osx_classlibs:
           config:
             env_vars:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
-  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
@@ -103,7 +101,6 @@ build_android:
           config:
             env_vars:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
-  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
@@ -126,7 +123,6 @@ build_win:
   tags:
   - buildfarm
   - windows
-  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
@@ -148,7 +144,6 @@ build_win_x86:
   tags:
   - buildfarm
   - windows
-  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
@@ -192,7 +187,6 @@ build_linux_x64:
   tags:
   - buildfarm
   - linux
-  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
@@ -215,7 +209,6 @@ build_linux_x86:
   tags:
   - buildfarm
   - linux
-  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
@@ -236,7 +229,6 @@ build_linux_x86:
 collate_builds:
   image: ubuntu:latest
   stage: collate
-  when: manual
   dependencies:
   - build_android
   - build_osx_runtime

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,13 +20,14 @@ build_osx_runtime:
   tags:
     - buildfarm
     - darwin
+  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
   - cd ../..
-  - perl external/buildscripts/build_runtime_osx.pl
+  - perl external/buildscripts/build_runtime_osx.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/osx-i386
   - cp -r builds/ incomingbuilds/osx-i386/
   artifacts:
@@ -42,13 +43,14 @@ build_osx_classlibs:
   tags:
     - buildfarm
     - darwin
+  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
   - cd ../..
-  - perl external/buildscripts/build_classlibs_osx.pl
+  - perl external/buildscripts/build_classlibs_osx.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/classlibs
   - cp -r ZippedClasslibs.tar.gz incomingbuilds/classlibs/
   - cd incomingbuilds/classlibs
@@ -68,13 +70,14 @@ build_android:
   tags:
     - buildfarm
     - darwin
+  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
   - cd ../..
-  - bash external/buildscripts/build_runtime_android.sh
+  - perl external/buildscripts/build_runtime_android.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/android/
   - cp -r builds/* incomingbuilds/android/
   artifacts:
@@ -90,12 +93,13 @@ build_win:
   tags:
   - buildfarm
   - windows
+  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
   - ./bee.exe
   - cd ../..
-  - perl external/buildscripts/build_runtime_win64.pl
+  - perl external/buildscripts/build_runtime_win64.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/win64
   - cp -r builds/* incomingbuilds/win64/
   artifacts:
@@ -111,12 +115,13 @@ build_win_x86:
   tags:
   - buildfarm
   - windows
+  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
   - ./bee.exe
   - cd ../..
-  - perl external/buildscripts/build_runtime_win.pl
+  - perl external/buildscripts/build_runtime_win.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/win32
   - cp -r builds/* incomingbuilds/win32/
   artifacts:
@@ -132,6 +137,7 @@ build_win_bare_minimum:
   tags:
   - buildfarm
   - windows
+  when: manual
   script:
   - git submodule update --init --recursive
   - cd external/buildscripts
@@ -153,13 +159,14 @@ build_linux_x64:
   tags:
   - buildfarm
   - linux
+  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
   - cd ../..
-  - perl external/buildscripts/build_runtime_linux.pl -build64=1
+  - perl external/buildscripts/build_runtime_linux.pl -build64=1 --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/linux64
   - cp -r builds/* incomingbuilds/linux64/
   artifacts:
@@ -175,13 +182,14 @@ build_linux_x86:
   tags:
   - buildfarm
   - linux
+  when: manual
   script:
   - git submodule update --init --recursive
   - chmod +x external/buildscripts/bee
   - cd external/buildscripts
   - ./bee
   - cd ../..
-  - perl external/buildscripts/build_runtime_linux.pl
+  - perl external/buildscripts/build_runtime_linux.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/linux32
   - cp -r builds/* incomingbuilds/linux32/
   artifacts:
@@ -195,6 +203,7 @@ build_linux_x86:
 collate_builds:
   image: ubuntu:latest
   stage: collate
+  when: manual
   dependencies:
   - build_android
   - build_osx_runtime

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -285,7 +285,7 @@ if ($build)
 	{
 		# Check out on the fly
 		print(">>> Checking out mono build tools extra to : $extraBuildTools\n");
-		my $repo = 'git@github.cds.internal.unity3d.com:unity/mono-build-tools-exta.git';
+		my $repo = 'git@github.cds.internal.unity3d.com:unity/mono-build-tools-extra.git';
 		print(">>> Cloning $repo at $extraBuildTools\n");
 		my $checkoutResult = system("git", "clone", "--recurse-submodules", $repo, "$extraBuildTools");
 

--- a/external/buildscripts/buildDependencies.txt
+++ b/external/buildscripts/buildDependencies.txt
@@ -2,74 +2,59 @@
 # name : <stevedore artifact name>
 # id : <stevedore artifact id>
 # repo : <stevedore repo name (can be testing/public/unityinternal)> 
-# files : <folder and/or comma-separated list of files downloaded and unpacked>
 
 name : 7z 
 id: 7z/9df1e3b3b120_12ed325f6a47f0e5cebc247dbe9282a5da280d392cce4e6c9ed227d57ff1e2ff.7z
 repo: testing
-files : 7z
 
 name : libgdiplus 
 id : libgdiplus/9df1e3b3b120_4cf7c08770db93922f54f38d2461b9122cddc898db58585864446e70c5ad3057.7z
 repo: testing
-files : libgdiplus
 
 name : MacBuildEnvironment 
 id : MacBuildEnvironment/9df1e3b3b120_2fc8e616a2e5dfb7907fc42d9576b427e692223c266dc3bc305de4bf03714e30.7z
 repo: testing
-files : MacBuildEnvironment
 
 name : mono 
 id : mono/9df1e3b3b120_f81c172b91f45b2e045f4ba52d5f65cc54041da1527f2c854bf9db3a99495007.7z
 repo: testing
-files : mono
 
 name : MonoBleedingEdge 
 id : MonoBleedingEdge/9df1e3b3b120_ab6d2f131e6bd4fe2aacafb0f683e8fa4e1ccba35552b6fe89bf359b6ee16215.7z 
 repo: testing
-files : MonoBleedingEdge
 
 name : reference-assemblies 
 id : reference-assemblies/9df1e3b3b120_bbb4750c6bf0a1784bec7d7c04b8ef5881f31f6212136e014694f3864a388886.7z
 repo: testing
-files : reference-assemblies
 
 name : linux-sdk-20170609 
 id : linux-sdk-20170609/9df1e3b3b120_9a3a0847d5b3767579e908b5a9ce050936617b1b9275a79a8b71bb3229998957.7z
 repo: testing
-files : linux-sdk-20170609
 
-name : libtool-2-4-6 
-id : libtool-2-4-6/9df1e3b3b120_50f88211570edd89e1bf344d33e416a2eb04519f54940ae72d954a5ee0b8a69c.7z
-repo: testing
-files : libtool-2-4-6
+name : libtool-src 
+id : libtool-src/2.4.6_49a0ed204b3b24572e044400cd05513f611bcca6ced0d0816a57ac3b17376257.7z
+repo: public
 
-name : texinfo-4-8 
-id : texinfo-4-8/9df1e3b3b120_f0f8445fc0e8b8d6f52b8be4c3ff09fa59c30ff4424fe8c9bea951b9893540c9.7z
-repo: testing
-files : texinfo-4-8
+name : texinfo-src 
+id : texinfo-src/4.8_975b9657ebef8a4fe3897047ca450b757a0a956b05399dc813f63e84829bac6a.7z
+repo: public
 
-name : automake-1-15 
-id : automake-1-15/9df1e3b3b120_815e3ebf8d8bd08aa7f6ac1bbdff50d0379febba2049a5520247f7f4a1a6b3a3.7z
-repo: testing
-files : automake-1-15
+name : automake-src
+id : automake-src/1.15_de1f60706336df404881d3c789d8e04f0bc50e6bf577d78cae438b089b02d8ed.7z
+repo: public
 
-name : autoconf-2-69 
-id : autoconf-2-69/9df1e3b3b120_08915db7451aeafc86abedc46ef88243a1179ebaef4829ac75e5de8bfc80d0d2.7z
-repo: testing
-files : autoconf-2-69
+name : autoconf-src 
+id : autoconf-src/2.69_0e4ba7a0363c68ad08a7d138b228596aecdaea68e1d8b8eefc645e6ac8fc85c7.7z
+repo: public
 
 name : android-ndk-r16b-darwin 
 id : android-ndk-r16b-darwin/9df1e3b3b120_c7cda5a221dd72799b7e618597b3f8766df7183d386becb2785631c2d3ac0d75.7z
 repo: testing
-files : android-ndk-r16b-darwin
 
 name : android-ndk-r16b-linux 
 id : android-ndk-r16b-linux/9df1e3b3b120_fbabd18208d82cbc810266e8b566bb0ea4e1e438de38d450a92deaa3e23757b6.7z
 repo: testing
-files : android-ndk-r16b-linux
 
 name : android-ndk-r16b-windows 
 id : android-ndk-r16b-windows/9df1e3b3b120_403e0d58eabae03f0d9e8d1d2cea2dbf1d14c380c3d1c7eeb6e8c60ffc15e1b8.7z
 repo: testing
-files : android-ndk-r16b-windows

--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -12,6 +12,7 @@ my $build = 1;
 my $clean = 1;
 my $mcsOnly = 0;
 my $skipMonoMake = 0;
+my $stevedoreBuildDeps=0;
 
 # Handy troubleshooting/niche options
 
@@ -24,6 +25,7 @@ GetOptions(
    "mcsOnly=i"=>\$mcsOnly,
    'skipmonomake=i'=>\$skipMonoMake,
    'shortprefix=i'=>\$shortPrefix,
+   'stevedorebuilddeps=i'=>\$stevedoreBuildDeps,
 ) or die ("illegal cmdline options");
 
 system(
@@ -37,4 +39,5 @@ system(
 	"--artifactscommon=1",
 	"--buildusandboo=1",
 	"--forcedefaultbuilddeps=1",
+	"--stevedorebuilddeps=$stevedoreBuildDeps",
 	"--shortprefix=$shortPrefix") eq 0 or die ("Failed building mono\n");

--- a/external/buildscripts/build_runtime_android.pl
+++ b/external/buildscripts/build_runtime_android.pl
@@ -11,18 +11,20 @@ my $buildScriptsRoot = "$monoroot/external/buildscripts";
 my $androidArch = "";
 my $clean = 1;
 my $windowsSubsystemForLinux = 0;
+my $stevedoreBuildDeps = 0;
 
 GetOptions(
    "androidarch=s"=>\$androidArch,
    "clean=i"=>\$clean,
    "windowssubsystemforlinux=i"=>\$windowsSubsystemForLinux,
+   "stevedorebuilddeps=i"=>\$stevedoreBuildDeps,
 ) or die ("illegal cmdline options");
 
 # By default, build runtime for all the variants we need.  But allow something to specify an individual variation to build
 if ($androidArch eq "")
 {
-	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=armv7a", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for armv7a\n");
-	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=x86", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for x86\n");
+	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=armv7a", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono for armv7a\n");
+	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--androidarch=x86", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono for x86\n");
 }
 else
 {

--- a/external/buildscripts/build_runtime_linux.pl
+++ b/external/buildscripts/build_runtime_linux.pl
@@ -8,10 +8,12 @@ my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
 
+my $stevedoreBuildDeps = 0;
 my $build64 = 0;
 
 GetOptions(
    "build64=i"=>\$build64,
+   "stevedorebuilddeps=i"=>\$stevedoreBuildDeps,
 ) or die ("illegal cmdline options");
 
 my $arch32 = 1;
@@ -20,4 +22,4 @@ if ($build64)
 	$arch32 = 0;
 }
 
-system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--arch32=$arch32", "--classlibtests=0", "--forcedefaultbuilddeps=1") eq 0 or die ("Failed building mono\n");
+system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--arch32=$arch32", "--classlibtests=0", "--forcedefaultbuilddeps=1", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono\n");

--- a/external/buildscripts/build_runtime_osx.pl
+++ b/external/buildscripts/build_runtime_osx.pl
@@ -8,4 +8,10 @@ my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
 
-system("perl", "$buildScriptsRoot/build_all_osx.pl", "--build=1", "--artifact=1", "--test=1", "--forcedefaultbuilddeps=1") eq 0 or die ("Failed building mono\n");
+my $stevedoreBuildDeps=0;
+
+GetOptions(
+   'stevedorebuilddeps=i'=>\$stevedoreBuildDeps,
+) or die ("illegal cmdline options");
+
+system("perl", "$buildScriptsRoot/build_all_osx.pl", "--build=1", "--artifact=1", "--test=1", "--forcedefaultbuilddeps=1", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono\n");

--- a/external/buildscripts/build_runtime_win.pl
+++ b/external/buildscripts/build_runtime_win.pl
@@ -7,8 +7,13 @@ use File::Path;
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
+my $stevedoreBuildDeps = 0;
+
+GetOptions(
+   "stevedorebuilddeps=i"=>\$stevedoreBuildDeps,
+) or die ("illegal cmdline options");
 
 # Note : Ideally we can switch back to this build approach once the random cygwin hangs on the build machines are sorted out
-#system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--arch32=1", "--classlibtests=0", "--forcedefaultbuilddeps=1") eq 0 or die ("Failed building mono\n");
+#system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--arch32=1", "--classlibtests=0", "--forcedefaultbuilddeps=1", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono\n");
 
-system("perl", "$buildScriptsRoot/build_win_no_cygwin.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--forcedefaultbuilddeps=1") eq 0 or die ("Failed building mono\n");
+system("perl", "$buildScriptsRoot/build_win_no_cygwin.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=1", "--forcedefaultbuilddeps=1", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono\n");

--- a/external/buildscripts/build_runtime_win64.pl
+++ b/external/buildscripts/build_runtime_win64.pl
@@ -8,7 +8,13 @@ my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
 
-# Note : Ideally we can switch back to this build approach once the random cygwin hangs on the build machines are sorted out
-#system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--classlibtests=0", "--forcedefaultbuilddeps=1") eq 0 or die ("Failed building mono\n");
+my $stevedoreBuildDeps = 0;
 
-system("perl", "$buildScriptsRoot/build_win_no_cygwin.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=0", "--forcedefaultbuilddeps=1") eq 0 or die ("Failed building mono\n");
+GetOptions(
+   "stevedorebuilddeps=i"=>\$stevedoreBuildDeps,
+) or die ("illegal cmdline options");
+
+# Note : Ideally we can switch back to this build approach once the random cygwin hangs on the build machines are sorted out
+#system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=1", "--test=1", "--artifact=1", "--classlibtests=0", "--forcedefaultbuilddeps=1", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono\n");
+
+system("perl", "$buildScriptsRoot/build_win_no_cygwin.pl", "--build=1", "--clean=1", "--artifact=1", "--arch32=0", "--forcedefaultbuilddeps=1", "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono\n");

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -37,6 +37,7 @@ my $winPerl = "perl";
 my $winMonoRoot = $monoroot;
 my $msBuildVersion = "14.0";
 my $buildDeps = "";
+my $stevedoreBuildDeps=0;
 
 print(">>> Build All Args = @ARGV\n");
 
@@ -53,6 +54,7 @@ GetOptions(
 	'checkoutonthefly=i'=>\$checkoutOnTheFly,
 	'builddeps=s'=>\$buildDeps,
 	'forcedefaultbuilddeps=i'=>\$forceDefaultBuildDeps,
+	'stevedorebuilddeps=i'=>\$stevedoreBuildDeps,
 ) or die ("illegal cmdline options");
 
 my $monoRevision = `git rev-parse HEAD`;
@@ -72,8 +74,16 @@ if ($buildDeps ne "" && not $forceDefaultBuildDeps)
 }
 else
 {
-	$externalBuildDeps = "$monoroot/../../mono-build-deps/build";
+	if($stevedoreBuildDeps)
+	{
+		$externalBuildDeps = "$monoroot/external/buildscripts/artifacts/Stevedore";
+	}
+	else
+	{
+		$externalBuildDeps = "$monoroot/../../mono-build-deps/build";
+	}
 }
+print(">>> External build deps = $externalBuildDeps\n");
 
 my $existingExternalMonoRoot = "$externalBuildDeps\\mono";
 my $existingExternalMono = "$existingExternalMonoRoot\\win";


### PR DESCRIPTION
This PR does the following:

1. Point `externalBuildDeps` to stevedore artifacts directory, instead of copying the downloaded artifacts to `$monoroot/../../mono-build-deps/build/`
(The copy step is unnecessary and had the overhead of keeping track of downloaded files so we can pass them as input to the copy action.)

2. Add `--stevedorebuilddeps=1/0` option to build scripts. The default is set to 0 (don't break Katana until config changes land). Update gitlabCI config to pass in stevedorebuilddeps=1.

3. Change autoconf, automake, texinfo, libtool to point to 'public' repo.

4. Use bokken-runners are Android, OSX runtime and Classlibs build.

Upcoming PR to use bokken for windows and linux after we have resolved all issues. 

Passing GitlabCI pipeline: https://gitlab.cds.internal.unity3d.com/vm/mono/pipelines/12496
Passing Katana run: https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?boo_branch=unity-trunk&cecil_branch=unity-master&krait-signal-handler_branch=master&mono_branch=use-stevedore-production&mono-build-tools-extra_branch=master&mono-build-deps_branch=default&unityscript_branch=unity-trunk

Note: This does not affect current build process on Katana because all changes are behind a `if(stevedorebuilddeps)` option. and the default is set to 0. 

Unless we pass in `--stevedorebuilddeps=1` to the perl scripts (as part of upcoming Katana PR), we will still be using ono for mono-build-deps.