### PR TITLE
Fix serialization issue with DataContractJsonSerializer UseSimpleDictionaryFormat (case 1070667)

### DIFF
--- a/mcs/class/System.Runtime.Serialization/ReferenceSources/JsonFormatReaderGenerator_static.cs
+++ b/mcs/class/System.Runtime.Serialization/ReferenceSources/JsonFormatReaderGenerator_static.cs
@@ -508,7 +508,9 @@ namespace System.Runtime.Serialization.Json
 					var jsonMemberName = XmlObjectSerializerReadContextComplexJson.GetJsonMemberName (xmlReader);
 					object key = null;
 
-					if (keyParseMode == KeyParseMode.UsingParseEnum)
+					if (keyParseMode == KeyParseMode.AsString)
+						key = jsonMemberName;
+					else if (keyParseMode == KeyParseMode.UsingParseEnum)
 						key = Enum.Parse (keyType, jsonMemberName);
 					else if (keyParseMode == KeyParseMode.UsingCustomParse)
 						key = keyDataContract.ParseMethod.Invoke (null, new object [] {jsonMemberName});


### PR DESCRIPTION
graft of upstream fix https://github.com/mono/mono/pull/9342/files for case 1070667
I've grafted only the code change and verified it fixes the issue locally.

Release Notes
Scripting: Fixes issue where DataContractJsonSerializer UseSimpleDictionaryFormat would fail to deserialize a dictionary (case 1070667)