### PR TITLE
Avoid scanning non-object GC memory (case 1091878)

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -348,6 +348,7 @@ struct _MonoClass {
 	USE_UINT8_BIT_FIELD(guint, simd_type       : 1); /* class is a simd intrinsic type */
 	USE_UINT8_BIT_FIELD(guint, is_generic      : 1); /* class is a generic type definition */
 	USE_UINT8_BIT_FIELD(guint, is_inflated     : 1); /* class is a generic instance */
+	USE_UINT8_BIT_FIELD(guint, has_non_object_gc_memory     : 1); /* class has UIntPtr field which may point to GC memory */
 
 	guint8     exception_type;	/* MONO_EXCEPTION_* */
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -671,6 +671,8 @@ compute_class_bitmap (MonoClass *class, gsize *bitmap, int size, int offset, int
 #else
 				if (class->image != mono_defaults.corlib)
 					break;
+				else
+					class->has_non_object_gc_memory = 1;
 #endif
 			case MONO_TYPE_STRING:
 			case MONO_TYPE_SZARRAY:

--- a/unity/unity_liveness.c
+++ b/unity/unity_liveness.c
@@ -160,9 +160,10 @@ static void mono_traverse_objects (LivenessState* state);
 
 static void mono_traverse_generic_object( MonoObject* object, LivenessState* state ) 
 {
-	gsize gc_desc = (gsize)(GET_VTABLE(object)->gc_descr);
+	MonoVTable* vtable = GET_VTABLE (object);
+	gsize gc_desc = (gsize)(vtable->gc_descr);
 
-	if (gc_desc & (gsize)1)
+	if (gc_desc & (gsize)1 && !(vtable->klass->has_non_object_gc_memory))
 		mono_traverse_gc_desc (object, state);
 	else if (GET_VTABLE(object)->klass->rank)
 		mono_traverse_array ((MonoArray*)object, state);


### PR DESCRIPTION
Mono treats UIntPtr fields in mscorlib as potential
reference fields since they may store non-object
GC memory there. Liveness assumes all GC memory
as determined via the GC descriptor points to
objects. Take slow scan path of field types
rather than GC descriptor in cases where the
gc descriptor may have bits set for non-object memory.