### PR TITLE
Expose mono_string_to_utf8_checked and mono_error_*

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1449,7 +1449,7 @@ mono_class_compute_gc_descriptor (MonoClass *class) MONO_INTERNAL;
 void
 mono_string_initialize_empty (MonoDomain *domain, MonoClass *stringClass);
 
-MONO_API char *
+char *
 mono_string_to_utf8_checked (MonoString *s, MonoError *error);
 
 gboolean

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1449,8 +1449,8 @@ mono_class_compute_gc_descriptor (MonoClass *class) MONO_INTERNAL;
 void
 mono_string_initialize_empty (MonoDomain *domain, MonoClass *stringClass);
 
-char *
-mono_string_to_utf8_checked (MonoString *s, MonoError *error) MONO_INTERNAL;
+MONO_API char *
+mono_string_to_utf8_checked (MonoString *s, MonoError *error);
 
 gboolean
 mono_class_is_reflection_method_or_constructor (MonoClass *class) MONO_INTERNAL;

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -43,7 +43,6 @@ typedef struct {
 
 G_BEGIN_DECLS
 
-MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_error_init (MonoError *error);
 

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -43,23 +43,24 @@ typedef struct {
 
 G_BEGIN_DECLS
 
-void
-mono_error_init (MonoError *error) MONO_INTERNAL;
+MONO_RT_EXTERNAL_ONLY
+MONO_API void
+mono_error_init (MonoError *error);
 
-void
-mono_error_init_flags (MonoError *error, unsigned short flags) MONO_INTERNAL;
+MONO_API void
+mono_error_init_flags (MonoError *error, unsigned short flags);
 
-void
-mono_error_cleanup (MonoError *error) MONO_INTERNAL;
+MONO_API void
+mono_error_cleanup (MonoError *error);
 
-gboolean
-mono_error_ok (MonoError *error) MONO_INTERNAL;
+MONO_API gboolean
+mono_error_ok (MonoError *error);
 
-unsigned short
-mono_error_get_error_code (MonoError *error) MONO_INTERNAL;
+MONO_API unsigned short
+mono_error_get_error_code (MonoError *error);
 
-const char*
-mono_error_get_message (MonoError *error) MONO_INTERNAL;
+MONO_API const char*
+mono_error_get_message (MonoError *error);
 
 G_END_DECLS
 #endif

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -43,22 +43,22 @@ typedef struct {
 
 G_BEGIN_DECLS
 
-MONO_API void
+void
 mono_error_init (MonoError *error);
 
-MONO_API void
+void
 mono_error_init_flags (MonoError *error, unsigned short flags);
 
-MONO_API void
+void
 mono_error_cleanup (MonoError *error);
 
-MONO_API gboolean
+gboolean
 mono_error_ok (MonoError *error);
 
-MONO_API unsigned short
+unsigned short
 mono_error_get_error_code (MonoError *error);
 
-MONO_API const char*
+const char*
 mono_error_get_message (MonoError *error);
 
 G_END_DECLS

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -826,6 +826,12 @@ mono_runtime_unhandled_exception_policy_set
 set_vprintf_func
 mono_type_is_reference
 mono_array_addr_with_size
+mono_error_init
+mono_error_init_flags
+mono_error_cleanup
+mono_error_ok
+mono_error_get_error_code
+mono_error_get_message
 
 mono_unity_runtime_set_main_args
 mono_unity_string_empty_wrapper

--- a/msvc/mono.def
+++ b/msvc/mono.def
@@ -748,6 +748,7 @@ mono_string_new_utf16
 mono_string_new_wrapper
 mono_string_to_utf16
 mono_string_to_utf8
+mono_string_to_utf8_checked
 mono_stringify_assembly_name
 mono_table_info_get_rows
 mono_thread_abort_all_other_threads


### PR DESCRIPTION
These are already exposed in  `unity-2018.3-mbe` but are needed for exception-safe code usage of `mono_string_to_utf8`.

See:
https://www.mono-project.com/docs/advanced/runtime/docs/mono-error/
http://docs.go-mono.com/index.aspx?link=xhtml%3Adeploy%2Fmono-api-string.html