### PR TITLE
Incremental gc editor support

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -633,6 +633,7 @@ mono_domain_create_appdomain_internal (char *friendly_name, MonoAppDomainSetupHa
 	goto_if_nok (error, leave);
 	MONO_HANDLE_SETVAL (ad, data, MonoDomain*, data);
 	data->domain = MONO_HANDLE_RAW (ad);
+	mono_gc_wbarrier_generic_nostore (&data->domain);	
 	data->friendly_name = g_strdup (friendly_name);
 
 	MONO_PROFILER_RAISE (domain_name, (data, data->friendly_name));
@@ -660,6 +661,7 @@ mono_domain_create_appdomain_internal (char *friendly_name, MonoAppDomainSetupHa
 	goto_if_nok (error, leave);
 
 	data->setup = MONO_HANDLE_RAW (copy_app_domain_setup (data, setup, error));
+	mono_gc_wbarrier_generic_nostore (&data->setup);
 	if (!mono_error_ok (error)) {
 		g_free (data->friendly_name);
 		goto leave;

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -454,6 +454,19 @@ mono_gc_is_incremental()
 #endif		
 }
 
+void 
+mono_gc_set_incremental(MonoBoolean value)
+{
+#if HAVE_BDWGC_GC
+	if (GC_is_incremental_mode() == value)
+		return;
+    if (value)
+		GC_enable_incremental();
+	else
+		GC_disable_incremental();
+#endif		
+}
+
 gboolean
 mono_gc_is_gc_thread (void)
 {

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -1096,10 +1096,9 @@ mono_gc_cleanup (void)
 		}
 		gc_thread = NULL;
 		mono_gc_base_cleanup ();
+
+		mono_reference_queue_cleanup ();
 	}
-
-	mono_reference_queue_cleanup ();
-
 	mono_coop_mutex_destroy (&finalizer_mutex);
 	mono_coop_mutex_destroy (&reference_queue_mutex);
 }

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -760,7 +760,7 @@ mono_gc_finalize_notify (void)
 	g_message ( "%s: prodding finalizer", __func__);
 #endif
 
-	if (mono_gc_is_null () || mono_gc_is_disabled())
+	if (mono_gc_is_null ())
 		return;
 
 #ifdef HOST_WASM
@@ -928,6 +928,18 @@ finalizer_thread (gpointer unused)
 	/* Register a hazard free queue pump callback */
 	mono_hazard_pointer_install_free_queue_size_callback (hazard_free_queue_is_too_big);
 
+	/* if GC is disabled, we run no finalizer, but we still run mono_w32process_signal_finished 
+	on the finalizer thread, so that processes can exit. */
+	if (mono_gc_is_disabled())
+	{
+		while (!finished)
+		{
+			mono_coop_sem_wait (&finalizer_sem, MONO_SEM_FLAGS_ALERTABLE);
+			mono_w32process_signal_finished();
+		}
+		return 0;
+	}
+	
 	while (!finished) {
 		/* Wait to be notified that there's at least one
 		 * finaliser to run
@@ -995,10 +1007,8 @@ mono_gc_init (void)
 
 	mono_gc_base_init ();
 
-	if (mono_gc_is_disabled ()) {
+	if (mono_gc_is_disabled ())
 		gc_disabled = TRUE;
-		return;
-	}
 
 #ifdef TARGET_WIN32
 	pending_done_event = CreateEvent (NULL, TRUE, FALSE, NULL);
@@ -1025,9 +1035,9 @@ mono_gc_cleanup (void)
 
 	if (mono_gc_is_null ())
 		return;
-
+	
+	finished = TRUE;
 	if (!gc_disabled) {
-		finished = TRUE;
 		if (mono_thread_internal_current () != gc_thread) {
 			int ret;
 			gint64 start;

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -114,6 +114,7 @@ MONO_API int64_t mono_gc_get_max_time_slice_ns ();
 MONO_API void   mono_gc_set_max_time_slice_ns (int64_t maxTimeSlice);
 MONO_API MonoBoolean mono_gc_pending_finalizers (void);
 MONO_API MonoBoolean mono_gc_is_incremental (void);
+MONO_API void 	mono_gc_set_incremental(MonoBoolean value);
 MONO_API void     mono_gc_finalize_notify    (void);
 MONO_API int    mono_gc_invoke_finalizers (void);
 /* heap walking is only valid in the pre-stop-world event callback */

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -108,6 +108,11 @@ mono_gc_is_incremental()
     return FALSE;
 }
 
+void
+mono_gc_set_incremental(MonoBoolean value)
+{
+}
+
 gboolean
 mono_gc_is_gc_thread (void)
 {

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1993,9 +1993,11 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 	 * vtable field in MonoObject, since we can no longer assume the
 	 * vtable is reachable by other roots after the appdomain is unloaded.
 	 */
-	if (!mono_gc_is_moving () && domain != mono_get_root_domain () && !mono_dont_free_domains)
+#if HAVE_BOEHM_GC
+	if (domain != mono_get_root_domain () && !mono_dont_free_domains)
 		vt->gc_descr = MONO_GC_DESCRIPTOR_NULL;
 	else
+#endif	
 		vt->gc_descr = klass->gc_descr;
 
 	gc_bits = mono_gc_get_vtable_bits (klass);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2844,6 +2844,11 @@ mono_gc_is_incremental()
 }
 
 void
+mono_gc_set_incremental(MonoBoolean value)
+{
+}
+
+void
 mono_gc_set_max_time_slice_ns(int64_t maxTimeSlice)
 {
 }


### PR DESCRIPTION
Changes required to run the editor in incremental gc mode:

-Fix some missing write barriers which get hit on domain reload
-Add an API to disable incremental GC at runtime (to make it possible to switch the setting without requiring an editor restart)
-Make sure that mono_w32process_signal_finished is called even if GC is disabled (otherwise we deadlock in validation mode, as there is no finalizer thread, and child processes are never reported as exited)
-We cannot use gc descriptors in child domains when using BoehmGC, as that crashes the GC when the child domain is unloaded. This was always the case, but mono code used `mono_gc_is_moving` to check for Boehm, which is no longer correct, so we now use an ifdef.