### PR TITLE
Install required 32 bit libs and set UNITY_THISISABUILDMACHINE on linux

### DIFF
--- a/.yamato/build_linux_x64.sh
+++ b/.yamato/build_linux_x64.sh
@@ -3,6 +3,7 @@ sudo apt-get install -y binutils debootstrap
 git submodule update --init --recursive
 # try again in case previous update failed
 git submodule update --init --recursive
+export UNITY_THISISABUILDMACHINE=1
 cd external/buildscripts
 ./bee
 cd ../..

--- a/.yamato/build_linux_x86.sh
+++ b/.yamato/build_linux_x86.sh
@@ -1,10 +1,17 @@
+sudo dpkg --add-architecture i386
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
 sudo apt-get install -y schroot
 sudo apt-get install -y binutils debootstrap
 sudo apt-get install -y m4
 sudo apt-get install -y libc6-i386
 sudo apt-get install -y libc6-dev-i386
-sudo apt-get install -y libncurses5-i386
+sudo apt-get install -y zlib1g:i386
+sudo apt-get install -y zlib1g-dev:i386
+sudo apt-get install -y libstdc++6:i386
+sudo apt-get install -y libncurses5:i386
+sudo apt-get install -y libncurses5-dev:i386
 git submodule update --init --recursive
+export UNITY_THISISABUILDMACHINE=1
 # try again in case previous update failed
 git submodule update --init --recursive
 cd external/buildscripts


### PR DESCRIPTION
Yamato does not set UNITY_THISISABUILDMACHINE env variable anymore on Linux. Set it.
Install required 32 bit libs. 

`sudo apt-get install -y libncurses5-i386` now throws an error "unable to locate package" causing the build to fail. So change it to `libncurses5:i386` and install dependent libs.