### PR TITLE
Fix boehm thread pinning

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -562,10 +562,12 @@ create_internal_thread_object (void)
 
 	thread->apartment_state = ThreadApartmentState_Unknown;
 	thread->managed_id = get_next_managed_thread_id ();
-	if (mono_gc_is_moving () && !defined(HAVE_BOEHM_GC)) {
+#if !defined(HAVE_BOEHM_GC)
+	if (mono_gc_is_moving ()) {
 		thread->thread_pinning_ref = thread;
 		MONO_GC_REGISTER_ROOT_PINNING (thread->thread_pinning_ref, MONO_ROOT_SOURCE_THREADING, NULL, "Thread Pinning Reference");
 	}
+#endif	
 
 	thread->priority = MONO_THREAD_PRIORITY_NORMAL;
 
@@ -884,10 +886,12 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 
 	mono_memory_barrier ();
 
-	if (mono_gc_is_moving () && !defined(HAVE_BOEHM_GC)) {
+#if !defined(HAVE_BOEHM_GC)
+	if (mono_gc_is_moving ()) {
 		MONO_GC_UNREGISTER_ROOT (thread->thread_pinning_ref);
 		thread->thread_pinning_ref = NULL;
 	}
+#endif	
 
 done:
 	SET_CURRENT_OBJECT (NULL);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -562,7 +562,7 @@ create_internal_thread_object (void)
 
 	thread->apartment_state = ThreadApartmentState_Unknown;
 	thread->managed_id = get_next_managed_thread_id ();
-	if (mono_gc_is_moving ()) {
+	if (mono_gc_is_moving () && !HAVE_BOEHM_GC) {
 		thread->thread_pinning_ref = thread;
 		MONO_GC_REGISTER_ROOT_PINNING (thread->thread_pinning_ref, MONO_ROOT_SOURCE_THREADING, NULL, "Thread Pinning Reference");
 	}
@@ -884,7 +884,7 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 
 	mono_memory_barrier ();
 
-	if (mono_gc_is_moving ()) {
+	if (mono_gc_is_moving () && !HAVE_BOEHM_GC) {
 		MONO_GC_UNREGISTER_ROOT (thread->thread_pinning_ref);
 		thread->thread_pinning_ref = NULL;
 	}

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -562,7 +562,7 @@ create_internal_thread_object (void)
 
 	thread->apartment_state = ThreadApartmentState_Unknown;
 	thread->managed_id = get_next_managed_thread_id ();
-	if (mono_gc_is_moving () && !HAVE_BOEHM_GC) {
+	if (mono_gc_is_moving () && !defined(HAVE_BOEHM_GC)) {
 		thread->thread_pinning_ref = thread;
 		MONO_GC_REGISTER_ROOT_PINNING (thread->thread_pinning_ref, MONO_ROOT_SOURCE_THREADING, NULL, "Thread Pinning Reference");
 	}
@@ -884,7 +884,7 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 
 	mono_memory_barrier ();
 
-	if (mono_gc_is_moving () && !HAVE_BOEHM_GC) {
+	if (mono_gc_is_moving () && !defined(HAVE_BOEHM_GC)) {
 		MONO_GC_UNREGISTER_ROOT (thread->thread_pinning_ref);
 		thread->thread_pinning_ref = NULL;
 	}


### PR DESCRIPTION
This was causing crashes around domain reloads when using incremental GC in the editor. It is not needed for Boehm.