### PR TITLE
Put dummy types used in ProcessImportedType in the proper namespace

### DIFF
--- a/mcs/class/System/System.CodeDom/CodeCompileUnit.cs
+++ b/mcs/class/System/System.CodeDom/CodeCompileUnit.cs
@@ -1,7 +1,12 @@
 #if UNITY_AOT
 
+namespace System.CodeDom
+{
+
 public class CodeCompileUnit
 {
+}
+
 }
 
 #endif

--- a/mcs/class/System/System.CodeDom/CodeTypeDeclaration.cs
+++ b/mcs/class/System/System.CodeDom/CodeTypeDeclaration.cs
@@ -1,7 +1,12 @@
 #if UNITY_AOT
 
+namespace System.CodeDom
+{
+
 public class CodeTypeDeclaration
 {
+}
+
 }
 
 #endif


### PR DESCRIPTION
These dummy types were added in 0e66d19f12c219c4e63cdab1f2d861993a7e3185
so that the `ProcessImportedType` method could be added to the
`IDataContractSurrogate` interface properly. However, the types were not
put in the proper namespace.

Recent changes to the profile stubber to handle overloaded methods
correctly caused an additional `ProcessImportedType` method to be
incorrectly stubbed in. This change allows the profile stubber to
correctly notice that this method exists, and not stubbing is done.