### PR TITLE
Use bokken runner for windows builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,13 +119,20 @@ build_android:
 build_win:
   stage: build
   tags:
-  - buildfarm
-  - windows
+    - bokken-job
+  variables:
+    BOKKEN_VM: build_win_vm
+    BOKKEN_JOB: |
+      resources:
+        - name: build_win_vm
+          image: platform-foundation/windows-mono-bokken:latest
+          flavor: b1.xlarge
+          type: Unity::VM
   script:
   - git submodule update --init --recursive
   - perl external/buildscripts/build_runtime_win64.pl --stevedorebuilddeps=1
-  - mkdir -p incomingbuilds/win64
-  - cp -r builds/* incomingbuilds/win64/
+  - powershell mkdir -p incomingbuilds/win64
+  - powershell cp -r builds/* incomingbuilds/win64/
   artifacts:
     paths:
     - incomingbuilds/win64
@@ -137,13 +144,20 @@ build_win:
 build_win_x86:
   stage: build
   tags:
-  - buildfarm
-  - windows
+    - bokken-job
+  variables:
+    BOKKEN_VM: build_win_x86_vm
+    BOKKEN_JOB: |
+      resources:
+        - name: build_win_x86_vm
+          image: platform-foundation/windows-mono-bokken:latest
+          flavor: b1.xlarge
+          type: Unity::VM
   script:
   - git submodule update --init --recursive
   - perl external/buildscripts/build_runtime_win.pl --stevedorebuilddeps=1
-  - mkdir -p incomingbuilds/win32
-  - cp -r builds/* incomingbuilds/win32/
+  - powershell mkdir -p incomingbuilds/win32
+  - powershell cp -r builds/* incomingbuilds/win32/
   artifacts:
     paths:
     - incomingbuilds/win32
@@ -155,13 +169,20 @@ build_win_x86:
 build_win_bare_minimum:
   stage: build
   tags:
-  - buildfarm
-  - windows
+    - bokken-job
+  variables:
+    BOKKEN_VM: build_win_bare_minimum
+    BOKKEN_JOB: |
+      resources:
+        - name: build_win_bare_minimum
+          image: platform-foundation/windows-mono-bokken:latest
+          flavor: b1.xlarge
+          type: Unity::VM
   script:
   - git submodule update --init --recursive
   - perl external/buildscripts/build_unityscript_bareminimum_win.pl
-  - mkdir -p incomingbuilds/bareminimum
-  - cp -r builds/* incomingbuilds/bareminimum/
+  - powershell mkdir -p incomingbuilds/bareminimum
+  - powershell cp -r builds/* incomingbuilds/bareminimum/
   artifacts:
     paths:
     - incomingbuilds/bareminimum

--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -40,6 +40,11 @@ sub CompileVCProj
 	my $config;
 
 	my $msbuild = $ENV{"ProgramFiles(x86)"}."/MSBuild/$msBuildVersion/Bin/MSBuild.exe";
+	
+	if ((! -d $extraBuildTools) || ($ENV{YAMATO_PROJECT_ID}) || ($ENV{USERNAME} == "bokken"))
+	{
+		$msbuild = $ENV{"ProgramFiles(x86)"}."/Microsoft Visual Studio/2017/Professional/MSBuild/15.0/Bin/MSBuild.exe";
+	}
 
     $config = $debug ? "Debug" : "Release";
 	my $arch = $arch32 ? "Win32" : "x64";

--- a/external/buildscripts/build_win_no_cygwin.pl
+++ b/external/buildscripts/build_win_no_cygwin.pl
@@ -39,6 +39,11 @@ my $msBuildVersion = "14.0";
 my $buildDeps = "";
 my $stevedoreBuildDeps=1;
 
+if($ENV{YAMATO_PROJECT_ID} || ($ENV{USERNAME} == "bokken"))
+{
+	$msBuildVersion = "15.0";			
+}
+
 print(">>> Build All Args = @ARGV\n");
 
 GetOptions(


### PR DESCRIPTION
Windows Buildfarm runners are currently broken. Switch to bokken.

Tested on a commit before squash: 
Win64: https://gitlab.cds.internal.unity3d.com/vm/mono/-/jobs/306706
Win32: https://gitlab.cds.internal.unity3d.com/vm/mono/-/jobs/306707
BareMininum: https://gitlab.cds.internal.unity3d.com/vm/mono/-/jobs/306708
