### PR TITLE
Implement a ReadString overload (case 1106236)

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlSerializationReader.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlSerializationReader.cs
@@ -1193,10 +1193,15 @@ namespace System.Xml.Serialization
 			throw new NotImplementedException ();
 		}
 
-		[MonoTODO]
 		protected string ReadString (string value, bool trim)
 		{
-			throw new NotImplementedException ();
+			readCount++;
+			string str = reader.ReadString ();
+			if (str != null && trim)
+				str = str.Trim();
+			if (value == null || value.Length == 0)
+				return str;
+			return value + str;
 		}
 		
 		[MonoTODO]


### PR DESCRIPTION
In the `XmlSerializationReader` class, the `ReadString(string, bool)`
overload was not implemented in the Mono class library implementation used
for the unityaot profile. The implementation used for the unityjit
profile from the reference source implements this method.

I've copied the implementation from the reference source code here into
the code used for the unityaot profile.

Release notes:

Mono: Implement XmlSerializationReader.ReadString(string, bool) in the profile used for AOT builds. (case 1106236)