### PR TITLE
Implement NamedPipeClientStream in the unityaot profile (case 1159863)

### DIFF
--- a/mcs/class/System.Core/System.IO.Pipes/NamedPipeClientStream.cs
+++ b/mcs/class/System.Core/System.IO.Pipes/NamedPipeClientStream.cs
@@ -74,7 +74,7 @@ namespace System.IO.Pipes
 		}
 
 		public NamedPipeClientStream (string serverName, string pipeName, PipeDirection direction, PipeOptions options, TokenImpersonationLevel impersonationLevel, HandleInheritability inheritability)
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 			: base (direction, DefaultBufferSize)
 		{
 			throw new NotImplementedException ();
@@ -88,13 +88,17 @@ namespace System.IO.Pipes
 		public NamedPipeClientStream (PipeDirection direction, bool isAsync, bool isConnected, SafePipeHandle safePipeHandle)
 			: base (direction, DefaultBufferSize)
 		{
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 			throw new NotImplementedException ();
 #else
 			if (IsWindows)
 				impl = new Win32NamedPipeClient (this, safePipeHandle);
 			else
+#if UNITY_AOT
+				throw new NotImplementedException ();
+#else
 				impl = new UnixNamedPipeClient (this, safePipeHandle);
+#endif
 			IsConnected = isConnected;
 			InitializeHandle (safePipeHandle, true, isAsync);
 #endif
@@ -106,13 +110,17 @@ namespace System.IO.Pipes
 			if (impersonationLevel != TokenImpersonationLevel.None ||
 			    inheritability != HandleInheritability.None)
 				throw ThrowACLException ();
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 			throw new NotImplementedException ();
 #else
 			if (IsWindows)
 				impl = new Win32NamedPipeClient (this, serverName, pipeName, desiredAccessRights, options, inheritability);
 			else
+#if UNITY_AOT
+				throw new NotImplementedException ();
+#else
 				impl = new UnixNamedPipeClient (this, serverName, pipeName, desiredAccessRights, options, inheritability);
+#endif
 #endif
 
 		}
@@ -121,13 +129,13 @@ namespace System.IO.Pipes
 			Dispose (false);
 		}
 
-#if !MOBILE
+#if !MOBILE || UNITY_AOT
 		INamedPipeClient impl;
 #endif
 
 		public void Connect ()
 		{
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 			throw new NotImplementedException ();
 #else
 			impl.Connect ();
@@ -138,7 +146,7 @@ namespace System.IO.Pipes
 
 		public void Connect (int timeout)
 		{
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 			throw new NotImplementedException ();
 #else			
 			impl.Connect (timeout);
@@ -174,7 +182,7 @@ namespace System.IO.Pipes
 		public int NumberOfServerInstances {
 			get {
 				CheckPipePropertyOperations ();
-#if MOBILE
+#if MOBILE && !UNITY_AOT
 				throw new NotImplementedException ();
 #else
 				return impl.NumberOfServerInstances;

--- a/mcs/class/System.Core/System.IO.Pipes/PipeStream.cs
+++ b/mcs/class/System.Core/System.IO.Pipes/PipeStream.cs
@@ -46,7 +46,7 @@ namespace System.IO.Pipes
 		// FIXME: not precise.
 		internal const int DefaultBufferSize = 0x400;
 
-#if !MOBILE
+#if !MOBILE || UNITY_AOT
 		internal static bool IsWindows {
 			get { return Win32Marshal.IsWindows; }
 		}

--- a/mcs/class/System.Core/unityaot_System.Core.dll.sources
+++ b/mcs/class/System.Core/unityaot_System.Core.dll.sources
@@ -1,3 +1,4 @@
 #include winaot_System.Core.dll.sources
 ../referencesource/System.Core/System/Linq/Enumerable.cs
 corefx/SR.cs
+System.IO.Pipes/PipeWin32.cs


### PR DESCRIPTION
This change builds the class library code to implement the
`NamedPipeClientStream` class in the unityaot profile on Windows. For
the time being, we will not implement this class for non-Windows
platforms, since that requires the Mono.Posix.dll assembly and a native
library as well.

We may consider adding support on Posix platforms in the future.

Release notes:

IL2CPP: Add support for NamedPipeClientStream on Windows platforms. (case 1159863)

I'll backport this change to 2019.2, 2019.2, and 2018.4.