### PR TITLE
Don't use exceptions for time zones (case 1100856)

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -209,7 +209,8 @@ namespace System
 					string tzName = null;
 					if (!TryGetNameFromPath (tzFilePath, out tzName))
 						tzName = "Local";
-					return FindSystemTimeZoneByFileName (tzName, tzFilePath);
+					if (File.Exists(tzFilePath))
+						return FindSystemTimeZoneByFileName (tzName, tzFilePath);
 				} catch (TimeZoneNotFoundException) {
 					continue;
 				}


### PR DESCRIPTION
The current class library code uses managed exceptions for flow control
for time zone handling. Specifically, it depends on exceptions to occur
if one of the files that _might_ have time zone information does not
exist.

On Android with IL2CPP we run into problems with C++ exceptions causing
hangs in some cases. Since IL2CPP implements managed exceptions using
C++ exceptions, this code can cause problems.

This change corrects Unity case 1100856.