### PR TITLE
Set using stevedoreBuildDeps as default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,9 +122,6 @@ build_win:
   - windows
   script:
   - git submodule update --init --recursive
-  - cd external/buildscripts
-  - ./bee.exe
-  - cd ../..
   - perl external/buildscripts/build_runtime_win64.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/win64
   - cp -r builds/* incomingbuilds/win64/
@@ -143,9 +140,6 @@ build_win_x86:
   - windows
   script:
   - git submodule update --init --recursive
-  - cd external/buildscripts
-  - ./bee.exe
-  - cd ../..
   - perl external/buildscripts/build_runtime_win.pl --stevedorebuilddeps=1
   - mkdir -p incomingbuilds/win32
   - cp -r builds/* incomingbuilds/win32/
@@ -164,9 +158,6 @@ build_win_bare_minimum:
   - windows
   script:
   - git submodule update --init --recursive
-  - cd external/buildscripts
-  - ./bee.exe
-  - cd ../..
   - perl external/buildscripts/build_unityscript_bareminimum_win.pl
   - mkdir -p incomingbuilds/bareminimum
   - cp -r builds/* incomingbuilds/bareminimum/

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -64,7 +64,7 @@ my $iphoneSimulatorArch="";
 my $tizen=0;
 my $tizenEmulator=0;
 my $windowsSubsystemForLinux=0;
-my $stevedoreBuildDeps=0;
+my $stevedoreBuildDeps=1;
 
 # Handy troubleshooting/niche options
 my $skipMonoMake=0;
@@ -304,20 +304,30 @@ if ($build)
 
 		if (!(-d "$externalBuildDeps"))
 		{
-			if (not $checkoutonthefly)
+			if($stevedoreBuildDeps)
 			{
-				print(">>> No external build deps found.  Might as well try to check them out.  If it fails, we'll continue and trust mono is in your PATH\n");
+				print(">>> Running bee to download build-deps...\n");
+				chdir($buildscriptsdir) eq 1 or die ("failed to chdir to $buildscriptsdir directory\n");
+				system("./bee") eq 0 or die ("failed to run bee\n");
+				chdir("$monoroot") eq 1 or die ("failed to chdir to $monoroot\n");
 			}
-
-			# Check out on the fly
-			print(">>> Checking out mono build dependencies to : $externalBuildDeps\n");
-			my $repo = "https://ono.unity3d.com/unity-extra/mono-build-deps";
-			print(">>> Cloning $repo at $externalBuildDeps\n");
-			my $checkoutResult = system("hg", "clone", $repo, "$externalBuildDeps");
-
-			if ($checkoutOnTheFly && $checkoutResult ne 0)
+			else
 			{
-				die("failed to checkout mono build dependencies\n");
+				if (not $checkoutonthefly)
+				{
+					print(">>> No external build deps found.  Might as well try to check them out.  If it fails, we'll continue and trust mono is in your PATH\n");
+				}
+
+				# Check out on the fly
+				print(">>> Checking out mono build dependencies to : $externalBuildDeps\n");
+				my $repo = "https://ono.unity3d.com/unity-extra/mono-build-deps";
+				print(">>> Cloning $repo at $externalBuildDeps\n");
+				my $checkoutResult = system("hg", "clone", $repo, "$externalBuildDeps");
+
+				if ($checkoutOnTheFly && $checkoutResult ne 0)
+				{
+					die("failed to checkout mono build dependencies\n");
+				}
 			}
 
 			# Only clean up if the dir exists.   Otherwise abs_path will return empty string

--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -12,7 +12,7 @@ my $build = 1;
 my $clean = 1;
 my $mcsOnly = 0;
 my $skipMonoMake = 0;
-my $stevedoreBuildDeps=0;
+my $stevedoreBuildDeps=1;
 
 # Handy troubleshooting/niche options
 

--- a/external/buildscripts/build_runtime_android.pl
+++ b/external/buildscripts/build_runtime_android.pl
@@ -11,7 +11,7 @@ my $buildScriptsRoot = "$monoroot/external/buildscripts";
 my $androidArch = "";
 my $clean = 1;
 my $windowsSubsystemForLinux = 0;
-my $stevedoreBuildDeps = 0;
+my $stevedoreBuildDeps = 1;
 
 GetOptions(
    "androidarch=s"=>\$androidArch,
@@ -28,5 +28,5 @@ if ($androidArch eq "")
 }
 else
 {
-	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=$clean", "--artifact=1", "--arch32=1", "--androidarch=$androidArch", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux") eq 0 or die ("Failed building mono for $androidArch\n");
+	system("perl", "$buildScriptsRoot/build.pl", "--build=1", "--clean=$clean", "--artifact=1", "--arch32=1", "--androidarch=$androidArch", "--forcedefaultbuilddeps=1", "--windowssubsystemforlinux=$windowsSubsystemForLinux",  "--stevedorebuilddeps=$stevedoreBuildDeps") eq 0 or die ("Failed building mono for $androidArch\n");
 }

--- a/external/buildscripts/build_runtime_linux.pl
+++ b/external/buildscripts/build_runtime_linux.pl
@@ -7,8 +7,7 @@ use File::Path;
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
-
-my $stevedoreBuildDeps = 0;
+my $stevedoreBuildDeps = 1;
 my $build64 = 0;
 
 GetOptions(

--- a/external/buildscripts/build_runtime_osx.pl
+++ b/external/buildscripts/build_runtime_osx.pl
@@ -7,8 +7,7 @@ use File::Path;
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
-
-my $stevedoreBuildDeps=0;
+my $stevedoreBuildDeps=1;
 
 GetOptions(
    'stevedorebuilddeps=i'=>\$stevedoreBuildDeps,

--- a/external/buildscripts/build_runtime_win.pl
+++ b/external/buildscripts/build_runtime_win.pl
@@ -7,7 +7,7 @@ use File::Path;
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
-my $stevedoreBuildDeps = 0;
+my $stevedoreBuildDeps = 1;
 
 GetOptions(
    "stevedorebuilddeps=i"=>\$stevedoreBuildDeps,

--- a/external/buildscripts/build_runtime_win64.pl
+++ b/external/buildscripts/build_runtime_win64.pl
@@ -8,7 +8,7 @@ my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
 my $buildScriptsRoot = "$monoroot/external/buildscripts";
 
-my $stevedoreBuildDeps = 0;
+my $stevedoreBuildDeps = 1;
 
 GetOptions(
    "stevedorebuilddeps=i"=>\$stevedoreBuildDeps,

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -37,7 +37,7 @@ my $winPerl = "perl";
 my $winMonoRoot = $monoroot;
 my $msBuildVersion = "14.0";
 my $buildDeps = "";
-my $stevedoreBuildDeps=0;
+my $stevedoreBuildDeps=1;
 
 print(">>> Build All Args = @ARGV\n");
 
@@ -98,58 +98,9 @@ if ($clean)
 
 if ($build)
 {
-	if ($existingMonoRootPath eq "")
+	if (!(-d "$externalBuildDeps"))
 	{
-		print(">>> No existing mono supplied.  Checking for external...\n");
-
-		if (!(-d "$externalBuildDeps"))
-		{
-			if (not $checkoutonthefly)
-			{
-				print(">>> No external build deps found.  Might as well try to check them out.  If it fails, we'll continue and trust mono is in your PATH\n");
-			}
-
-			# Check out on the fly
-			print(">>> Checking out mono build dependencies to : $externalBuildDeps\n");
-			my $repo = "https://ono.unity3d.com/unity-extra/mono-build-deps";
-			print(">>> Cloning $repo at $externalBuildDeps\n");
-			my $checkoutResult = system("hg", "clone", $repo, "$externalBuildDeps");
-
-			if ($checkoutOnTheFly && $checkoutResult ne 0)
-			{
-				die("failed to checkout mono build dependencies\n");
-			}
-		}
-
-		if (-d "$existingExternalMono")
-		{
-			print(">>> External mono found at : $existingExternalMono\n");
-
-			if (-d "$existingExternalMono/builds")
-			{
-				print(">>> Mono already extracted at : $existingExternalMono/builds\n");
-			}
-
-			if (!(-d "$existingExternalMono/builds"))
-			{
-				# We need to extract builds.zip
-				print(">>> Extracting mono builds.zip...\n");
-				my $SevenZip = "$externalBuildDeps/7z/win64/7za.exe";
-				print(">>> Using 7z : $SevenZip\n");
-				system("$SevenZip", "x", "$existingExternalMono/builds.zip", "-o$existingExternalMono") eq 0 or die("Failed extracting mono builds.zip\n");
-			}
-
-			$existingMonoRootPath = "$existingExternalMono/builds";
-		}
-		else
-		{
-			print(">>> No external mono found.  Trusting a new enough mono is in your PATH.\n");
-		}
-	}
-
-	if ($existingMonoRootPath ne "" && !(-d $existingMonoRootPath))
-	{
-		die("Existing mono not found at : $existingMonoRootPath\n");
+		print(">>> mono-build-deps is not required for windows runtime builds...\n");
 	}
 
 	system("$winPerl", "$winMonoRoot/external/buildscripts/build_runtime_vs.pl", "--build=$build", "--arch32=$arch32", "--msbuildversion=$msBuildVersion", "--clean=$clean", "--debug=$debug", "--gc=bdwgc") eq 0 or die ('failed building mono bdwgc with VS\n');


### PR DESCRIPTION
1. Windows runtime builds do not use any build-deps. There is no need to pull them down. This will save a lot of time!

2. The workflow was to run Bee to pull down artifacts BEFORE running the perl script. 
In this PR, have build.pl run Bee IF it was not run before running the perl script. 

3. Make `stevedoreBuildDeps=1` default. We don't have to pass in --stevedorebuilddeps=1 anymore. It wouldn't hurt to pass it in for clarity, so I kept it in the Gitlab CI config.

Tested here  https://gitlab.cds.internal.unity3d.com/vm/mono/pipelines/13901

@joshpeterson We don't have to backport any of the stevedore related changes now. On Katana configs, I will remove `--stevedorebuilddeps=1`, which means
- On backport branches, it will just pull down build-deps from ono. 
- On unity-master, it will use stevedore. Does this sounds good?





