### PR TITLE
Fix System.Numerics sizes

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1999,9 +1999,6 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				real_size = field_offsets [i] + size;
 			}
 
-			/* Make SIMD types as big as a SIMD register since they can be stored into using simd stores */
-			if (klass->simd_type)
-				real_size = MAX (real_size, sizeof (MonoObject) + 16);
 			instance_size = MAX (real_size, instance_size);
        
 			if (instance_size & (min_align - 1)) {
@@ -5837,7 +5834,9 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		if (!strncmp (name, "Vector", 6))
 			klass->simd_type = !strcmp (name + 6, "2d") || !strcmp (name + 6, "2ul") || !strcmp (name + 6, "2l") || !strcmp (name + 6, "4f") || !strcmp (name + 6, "4ui") || !strcmp (name + 6, "4i") || !strcmp (name + 6, "8s") || !strcmp (name + 6, "8us") || !strcmp (name + 6, "16b") || !strcmp (name + 6, "16sb");
 	} else if (klass->image->assembly_name && !strcmp (klass->image->assembly_name, "System.Numerics") && !strcmp (nspace, "System.Numerics")) {
-		if (!strcmp (name, "Vector2") || !strcmp (name, "Vector3") || !strcmp (name, "Vector4"))
+		/* The JIT can't handle SIMD types with != 16 size yet */
+		//if (!strcmp (name, "Vector2") || !strcmp (name, "Vector3") || !strcmp (name, "Vector4"))
+		if (!strcmp (name, "Vector4"))
 			klass->simd_type = 1;
 	}
 

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -2081,6 +2081,9 @@ emit_vector_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignatu
 	MonoMethodSignature *sig = mono_method_signature (cmethod);
 	MonoType *type = &cmethod->klass->byval_arg;
 
+	if (!cmethod->klass->simd_type)
+		return NULL;
+
 	/*
 	 * Vector2/3/4 are handled the same way, since the underlying SIMD type is the same (4 * r4).
 	 */


### PR DESCRIPTION
[jit] Avoid extending the size of Vector2/Vector3 to 16 bytes. Disable SIMD for these types for now, since the SIMD code can't handle types (#6746)

which are smaller than a SIMD reg.

Fixes https://github.com/mono/mono/issues/6411.

Fixes Unity case 1118631 

https://issuetracker.unity3d.com/issues/system-dot-numerics-vector-sizes-are-all-16-bytes-instead-of-8-12-and-16-bytes