### PR TITLE
Fixing a corner case where an invalid timezone on windows would throw a

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -165,7 +165,13 @@ namespace System
 				if (string.IsNullOrEmpty(name))
 					name = GetLocalTimeZoneKeyNameWin32Fallback();
 				if (name != null)
-					return TimeZoneInfo.FindSystemTimeZoneById (name);
+				{
+					try{
+						return TimeZoneInfo.FindSystemTimeZoneById (name);
+					} catch (TimeZoneNotFoundException) {
+						return GetLocalTimeZoneInfoWinRTFallback();
+					}
+				}
 			} else if (IsWindows) {
 				return GetLocalTimeZoneInfoWinRTFallback ();
 			}


### PR DESCRIPTION
TimeZoneNotFoundException. Added a catch to allow mono to try the WinRT
fallback which appears to work even when there is an invalid timezone
value in the registry.

Fixes: 1169719
