### PR TITLE
Break out of outter loop once file is found. (case 1118285)

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3824,7 +3824,7 @@ create_event_list (EventKind event, GPtrArray *reqs, MonoJitInfo *ji, DebuggerEv
 							break;
 					}
 #else
-					while ((method = mono_class_get_methods (ei->klass, &iter))) {
+					while (!found && (method = mono_class_get_methods (ei->klass, &iter))) {
 						MonoDebugMethodInfo *minfo = mono_debug_lookup_method (method);
 
 						if (minfo) {


### PR DESCRIPTION
We were overwriting a `found` value of `TRUE` with `FALSE` on subsequent iterations.

case 1118285 - Fix breakpoint resolution for methods in partial classes