### PR TITLE
[Do not merge] Reorg buildszip by platform

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1438,6 +1438,18 @@ if ($artifact)
 
 	if ($artifactsCommon)
 	{
+		#Do platform specific set up for distribution directory
+		if ($^O eq "linux")
+		{	
+			$distdir = $arch32 ? "$buildsroot/linux/x86/mono" : "$buildsroot/linux/x86_64/mono";
+			$distDirArchBin = "$distdir/bin";
+		}
+		elsif ($^O eq 'darwin')
+		{
+			$distdir = "$buildsroot/osx/mono";
+			$distDirArchBin = "$distdir/bin";
+		}
+	
 		print(">>> Creating common artifacts...\n");
 		print(">>> distribution directory = $distdir\n");
 
@@ -1530,7 +1542,8 @@ if ($artifact)
 	}
 	elsif ($android)
 	{
-		$embedDirArchDestination = "$embedDirRoot/android/$androidArch";
+		$embedDirRoot = "$buildsroot/android";
+		$embedDirArchDestination = "$embedDirRoot/$androidArch/embedruntimes";
 		$versionsOutputFile = "$buildsroot/versions-android-$androidArch.txt";
 	}
 	elsif ($tizenEmulator)
@@ -1545,21 +1558,27 @@ if ($artifact)
 	}
 	elsif($^O eq "linux")
 	{
-		$embedDirArchDestination = $arch32 ? "$embedDirRoot/linux32" : "$embedDirRoot/linux64";
-		$distDirArchBin = $arch32 ? "$distdir/bin-linux32" : "$distdir/bin-linux64";
+		$embedDirRoot = "$buildsroot/linux";
+		$embedDirArchDestination = $arch32 ? "$embedDirRoot/x86/embedruntimes" : "$embedDirRoot/x86_64/embedruntimes";
+		$distdir = $arch32 ? "$buildsroot/linux/x86/mono" : "$buildsroot/linux/x86_64/mono";
+		$distDirArchBin = "$distdir/bin";
 		$versionsOutputFile = $arch32 ? "$buildsroot/versions-linux32.txt" : "$buildsroot/versions-linux64.txt";
 	}
 	elsif($^O eq 'darwin')
 	{
 		# Note these tmp directories will get merged into a single 'osx' directory later by a parent script
-		$embedDirArchDestination = "$embedDirRoot/osx-tmp-$monoHostArch";
+		$embedDirRoot = "$buildsroot/osx";
+		$embedDirArchDestination = "$embedDirRoot/embedruntimes/osx-tmp-$monoHostArch";
+		$distdir = "$buildsroot/osx/mono";
 		$distDirArchBin = "$distdir/bin-osx-tmp-$monoHostArch";
 		$versionsOutputFile = $arch32 ? "$buildsroot/versions-osx32.txt" : "$buildsroot/versions-osx64.txt";
 	}
 	else
 	{
-		$embedDirArchDestination = $arch32 ? "$embedDirRoot/win32" : "$embedDirRoot/win64";
-		$distDirArchBin = $arch32 ? "$distdir/bin" : "$distdir/bin-x64";
+		$embedDirRoot = "$buildsroot/win";
+		$embedDirArchDestination = $arch32 ? "$embedDirRoot/x86/embedruntimes" : "$embedDirRoot/x86_64/embedruntimes";
+		$distdir = $arch32 ? "$buildsroot/win/x86/mono" : "$buildsroot/win/x86_64/mono";
+		$distDirArchBin = "$distdir/bin";
 		$versionsOutputFile = $arch32 ? "$buildsroot/versions-win32.txt" : "$buildsroot/versions-win64.txt";
 	}
 
@@ -1667,7 +1686,8 @@ if ($artifact)
 		}
 		elsif($^O eq "linux")
 		{
-			my $distDirArchEtc = $arch32 ? "$distdir/etc-linux32" : "$distdir/etc-linux64";
+			$distdir = $arch32 ? "$buildsroot/linux/x86/mono" : "$buildsroot/linux/x86_64/mono";
+			my $distDirArchEtc = "$distdir/etc";
 
 			if (-d "$distDirArchEtc")
 			{

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1543,7 +1543,7 @@ if ($artifact)
 	elsif ($android)
 	{
 		$embedDirRoot = "$buildsroot/android";
-		$embedDirArchDestination = "$embedDirRoot/$androidArch/embedruntimes";
+		$embedDirArchDestination = "$embedDirRoot/$androidArch/embedruntime";
 		$versionsOutputFile = "$buildsroot/versions-android-$androidArch.txt";
 	}
 	elsif ($tizenEmulator)
@@ -1559,7 +1559,7 @@ if ($artifact)
 	elsif($^O eq "linux")
 	{
 		$embedDirRoot = "$buildsroot/linux";
-		$embedDirArchDestination = $arch32 ? "$embedDirRoot/x86/embedruntimes" : "$embedDirRoot/x86_64/embedruntimes";
+		$embedDirArchDestination = $arch32 ? "$embedDirRoot/x86/embedruntime" : "$embedDirRoot/x86_64/embedruntime";
 		$distdir = $arch32 ? "$buildsroot/linux/x86/mono" : "$buildsroot/linux/x86_64/mono";
 		$distDirArchBin = "$distdir/bin";
 		$versionsOutputFile = $arch32 ? "$buildsroot/versions-linux32.txt" : "$buildsroot/versions-linux64.txt";
@@ -1568,7 +1568,7 @@ if ($artifact)
 	{
 		# Note these tmp directories will get merged into a single 'osx' directory later by a parent script
 		$embedDirRoot = "$buildsroot/osx";
-		$embedDirArchDestination = "$embedDirRoot/embedruntimes/osx-tmp-$monoHostArch";
+		$embedDirArchDestination = "$embedDirRoot/embedruntime/osx-tmp-$monoHostArch";
 		$distdir = "$buildsroot/osx/mono";
 		$distDirArchBin = "$distdir/bin-osx-tmp-$monoHostArch";
 		$versionsOutputFile = $arch32 ? "$buildsroot/versions-osx32.txt" : "$buildsroot/versions-osx64.txt";
@@ -1576,7 +1576,7 @@ if ($artifact)
 	else
 	{
 		$embedDirRoot = "$buildsroot/win";
-		$embedDirArchDestination = $arch32 ? "$embedDirRoot/x86/embedruntimes" : "$embedDirRoot/x86_64/embedruntimes";
+		$embedDirArchDestination = $arch32 ? "$embedDirRoot/x86/embedruntime" : "$embedDirRoot/x86_64/embedruntime";
 		$distdir = $arch32 ? "$buildsroot/win/x86/mono" : "$buildsroot/win/x86_64/mono";
 		$distDirArchBin = "$distdir/bin";
 		$versionsOutputFile = $arch32 ? "$buildsroot/versions-win32.txt" : "$buildsroot/versions-win64.txt";

--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -73,10 +73,10 @@ if ($artifact)
 {
 	print(">>> Creating universal binaries\n");
 	# Merge stuff in the embedruntimes directory
-	my $embedDirRoot = "$buildsroot/embedruntimes";
-	my $embedDirDestination = "$embedDirRoot/osx";
-	my $embedDirSource32 = "$embedDirRoot/osx-tmp-$monoArch32Target";
-	my $embedDirSource64 = "$embedDirRoot/osx-tmp-x86_64";
+	my $embedDirRoot = "$buildsroot/osx";
+	my $embedDirDestination = "$embedDirRoot/embedruntimes";
+	my $embedDirSource32 = "$embedDirRoot/embedruntimes/osx-tmp-$monoArch32Target";
+	my $embedDirSource64 = "$embedDirRoot/embedruntimes/osx-tmp-x86_64";
 
 	system("mkdir -p $embedDirDestination");
 
@@ -111,9 +111,9 @@ if ($artifact)
 	}
 
 	# Merge stuff in the monodistribution directory
-	my $distDirRoot = "$buildsroot/monodistribution";
-	my $distDirDestinationBin = "$buildsroot/monodistribution/bin";
-	my $distDirDestinationLib = "$buildsroot/monodistribution/lib";
+	my $distDirRoot = "$buildsroot/osx/mono";
+	my $distDirDestinationBin = "$distDirRoot/bin";
+	my $distDirDestinationLib = "$distDirRoot/lib";
 	my $distDirSourceBin32 = "$distDirRoot/bin-osx-tmp-$monoArch32Target";
 	my $distDirSourceBin64 = "$distDirRoot/bin-osx-tmp-x86_64";
 

--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -72,11 +72,11 @@ system("perl", "$buildscriptsdir/build.pl", "--clean=1", "--classlibtests=0", @p
 if ($artifact)
 {
 	print(">>> Creating universal binaries\n");
-	# Merge stuff in the embedruntimes directory
+	# Merge stuff in the embedruntime directory
 	my $embedDirRoot = "$buildsroot/osx";
-	my $embedDirDestination = "$embedDirRoot/embedruntimes";
-	my $embedDirSource32 = "$embedDirRoot/embedruntimes/osx-tmp-$monoArch32Target";
-	my $embedDirSource64 = "$embedDirRoot/embedruntimes/osx-tmp-x86_64";
+	my $embedDirDestination = "$embedDirRoot/embedruntime";
+	my $embedDirSource32 = "$embedDirRoot/embedruntime/osx-tmp-$monoArch32Target";
+	my $embedDirSource64 = "$embedDirRoot/embedruntime/osx-tmp-x86_64";
 
 	system("mkdir -p $embedDirDestination");
 

--- a/external/buildscripts/build_unityscript_bareminimum_win.pl
+++ b/external/buildscripts/build_unityscript_bareminimum_win.pl
@@ -8,7 +8,7 @@ use File::Basename;
 
 my $root = getcwd();
 
-my $monodistro = "$root/builds/monodistribution";
+my $monodistro = "$root/builds/mono";
 my $libmono = "$monodistro/lib/mono";
 
 sub AddDotNetFolderToPath() {

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -22,7 +22,6 @@ my $buildscriptsdir = "$monoroot\\external\\buildscripts";
 my $addtoresultsdistdir = "$buildscriptsdir\\add_to_build_results\\monodistribution";
 my $monoprefix = "$monoroot\\tmp\\monoprefix";
 my $buildsroot = "$monoroot\\builds";
-my $distdir = "$buildsroot\\monodistribution";
 my $buildMachine = $ENV{UNITY_THISISABUILDMACHINE};
 
 my $build=0;
@@ -192,10 +191,9 @@ if ($artifact)
 
 	# Do the platform specific logic to create the builds output structure that we want
 
-	my $embedDirRoot = "$buildsroot\\embedruntimes";
-
-	my $embedDirArchDestination = $arch32 ? "$embedDirRoot\\win32" : "$embedDirRoot\\win64";
-	my $distDirArchBin = $arch32 ? "$distdir\\bin" : "$distdir\\bin-x64";
+	my $embedDirArchDestination = $arch32 ? "$buildsroot\\win\\x86\\embedruntimes" : "$buildsroot\\win\\x86_64\\embedruntimes";
+	my $distDirArchBin = $arch32 ? "$buildsroot\\win\\x86\\mono\\bin" : "$buildsroot\\win\\x86_64\\mono\\bin";
+	
 	my $versionsOutputFile = $arch32 ? "$buildsroot\\versions-win32.txt" : "$buildsroot\\versions-win64.txt";
 
 	# Make sure the directory for our architecture is clean before we copy stuff into it
@@ -214,29 +212,23 @@ if ($artifact)
 	if (!(-d "$buildsroot"))
 	{
 		print(">>> Creating directory $buildsroot\n");
-		system("mkdir $buildsroot") eq 0 or die("failed to create directory $buildsroot\n");
+		system("mkdir -p $buildsroot") eq 0 or die("failed to create directory $buildsroot\n");
 	}
 
-	if (!(-d "$embedDirRoot"))
+	if (!(-d "$embedDirArchDestination"))
 	{
-		print(">>> Creating directory $embedDirRoot\n");
-		system("mkdir $embedDirRoot") eq 0 or die("failed to create directory $embedDirRoot\n");
+		print(">>> Creating directory $embedDirArchDestination\n");
+		system("mkdir -p $embedDirArchDestination") eq 0 or die("failed to create directory $embedDirArchDestination\n");
 	}
 
-	if (!(-d "$distdir"))
+	if (!(-d "$distDirArchBin"))
 	{
-		print(">>> Creating directory $distdir\n");
-		system("mkdir $distdir") eq 0 or die("failed to create directory $distdir\n");
+		print(">>> Creating directory $distDirArchBin\n");
+		system("mkdir -p $distDirArchBin") eq 0 or die("failed to create directory $distDirArchBin\n");
 	}
-
-	print(">>> Creating directory $embedDirArchDestination\n");
-	system("mkdir $embedDirArchDestination") eq 0 or die("failed to create directory $embedDirArchDestination\n");
-
-	print(">>> Creating directory $distDirArchBin\n");
-	system("mkdir $distDirArchBin") eq 0 or die("failed to create directory $distDirArchBin\n");
 
 	# embedruntimes directory setup
-	print(">>> Creating embedruntimes directory : $embedDirArchDestination\n");
+	print(">>> Setting up embedruntimes directory : $embedDirArchDestination\n");
 
 	copy("$monoprefix/bin/mono-2.0-bdwgc.dll", "$embedDirArchDestination/.") or die ("failed copying mono-2.0-bdwgc.dll\n");
 	copy("$monoprefix/bin/mono-2.0-bdwgc.pdb", "$embedDirArchDestination/.") or die ("failed copying mono-2.0-bdwgc.pdb\n");
@@ -248,7 +240,7 @@ if ($artifact)
 	copy("$monoprefix/bin/MonoPosixHelper.pdb", "$embedDirArchDestination/.") or die ("failed copying MonoPosixHelper.pdb\n");
 
 	# monodistribution directory setup
-	print(">>> Creating monodistribution directory\n");
+	print(">>> Setting up monodistribution directory : $distDirArchBin\n");
 	copy("$monoprefix/bin/mono-2.0-bdwgc.dll", "$distDirArchBin/.") or die ("failed copying mono-2.0-bdwgc.dll\n");
 	copy("$monoprefix/bin/mono-2.0-bdwgc.pdb", "$distDirArchBin/.") or die ("failed copying mono-2.0-bdwgc.pdb\n");
 

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -191,7 +191,7 @@ if ($artifact)
 
 	# Do the platform specific logic to create the builds output structure that we want
 
-	my $embedDirArchDestination = $arch32 ? "$buildsroot\\win\\x86\\embedruntimes" : "$buildsroot\\win\\x86_64\\embedruntimes";
+	my $embedDirArchDestination = $arch32 ? "$buildsroot\\win\\x86\\embedruntime" : "$buildsroot\\win\\x86_64\\embedruntime";
 	my $distDirArchBin = $arch32 ? "$buildsroot\\win\\x86\\mono\\bin" : "$buildsroot\\win\\x86_64\\mono\\bin";
 	
 	my $versionsOutputFile = $arch32 ? "$buildsroot\\versions-win32.txt" : "$buildsroot\\versions-win64.txt";
@@ -227,8 +227,8 @@ if ($artifact)
 		system("mkdir -p $distDirArchBin") eq 0 or die("failed to create directory $distDirArchBin\n");
 	}
 
-	# embedruntimes directory setup
-	print(">>> Setting up embedruntimes directory : $embedDirArchDestination\n");
+	# embedruntime directory setup
+	print(">>> Setting up embedruntime directory : $embedDirArchDestination\n");
 
 	copy("$monoprefix/bin/mono-2.0-bdwgc.dll", "$embedDirArchDestination/.") or die ("failed copying mono-2.0-bdwgc.dll\n");
 	copy("$monoprefix/bin/mono-2.0-bdwgc.pdb", "$embedDirArchDestination/.") or die ("failed copying mono-2.0-bdwgc.pdb\n");


### PR DESCRIPTION
Reorganize builds.zip based on platform.

Attached format.

Requires changes on the desktop side to make it all work. Do not merge. 

I have kicked off a build on Katana and will report here when its ready, but I would like to get this out to review.

cc @PeteLewisUnity 
