### PR TITLE
Automate creating stevedore mbe artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ docs/perlmod*
 artifacts
 .vs
 external/buildscripts/build.gen*
+stevedore
 
 # Allow
 !external/buildscripts/bee.exe

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,8 +237,17 @@ build_linux_x86:
     - /opt/post_build_script.sh
 
 collate_builds:
-  image: ubuntu:latest
   stage: collate
+  tags:
+    - bokken-job
+  variables:
+    BOKKEN_VM: collate_ubuntu
+    BOKKEN_JOB: |
+      resources:
+        - name: collate_ubuntu
+          image: cds-ops/ubuntu-18.04-agent:v1.0.11-765607
+          flavor: b1.large
+          type: Unity::VM
   dependencies:
   - build_android
   - build_osx_runtime
@@ -249,10 +258,9 @@ collate_builds:
   - build_linux_x86
   - build_linux_x64
   before_script:
-  - apt-get update -qy && apt-get -qy upgrade
-  - apt-get install -qy perl
-  - apt-get install -qy zip unzip
-  - apt-get install -qy p7zip-full p7zip-rar
+  - sudo DEBIAN_FRONTEND=noninteractive apt-get update -qy && sudo DEBIAN_FRONTEND=noninteractive apt-get -qy upgrade
+  - sudo apt-get install -qy zip unzip
+  - sudo apt-get install -qy p7zip-full p7zip-rar
   script:
   - perl external/buildscripts/collect_allbuilds.pl
   - pwd
@@ -260,6 +268,8 @@ collate_builds:
   artifacts:
     paths:
     - collectedbuilds/builds.7z
+    - stevedore/MonoBleedingEdge.7z
+    - stevedore/artifactid.txt
     expire_in: 1 week
 
     

--- a/.yamato/collate_builds.yml
+++ b/.yamato/collate_builds.yml
@@ -27,3 +27,7 @@ artifacts:
   builds:
     paths:
       - collectedbuilds/builds.7z
+  stevedore:
+    paths:
+      - stevedore/MonoBleedingEdge.7z
+      - stevedore/artifactid.txt


### PR DESCRIPTION
As part of `collate_builds`, create the `MonoBleedingEdge.7z`artifact that we can upload to stevedore.
Create artifactid.txt that contains the stevedore artifact id. 

Save `MonoBleedingEdge.7z` and `artifactid.txt` as artifacts on GitlabCI and Yamato builds.

Gitlab: https://gitlab.cds.internal.unity3d.com/vm/mono/-/jobs/364519/artifacts/browse/stevedore/

Yamato: https://yamato.prd.cds.internal.unity3d.com/jobs/81-mono/tree/stevedore-7z/.yamato%252Fcollate_builds.yml/233948/job


