### PR TITLE
Handle the empty file inode on macOS and FAT32 (with the proper define)

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1793,7 +1793,7 @@ static mode_t convert_perms(guint32 sharemode)
 
 static gboolean already_shared(gboolean file_alread_shared, ino_t inode)
 {
-#if PLATFORM_MACOSX
+#if HOST_DARWIN
 	/* On macOS and FAT32 partitions, we will sometimes get this inode value
 	 * for more than one file. It means the file is empty (FILENO_EMPTY is
 	 * defined in an internal header).  When this happens, the hash table of


### PR DESCRIPTION
Previously, 5174f7ede24ba29d16d297247397b11e56c40355 was an attempt to
correct this issue. However, the `#define` scheme for Mono changed since
then, so `PLATFORM_MACOSX` became `HOST_DARWIN`.

This change uses the proper define to correct Unity case 1166108.