### PR TITLE
Handle the empty file inode on macOS and FAT32

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1791,6 +1791,22 @@ static mode_t convert_perms(guint32 sharemode)
 }
 #endif
 
+static gboolean already_shared(gboolean file_alread_shared, ino_t inode)
+{
+#if PLATFORM_MACOSX
+	/* On macOS and FAT32 partitions, we will sometimes get this inode value
+	 * for more than one file. It means the file is empty (FILENO_EMPTY is
+	 * defined in an internal header).  When this happens, the hash table of
+	 * file shares becomes corrupt, since more then one file has the same
+	 * inode. Instead, let's assume it is always fine to share empty files.
+	 * (Unity case 950616).
+	 */
+	return file_alread_shared && inode != 999999999;
+#else
+	return file_alread_shared;
+#endif
+}
+
 static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 				   guint32 fileaccess,
 				   FileShare **share_info)
@@ -1800,7 +1816,7 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 
 	file_already_shared = file_share_get (statbuf->st_dev, statbuf->st_ino, sharemode, fileaccess, &file_existing_share, &file_existing_access, share_info);
 	
-	if (file_already_shared) {
+	if (already_shared (file_already_shared, statbuf->st_ino)) {
 		/* The reference to this share info was incremented
 		 * when we looked it up, so be careful to put it back
 		 * if we conclude we can't use this file.


### PR DESCRIPTION
On macOS and FAT32 partitions, we will sometimes get this inode value
for more than one file. It means the file is empty.  When this happens,
the hash table of file shares becomes corrupt, since more then one file
has the same inode. Instead, let's assume it is always fine to share
empty files. (Unity case 950616).

This change was not applied to new Mono, originally I just applied it to old Mono. Once we switch to using new Mono to run tools (e.g. UnityLinker) by default, the problem occurred again. So this PR cherry-picks the change to the new Mono branch, and corrects Unity case 1166108.

Release notes:

UnityLinker: Allow UnityLinker to run properly on FAT32 partitions on macOS. (case 1166108).

I'll back port this change to 2018.4, 2019.1, and 2019.2.