### PR TITLE
Fix LargeArrayBuilder CopyToCore Issue

### DIFF
--- a/external/corefx-bugfix/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/external/corefx-bugfix/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -234,7 +234,7 @@ namespace System.Collections.Generic
             T[] buffer = GetBuffer(row);
             int copied =
 #if __MonoCS__
-            CopyToCore(buffer, column, array, arrayIndex, count);
+            CopyToCore(buffer, column, array, ref arrayIndex, ref count);
 #else
             CopyToCore(buffer, column);
 #endif
@@ -249,7 +249,7 @@ namespace System.Collections.Generic
                 buffer = GetBuffer(++row);
                 copied =
 #if __MonoCS__
-                CopyToCore(buffer, 0, array, arrayIndex, count);
+                CopyToCore(buffer, 0, array, ref arrayIndex, ref count);
 #else
                 CopyToCore(buffer, 0);
 #endif
@@ -260,7 +260,7 @@ namespace System.Collections.Generic
 #if __MonoCS__
         }
 
-        static int CopyToCore(T[] sourceBuffer, int sourceIndex, T[] array, int arrayIndex, int count)
+        static int CopyToCore(T[] sourceBuffer, int sourceIndex, T[] array, ref int arrayIndex, ref int count)
 #else
             int CopyToCore(T[] sourceBuffer, int sourceIndex)
 #endif


### PR DESCRIPTION
graft fix for https://github.com/mono/corefx/commit/0bf46dbe2cf0a215ca6e64793b7c434433f50722
Into Unity