### PR TITLE
Grow StackSlotInfo array rather than asserting (case 1103205)

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1157,6 +1157,7 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 	StackSlotInfo *scalar_stack_slots, *vtype_stack_slots, *slot_info;
 	MonoType *t;
 	int nvtypes;
+	int vtype_stack_slots_size = 256;
 	gboolean reuse_slot;
 
 	LSCAN_DEBUG (printf ("Allocate Stack Slots 2 for %s:\n", mono_method_full_name (cfg->method, TRUE)));
@@ -1235,14 +1236,22 @@ mono_allocate_stack_slots2 (MonoCompile *cfg, gboolean backward, guint32 *stack_
 			/* Fall through */
 		case MONO_TYPE_VALUETYPE:
 			if (!vtype_stack_slots)
-				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * 256);
+				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * vtype_stack_slots_size);
 			for (i = 0; i < nvtypes; ++i)
 				if (t->data.klass == vtype_stack_slots [i].vtype)
 					break;
 			if (i < nvtypes)
 				slot_info = &vtype_stack_slots [i];
 			else {
-				g_assert (nvtypes < 256);
+				if (nvtypes == vtype_stack_slots_size) {
+					int new_slots_size = vtype_stack_slots_size * 2;
+					StackSlotInfo* new_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * new_slots_size);
+
+					memcpy (new_slots, vtype_stack_slots, sizeof (StackSlotInfo) * vtype_stack_slots_size);
+
+					vtype_stack_slots = new_slots;
+					vtype_stack_slots_size = new_slots_size;
+				}
 				vtype_stack_slots [nvtypes].vtype = t->data.klass;
 				slot_info = &vtype_stack_slots [nvtypes];
 				nvtypes ++;
@@ -1468,6 +1477,7 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 	StackSlotInfo *scalar_stack_slots, *vtype_stack_slots, *slot_info;
 	MonoType *t;
 	int nvtypes;
+	int vtype_stack_slots_size = 256;
 	gboolean reuse_slot;
 
 	if ((cfg->num_varinfo > 0) && MONO_VARINFO (cfg, 0)->interval)
@@ -1533,14 +1543,22 @@ mono_allocate_stack_slots (MonoCompile *cfg, gboolean backward, guint32 *stack_s
 			/* Fall through */
 		case MONO_TYPE_VALUETYPE:
 			if (!vtype_stack_slots)
-				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * 256);
+				vtype_stack_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * vtype_stack_slots_size);
 			for (i = 0; i < nvtypes; ++i)
 				if (t->data.klass == vtype_stack_slots [i].vtype)
 					break;
 			if (i < nvtypes)
 				slot_info = &vtype_stack_slots [i];
 			else {
-				g_assert (nvtypes < 256);
+				if (nvtypes == vtype_stack_slots_size) {
+					int new_slots_size = vtype_stack_slots_size * 2;
+					StackSlotInfo* new_slots = (StackSlotInfo *)mono_mempool_alloc0 (cfg->mempool, sizeof (StackSlotInfo) * new_slots_size);
+
+					memcpy (new_slots, vtype_stack_slots, sizeof (StackSlotInfo) * vtype_stack_slots_size);
+
+					vtype_stack_slots = new_slots;
+					vtype_stack_slots_size = new_slots_size;
+				}
 				vtype_stack_slots [nvtypes].vtype = t->data.klass;
 				slot_info = &vtype_stack_slots [nvtypes];
 				nvtypes ++;


### PR DESCRIPTION
case 1103205 - Fix crash when method has large number of types used