### PR TITLE
Fix warning crash

### DIFF
--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -189,7 +189,7 @@ selector_thread_wakeup_drain_pipes (void)
 			break;
 		if (received == SOCKET_ERROR) {
 			if (WSAGetLastError () != WSAEINTR && WSAGetLastError () != WSAEWOULDBLOCK)
-				g_warning ("selector_thread_wakeup_drain_pipes: recv () failed, error (%d) %s\n", WSAGetLastError ());
+				g_warning ("selector_thread_wakeup_drain_pipes: recv () failed, error (%d)\n", WSAGetLastError ());
 			break;
 		}
 #endif


### PR DESCRIPTION
The format string was incorrect in this case, which leads to this crash
in Unity:

https://crashes.hq.unity3d.com/crashes/5aa00d01b4db11000de20c8e?versions_range=2018.3.5..2019.2.99&date_start=&date_end=&source=

Simply remove the unused `%s` format specifier here.

I'm planing to back port this change to 2019.1 and 2018.3.

Release notes:

Mono: Fix an intermittent crash in strnlen, from the selector_thread_wakeup_drain_pipes function.

I'll also upstream this fix once it lands in our repo.