### PR TITLE
Use wrapped method if available (case 1093274)

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1087,13 +1087,14 @@ mono_param_get_objects_internal (MonoDomain *domain, MonoMethod *method, MonoCla
 		return res;
 	}
 
-	/* UNITY: wrapper methods are being captured in callstacks, even thought users should not encounter them.
-	 * The logic in param_objects_construct cannot handle this. Just return empty array (case 1073634) */
+	/* Wrapper methods are exposed in stack traces.
+	 * The logic in param_objects_construct cannot handle some wrappers.
+	 * Get the underlying method if it's available.
+	 */
 	if (method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
-		MonoArrayHandle res = mono_array_new_handle (domain, mono_class_get_mono_parameter_info_class (), 0, error);
-		goto_if_nok (error, fail);
-
-		return res;
+		MonoMethod* wrapped_method = mono_marshal_method_from_wrapper (method);
+		if (wrapped_method)
+			method = wrapped_method;
 	}
 
 	/* Note: the cache is based on the address of the signature into the method


### PR DESCRIPTION
Reverts part of fix for case 1073634

Release Notes: Fix TargetParameterCountException if target method is PInvoke

Previously we returned empty parameter info array. Unfortunately this array is used to match delegate and method signatures for invokes. In some cases a delegate is targeting a PInvoke and previous logic would cause signatures to not match.

Fixes https://issuetracker.unity3d.com/issues/targetparametercountexception-errors-are-thrown-after-importing-substance-in-unity-asset