### PR TITLE
[Android] Fix the issue that Environment.TickCount returns wrong value…

### DIFF
--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -91,6 +91,9 @@ mono_100ns_datetime (void)
 
 #include <time.h>
 
+/* a made up uptime of 300 seconds */
+#define MADEUP_BOOT_TIME (300 * MTICKS_PER_SEC)
+
 static gint64
 get_boot_time (void)
 {
@@ -121,14 +124,20 @@ get_boot_time (void)
 		fclose (uptime);
 	}
 #endif
-	/* a made up uptime of 300 seconds */
-	return (gint64)300 * MTICKS_PER_SEC;
+	return (gint64)MADEUP_BOOT_TIME;
 }
 
 /* Returns the number of milliseconds from boot time: this should be monotonic */
 gint64
 mono_msec_boottime (void)
 {
+#if defined(ANDROID)
+	struct timespec ts;
+	if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0) {
+		return (gint64)MADEUP_BOOT_TIME;
+	}
+	return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+#else
 	static gint64 boot_time = 0;
 	gint64 now;
 	if (!boot_time)
@@ -136,6 +145,7 @@ mono_msec_boottime (void)
 	now = mono_100ns_datetime ();
 	/*printf ("now: %llu (boot: %llu) ticks: %llu\n", (gint64)now, (gint64)boot_time, (gint64)(now - boot_time));*/
 	return (now - boot_time)/10000;
+#endif
 }
 
 /* Returns the number of 100ns ticks from unspecified time: this should be monotonic */


### PR DESCRIPTION
[Android] Fix the issue that Environment.TickCount returns wrong value due to /proc/uptime is unaccessible on Android 8 and above.

The root cause is we can't open 'proc/uptime' to get the boot time on Android 8 and above due to Android 8 'proc' permissions change. So we use clock_gettime() on android instead.