### PR TITLE
Fix data race when accessing and destroying mono_profiler_state.profilers_readers

### DIFF
--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -48,6 +48,7 @@ typedef struct {
 	gboolean startup_done;
 
 	MonoProfilerHandle profilers;
+	volatile gint32 profilers_readers;
 
 	gboolean code_coverage;
 	mono_mutex_t coverage_mutex;

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -1025,7 +1025,28 @@ mono_profiler_cleanup (void)
 #undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
+	/* Aqcuire the write lock */
+	do {
+		gint32 readers = mono_atomic_load_i32(&mono_profiler_state.profilers_readers);
+		if(readers == 0) {
+			if(mono_atomic_cas_i32(&mono_profiler_state.profilers_readers, -1, readers) == 0)
+				break;
+		}
+		mono_thread_info_yield();
+	} while(1);
+
 	MonoProfilerHandle head = mono_profiler_state.profilers;
+	mono_profiler_state.profilers = NULL;
+
+	/* Release the write lock */
+	do {
+		gint32 readers = mono_atomic_load_i32(&mono_profiler_state.profilers_readers);
+		if(readers == -1) {
+			if(mono_atomic_cas_i32(&mono_profiler_state.profilers_readers, 0, readers) == -1)
+				break;
+		}
+		mono_thread_info_yield();
+	} while(1);
 
 	while (head) {
 		MonoProfilerCleanupCallback cb = head->cleanup_callback;
@@ -1099,11 +1120,32 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	void \
 	mono_profiler_raise_ ## name params \
 	{ \
+		/* Acquire the read lock */ \
+		do { \
+			gint32 readers = mono_atomic_load_i32(&mono_profiler_state.profilers_readers); \
+			if(readers != -1) { \
+				gint32 new_readers = readers+1; \
+				if(mono_atomic_cas_i32(&mono_profiler_state.profilers_readers, new_readers, readers) == readers) \
+					break; \
+			} \
+			mono_thread_info_yield(); \
+		} while(1); \
+		/* Call the callbacks */ \
 		for (MonoProfilerHandle h = mono_profiler_state.profilers; h; h = h->next) { \
 			MonoProfiler ## type ## Callback cb = h->name ## _cb; \
 			if (cb) \
 				cb args; \
 		} \
+		/* Release the read lock */ \
+		do { \
+			gint32 readers = mono_atomic_load_i32(&mono_profiler_state.profilers_readers); \
+			if(readers != -1) { \
+				gint32 new_readers = readers-1; \
+				if(mono_atomic_cas_i32(&mono_profiler_state.profilers_readers, new_readers, readers) == readers) \
+					break; \
+			} \
+			mono_thread_info_yield(); \
+		} while(1); \
 	}
 #define MONO_PROFILER_EVENT_0(name, type) \
 	_MONO_PROFILER_EVENT(name, type, (void), (h->prof))


### PR DESCRIPTION
As seen in various crashes during teardown on Linux - a thread would reach `mono_profiler_raise_thread_stopped` or other callback iterators, at the same time as `mono_profiler_cleanup` was being called on the main thread.

While iterating the profilers to trigger callbacks, the main thread can free up the actual profiler objects in the `profilers` linked list, causing either an immediate `SIGSEGV` or more commonly, if another thread has managed to allocate into the same spot on the heap, undefined memory access and/or heap corruption.

Mono doesn't have an internal read-write lock, or lockless list implementation that can be iterated on during destruction, so I've implemented a simple read-write lock with an int32 counter for the number of readers, this allows the main thread to take a write lock when it needs to actually change the linked list, but the threads triggering callbacks are never actually in contention as they only ever grab the read lock.