### PR TITLE
Allow namespace-agnostic class lookup by passing NULL namespace.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -7713,7 +7713,7 @@ find_nocase (gpointer key, gpointer value, gpointer user_data)
 	char *name = (char*)key;
 	FindUserData *data = (FindUserData*)user_data;
 
-	if (!data->value && (mono_utf8_strcasecmp (name, (char*)data->key) == 0))
+	if (!data->value && (NULL == data->key || (mono_utf8_strcasecmp (name, (char*)data->key) == 0)))
 		data->value = value;
 }
 
@@ -7808,7 +7808,7 @@ mono_class_from_name_case_checked (MonoImage *image, const char *name_space, con
 			continue;
 		n = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAME]);
 		nspace = mono_metadata_string_heap (image, cols [MONO_TYPEDEF_NAMESPACE]);
-		if (mono_utf8_strcasecmp (n, name) == 0 && mono_utf8_strcasecmp (nspace, name_space) == 0)
+		if (mono_utf8_strcasecmp (n, name) == 0 && (NULL == name_space || (mono_utf8_strcasecmp (nspace, name_space) == 0)))
 			return mono_class_get_checked (image, MONO_TOKEN_TYPE_DEF | i, error);
 	}
 	return NULL;


### PR DESCRIPTION
@Tak added a patch to allow looking up classes in any namespace by passing a NULL `name_space` parameter to `mono_class_from_name_case`: https://github.com/Unity-Technologies/mono/commit/622a9923ec31ca101ff39c79e05908b3cb245cf5

That patch was lost when we updated to MonoBleedingEdge. While it still works correctly without the patch, this will keep logging annoying asserts to the console like this:

`gstr.c:876: assertion 's2 != NULL' failed`

This PR brings back the fix.