### PR TITLE
Compile ProcessImportedType in IDataContractSurrogate for unityaot

### DIFF
--- a/mcs/class/Facades/System.Runtime.Serialization.Xml/DataContractSerializerExtensions.cs
+++ b/mcs/class/Facades/System.Runtime.Serialization.Xml/DataContractSerializerExtensions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !NO_CODEDOM
+#if !NO_CODEDOM || UNITY_AOT
 using System.CodeDom;
 #endif
 using System.Collections.ObjectModel;
@@ -73,7 +73,7 @@ namespace System.Runtime.Serialization
                 throw NotImplemented.ByDesign;
             }
 
-#if !NO_CODEDOM
+#if !NO_CODEDOM || UNITY_AOT
             public CodeTypeDeclaration ProcessImportedType(CodeTypeDeclaration typeDeclaration, CodeCompileUnit compileUnit)
             {
                 throw NotImplemented.ByDesign;

--- a/mcs/class/System/System.CodeDom/CodeCompileUnit.cs
+++ b/mcs/class/System/System.CodeDom/CodeCompileUnit.cs
@@ -1,0 +1,7 @@
+#if UNITY_AOT
+
+public class CodeCompileUnit
+{
+}
+
+#endif

--- a/mcs/class/System/System.CodeDom/CodeTypeDeclaration.cs
+++ b/mcs/class/System/System.CodeDom/CodeTypeDeclaration.cs
@@ -1,0 +1,7 @@
+#if UNITY_AOT
+
+public class CodeTypeDeclaration
+{
+}
+
+#endif

--- a/mcs/class/System/unityaot_System.dll.sources
+++ b/mcs/class/System/unityaot_System.dll.sources
@@ -2,3 +2,5 @@
 ../System.Web/System.Web/HttpUtility.cs
 ../System.Web/System.Web.Util/Helpers.cs
 ../System.Web/System.Web.Util/HttpEncoder.cs
+System.CodeDom/CodeCompileUnit.cs
+System.CodeDom/CodeTypeDeclaration.cs

--- a/mcs/class/referencesource/System.Runtime.Serialization/System/Runtime/Serialization/IDataContractSurrogate.cs
+++ b/mcs/class/referencesource/System.Runtime.Serialization/System/Runtime/Serialization/IDataContractSurrogate.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.Serialization
         object GetCustomDataToExport(Type clrType, Type dataContractType);
         void GetKnownCustomDataTypes(Collection<Type> customDataTypes);
         Type GetReferencedTypeOnImport(string typeName, string typeNamespace, object customData);
-#if !NO_CODEDOM
+#if !NO_CODEDOM || UNITY_AOT
         CodeTypeDeclaration ProcessImportedType(CodeTypeDeclaration typeDeclaration, CodeCompileUnit compileUnit);
 #endif
     }
@@ -70,7 +70,7 @@ namespace System.Runtime.Serialization
                 return null;
             return surrogate.GetReferencedTypeOnImport(typeName, typeNamespace, customData);
         }
-#if !NO_CODEDOM
+#if !NO_CODEDOM || UNITY_AOT
         internal static CodeTypeDeclaration ProcessImportedType(IDataContractSurrogate surrogate, CodeTypeDeclaration typeDeclaration, CodeCompileUnit compileUnit)
         {
             return surrogate.ProcessImportedType(typeDeclaration, compileUnit);


### PR DESCRIPTION
The `IDataContractSurrogate` interface is part of the public API of
.NET 4.7.1. In has a method named `ProcessImportedType`, which was not
compiled into the unityaot profile.

The `ProcessImportedType` method uses types `CodeTypeDeclaration` and
`CodeCompileUnit` as parameters. Both of these types are pretty large,
and we don't want to compile them into the unityaot profile.

So in order to compile the `ProcessImportedType` method method, add
empty `CodeTypeDeclaration` and `CodeCompileUnit` types in unityaot (the
profile stubber will fill these in properly). This change allows the
unstripped unityaot profile work correctly with IL2CPP.

It is difficult for the profile stubber to handle this case, because
the code in `SurrogateProviderAdapter` is in a facade assembly, which
the profile stubber currently ignores.