### PR TITLE
OS synchronization context

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/exception.cs
+++ b/mcs/class/referencesource/mscorlib/system/exception.cs
@@ -1114,6 +1114,9 @@ namespace System {
 
             return this;
         }
+		
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern void ReportUnhandledException(Exception exception);
 #endif
     }
 

--- a/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs
@@ -420,10 +420,17 @@ namespace System.Threading
         [MonoPInvokeCallback(typeof(InvocationEntryDelegate))]
         private static void InvocationEntry(IntPtr arg)
         {
-            var invocationContextHandle = GCHandle.FromIntPtr(arg);
-            var invocationContext = (InvocationContext)invocationContextHandle.Target;
-            invocationContextHandle.Free();
-            invocationContext.Invoke();
+			try
+			{
+				var invocationContextHandle = GCHandle.FromIntPtr(arg);
+				var invocationContext = (InvocationContext)invocationContextHandle.Target;
+				invocationContextHandle.Free();
+				invocationContext.Invoke();
+			}
+			catch (Exception e)
+			{
+				Exception.ReportUnhandledException(e);
+			}
         }
 
 		[AttributeUsage (AttributeTargets.Method)]

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1183,3 +1183,10 @@ mono_exception_from_name_four_strings_checked (MonoImage *image, const char *nam
 
 	return create_exception_four_strings (klass, a1, a2, a3, a4, error);
 }
+
+void
+ves_icall_System_Exception_ReportUnhandledException(MonoObject *exc)
+{
+	mono_unhandled_exception (exc);
+	mono_invoke_unhandled_exception_hook (exc);
+}

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -161,6 +161,9 @@ typedef void  (*MonoUnhandledExceptionFunc)         (MonoObject *exc, void *user
 MONO_API void mono_install_unhandled_exception_hook (MonoUnhandledExceptionFunc func, void *user_data);
 void          mono_invoke_unhandled_exception_hook  (MonoObject *exc);
 
+void
+ves_icall_System_Exception_ReportUnhandledException (MonoObject *exc);
+
 MONO_END_DECLS
 
 #endif /* _MONO_METADATA_EXCEPTION_H_ */

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -293,6 +293,9 @@ HANDLES(ICALL(ENV_18, "internalGetGacPath", ves_icall_System_Environment_GetGacP
 HANDLES(ICALL(ENV_19, "internalGetHome", ves_icall_System_Environment_InternalGetHome))
 ICALL(ENV_20, "set_ExitCode", mono_environment_exitcode_set)
 
+ICALL_TYPE(EXCEPTION, "System.Exception", EXCEPTION_1)
+HANDLES(ICALL(EXCEPTION_1, "ReportUnhandledException", ves_icall_System_Exception_ReportUnhandledException))
+
 ICALL_TYPE(GC, "System.GC", GC_0)
 ICALL(GC_0, "GetCollectionCount", mono_gc_collection_count)
 ICALL(GC_0a, "GetGeneration", mono_gc_get_generation)

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -935,6 +935,10 @@ HANDLES(ICALL(NATIVEC_3, "OpenEvent_internal(string,System.Security.AccessContro
 ICALL(NATIVEC_4, "ResetEvent_internal",  ves_icall_System_Threading_Events_ResetEvent_internal)
 ICALL(NATIVEC_5, "SetEvent_internal",    ves_icall_System_Threading_Events_SetEvent_internal)
 
+ICALL_TYPE(OSSYNCCONTEXT, "System.Threading.OSSpecificSynchronizationContext", OSSYNCCONTEXT_1)
+HANDLES(ICALL(OSSYNCCONTEXT_1, "GetOSContext", ves_icall_System_Threading_OSSpecificSynchronizationContext_GetOSContext))
+ICALL(OSSYNCCONTEXT_2, "PostInternal", ves_icall_System_Threading_OSSpecificSynchronizationContext_PostInternal)
+
 ICALL_TYPE(SEMA, "System.Threading.Semaphore", SEMA_1)
 ICALL(SEMA_1, "CreateSemaphore_internal(int,int,string,int&)", ves_icall_System_Threading_Semaphore_CreateSemaphore_internal)
 ICALL(SEMA_2, "OpenSemaphore_internal(string,System.Security.AccessControl.SemaphoreRights,int&)", ves_icall_System_Threading_Semaphore_OpenSemaphore_internal)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8751,3 +8751,15 @@ mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignatu
 	return mono_register_jit_icall_full (func, name, sig, no_wrapper, NULL);
 }
 
+MonoObjectHandle
+ves_icall_System_Threading_OSSpecificSynchronizationContext_GetOSContext ()
+{
+	return NULL_HANDLE;
+}
+
+void
+ves_icall_System_Threading_OSSpecificSynchronizationContext_PostInternal (gpointer callback, gpointer arg)
+{
+	/* This isn't actually reachable since ves_icall_System_Threading_OSSpecificSynchronizationContext_GetOSContext always returns NULL */
+	mono_set_pending_exception (mono_get_exception_not_implemented ("System.Threading.InteropServices.OSSpecificSynchronizationContext.PostInternal internal call is not implemented."));
+}

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -267,4 +267,10 @@ mono_thread_internal_describe (MonoInternalThread *internal, GString *str);
 gboolean
 mono_thread_internal_is_current (MonoInternalThread *internal);
 
+MonoObjectHandle
+ves_icall_System_Threading_OSSpecificSynchronizationContext_GetOSContext ();
+
+void
+ves_icall_System_Threading_OSSpecificSynchronizationContext_PostInternal (gpointer callback, gpointer arg);
+
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */


### PR DESCRIPTION
This PR implements a mechanism for the runtime to provide a fallback SynchronizationContext. This is needed in scenarios where managed code doesn't necessarily set its own SynchronizationContext and awaits on OS UI thread. .NET runtime makes sure that we end up on the same thread after await, but there was no such mechanism in IL2CPP. Since the way it's handled is highly platform specific, I decided to implement those details in il2cpp OS abstraction layer.

This is one part of the fix for https://fogbugz.unity3d.com/f/cases/1130193/ (another part is in IL2CPP).

Is there anything I can do to minimize the risk of these changes? I made sure Mono builds on katana: 

https://katana.bf.unity3d.com/projects/Mono%20Runtime%20and%20Classlibs/builders?krait-signal-handler_branch=master&mono-build-deps_branch=default&mono_branch=os-synchronization-context&boo_branch=unity-trunk&cecil_branch=unity-master&unityscript_branch=unity-trunk&mono-build-tools-extra_branch=master

However, I don't think any tests run there.