### PR TITLE
[metadata] Fields whose types are gparams with a reference type const…

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1186,6 +1186,7 @@ GENERATE_GET_CLASS_WITH_CACHE_DECL (variant)
 #endif
 
 GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)
+GENERATE_GET_CLASS_WITH_CACHE_DECL (valuetype)
 
 extern MonoDefaults mono_defaults;
 
@@ -1370,6 +1371,9 @@ mono_class_vtable_full (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
 gboolean
 mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate);
+
+MonoClass*
+mono_generic_param_get_base_type (MonoClass *klass);
 
 gboolean
 mono_class_has_variant_generic_params (MonoClass *klass);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -974,5 +974,7 @@ mono_signature_get_managed_fmt_string (MonoMethodSignature *sig);
 gboolean
 mono_type_in_image (MonoType *type, MonoImage *image);
 
+#define MONO_CLASS_IS_INTERFACE_INTERNAL(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_INTERFACE) || mono_type_is_generic_parameter (&c->byval_arg))
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6815,6 +6815,11 @@ mono_type_is_pointer (MonoType *type)
 mono_bool
 mono_type_is_reference (MonoType *type)
 {
+	/* NOTE: changing this function to return TRUE more often may have
+	 * consequences for generic sharing in the AOT compiler.  In
+	 * particular, returning TRUE for generic parameters with a 'class'
+	 * constraint may cause crashes.
+	 */
 	return (type && (((type->type == MONO_TYPE_STRING) ||
 		(type->type == MONO_TYPE_SZARRAY) || (type->type == MONO_TYPE_CLASS) ||
 		(type->type == MONO_TYPE_OBJECT) || (type->type == MONO_TYPE_ARRAY)) ||

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -374,6 +374,7 @@ TESTS_CS_SRC=		\
 	generic-stack-traces2.2.cs	\
 	bug-472600.2.cs	\
 	recursive-generics.2.cs	\
+	recursive-generics.3.cs	\
 	bug-473482.2.cs	\
 	bug-473999.2.cs	\
 	bug-479763.2.cs	\

--- a/mono/tests/recursive-generics.3.cs
+++ b/mono/tests/recursive-generics.3.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+class Program {
+	static void Main (string[] args)
+	{
+		// If this runs without a TLE, the test passed.  A
+		// TypeLoadException due to recursion during type
+		// initialization is a failure.
+		var subC = new SubClass ();
+		Console.WriteLine (subC.GetTest ());
+		// same as above, but try to land in generic sharing code.
+		var genSubC = new GenericSubClass<object> ();
+		Console.WriteLine (genSubC.GetTest ());
+	}
+}
+
+public struct ValueTest<U> {
+        // When U is instantiated with T, from BaseClass, we know it'll be a
+	// reference field without having to fully initialize its parent
+	// (namely BaseClass<T> itself), so we know the instantiation
+	// ValueTest<T> won't be blittable.
+	public readonly U value;
+}
+
+public abstract class BaseClass<T> where T : BaseClass<T> {
+	public ValueTest<T> valueTest = default (ValueTest<T>);
+}
+
+public class SubClass : BaseClass<SubClass> {
+	private string test = "test";
+
+	public string GetTest()
+	{
+		return test;
+	}
+}
+
+public class GenericSubClass<T> : BaseClass<GenericSubClass<T>> {
+	private string test = "test";
+
+	public string GetTest()
+	{
+		return test;
+	}
+}


### PR DESCRIPTION
…raint aren't blittlable. (#15761)

* [metadata] Fields whose types are gparams with a reference type constraint
aren't blittlable.
Don't try to layout the field to find out if it's blittable.
For gshared gparams, follow the blittability of the constraint.

Fixes certain recursive examples.

```
using System;

namespace TestRecursiveType
{
    class Program
    {
        static void Main(string[] args)
        {
            SubClass subC = new SubClass();
            Console.WriteLine(subC.GetTest());
        }
    }

    public struct ValueTest<U>
    {
        // When U is instantiated with T, from BaseClass, we know it'll be a
	// reference field, so we know the instantiation ValueTest<T> won't
	// be blittable.
        public readonly U value;
    }

    public abstract class BaseClass<T> where T : BaseClass<T>
    {
        public ValueTest<T> valueTest = default(ValueTest<T>);
    }

    public class SubClass : BaseClass<SubClass>
    {
        private String test = "test";

        public string GetTest()
        {
            return test;
        }
    }
}
```

Fixes https://github.com/mono/mono/issues/15760
**Unity Fixes https://fogbugz.unity3d.com/f/cases/1147579/**

---

The failure is happening when we are doing mono_class_setup_fields ("BaseClass<T>") which needs to decide for each field whether it is blittable or not. So therefore we are trying to decide if ValueTest<T> (that is: the ValueTest<U> field inside BaseClass<T>) is blittable or not.

So we instantiate U with T.
Now to decide whether VaueTest<T> is blittable or not, we look at every field.
So then we look at T value.
To decide if T is blittable we first check if it's a reference type.

That check is currently inadequate for generic parameters - what the PR adds is the ability to see if theres a T : class constraint or a T : C constraint - where C is some class. As soon as we know that T's constraint will force it to be a reference type we can definitely say that T won't be blittable without having to initialize C, at all.

Previously, Mono would see that T is some kind of type for which it couldn't definitively decide that it's a reference type and it would call: mono_class_setup_fields (field_class) which would then try to setup the fields of the parent class BaseClass<T>. And that would hit the recursion check.

**Unity cherry-pick note: Needed to bring MONO_CLASS_IS_INTERFACE_INTERNAL
and mono_class_get_valuetype_class forward**