### PR TITLE
Avoid unhandled DllNotFoundException in System.Net on platforms without libc

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/IPGlobalProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/IPGlobalProperties.cs
@@ -68,6 +68,8 @@ namespace System.Net.NetworkInformation {
 #if UNITY
 				} catch (EntryPointNotFoundException) {
 					return String.Empty;
+				} catch (DllNotFoundException) {
+					return String.Empty;
 				}
 #endif
 				int len = Array.IndexOf<byte> (bytes, 0);


### PR DESCRIPTION
For certain more exotic platforms, [DllImport ("libc")] does not work even if most of the code in System.Net does work. This pull request catches the exception thrown when System.Net classes try to call getdomainname, which does a pinvoke into libc. 