### PR TITLE
Use the non-server default connection limit for unityaot (case 1156607)

### DIFF
--- a/mcs/class/System/System.Net/ServicePointManager.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.cs
@@ -132,7 +132,7 @@ namespace System.Net
 		// Fields
 		
 		public const int DefaultNonPersistentConnectionLimit = 4;
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 		public const int DefaultPersistentConnectionLimit = 10;
 #else
 		public const int DefaultPersistentConnectionLimit = 2;


### PR DESCRIPTION
The default value for `DefaultConnectionLimit`, which is set based on
the `DefaultPersistentConnectionLimit` value should be 2 for all
non-ASP.NET applications.

So for the unityaot profile, used with IL2CPP, use the value of 2.

Release notes:

IL2CPP: Set the ServicePointManager DefaultConnectionLimit property to a value of 2. (case 1156607).

I'll back port this change to 2019.2 and 2019.1.