### PR TITLE
Fix parenthesis position in debugger-agent

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8051,7 +8051,7 @@ clear_assembly_from_modifier (EventRequest *req, Modifier *m, MonoAssembly *asse
 {
 	int i;
 
-	if (m->kind == MOD_KIND_EXCEPTION_ONLY && m->data.exc_class && mono_image_get_assembly (mono_class_get_image (m->data.exc_class) == assembly))
+	if (m->kind == MOD_KIND_EXCEPTION_ONLY && m->data.exc_class && mono_image_get_assembly (mono_class_get_image (m->data.exc_class)) == assembly)
 		m->kind = MOD_KIND_NONE;
 	if (m->kind == MOD_KIND_ASSEMBLY_ONLY && m->data.assemblies) {
 		int count = 0, match_count = 0, pos;


### PR DESCRIPTION
The reason this works, is that in c you are comparing two pointers. The compiler could potentially see that these are two different types, `MonoImage` and `MonoAssembly`. Therefore: `mono_class_get_image (m->data.exc_class) == assembly` will always be false or 0.
