### PR TITLE
[Backport unity-2019.1-mbe] Add stevedore conf

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,7 @@ build_osx_runtime:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   script:
   - git submodule update --init --recursive
+  - cp .yamato/config/Stevedore.conf ~/Stevedore.conf
   - cd external/buildscripts
   - ./bee
   - cd ../..
@@ -66,6 +67,7 @@ build_osx_classlibs:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   script:
   - git submodule update --init --recursive
+  - cp .yamato/config/Stevedore.conf ~/Stevedore.conf
   - cd external/buildscripts
   - ./bee
   - cd ../..
@@ -102,6 +104,7 @@ build_android:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   script:
   - git submodule update --init --recursive
+  - cp .yamato/config/Stevedore.conf ~/Stevedore.conf
   - cd external/buildscripts
   - ./bee
   - cd ../..

--- a/.yamato/build_android.sh
+++ b/.yamato/build_android.sh
@@ -1,4 +1,5 @@
 git submodule update --init --recursive
+cp .yamato/config/Stevedore.conf ~/Stevedore.conf
 cd external/buildscripts
 ./bee
 cd ../..

--- a/.yamato/build_osx_classlibs.sh
+++ b/.yamato/build_osx_classlibs.sh
@@ -1,4 +1,5 @@
 git submodule update --init --recursive
+cp .yamato/config/Stevedore.conf ~/Stevedore.conf
 cd external/buildscripts
 ./bee
 cd ../..

--- a/.yamato/build_osx_runtime.sh
+++ b/.yamato/build_osx_runtime.sh
@@ -1,4 +1,5 @@
 git submodule update --init --recursive
+cp .yamato/config/Stevedore.conf ~/Stevedore.conf
 cd external/buildscripts
 ./bee
 cd ../..

--- a/.yamato/config/Stevedore.conf
+++ b/.yamato/config/Stevedore.conf
@@ -1,0 +1,34 @@
+# ~/Stevedore.conf (contact: #devs-stevedore)
+# Best practice config for Slough (SLO) machines
+
+# Do not use OAuth interactive authorization
+oauth.client-id =
+
+# Prevent instabilities if artifacts are requested from the wrong
+# repository (in which case a cache hit could mask the error).
+cache-folder.group-by-repo = true
+
+# No proxy needed to reach build farm mirror (and as of this writing,
+# Stevedore does not support NO_PROXY).
+proxy =
+
+# The timeout limits time spent waiting for the HTTP response headers.
+# For a cache miss, artifactory-slo won't respond until it has downloaded
+# the entire artifact from the origin server. 100s should be enough for
+# even the largest artifacts and a slow origin (e.g. 1 GB at 10 MB/s).
+timeout = 100000
+
+# For telemetry, we DO need proxy (and with a low 5s timeout)
+telemetry = full
+telemetry.proxy = http://proxy.bf.unity3d.com:3128
+telemetry.tag = unity-rec-slo
+telemetry.timeout = 5000
+
+# Use mirror for retrieving all artifacts
+repo.public.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-public/
+repo.main.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-main/
+repo.unity-internal.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-unity-internal/
+repo.testing.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-testing/
+repo.ms-consoles.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-ms-consoles/
+repo.sony-consoles.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-sony-consoles/
+repo.nintendo-consoles.url = https://artifactory-slo.bf.unity3d.com/artifactory/public-generic-stevedore-nintendo-consoles/


### PR DESCRIPTION
Recent firewall changes cause artifact download failure on `buildfarm/mac:latest`

For builds using `buildfarm/mac:latest`, add Stevedore.conf to download from Slough mirror and copy it to home directory. This image is hand-built, so we have to do it in the script.

For other images, I will add the config to the image and rebuild it.