### PR TITLE
[debugger-agent] Fix mono_debugger_disconnect implementation

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -764,6 +764,7 @@ static MonoCoopMutex debug_mutex;
 
 static void transport_init (void);
 static void transport_connect (const char *address);
+static void transport_close2 (void);
 static gboolean transport_handshake (void);
 static void register_transport (DebuggerTransport *trans);
 
@@ -1090,9 +1091,6 @@ mono_debugger_get_generate_debug_info ()
 {
 	return disable_optimizations;
 }
-
-// Declare transport_close2 method
-static void transport_close2(void);
 
 MONO_API void
 mono_debugger_disconnect ()

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1091,12 +1091,18 @@ mono_debugger_get_generate_debug_info ()
 	return disable_optimizations;
 }
 
+// Declare transport_close2 method
+static void transport_close2(void);
+
 MONO_API void
 mono_debugger_disconnect ()
 {
-	stop_debugger_thread ();
-	transport_connect (agent_config.address);
-	start_debugger_thread ();
+	// We just need to close the debugger client socket since
+	// the thread is blocked in the RECV method. The debugger_thread
+	// loop already handles the debugger client disconnection properly,
+	// so calling transport_close2 method is enough since the method
+	// only closes the debugger client socket.
+	transport_close2();
 }
 
 typedef void (*MonoDebuggerAttachFunc)(gboolean attached);


### PR DESCRIPTION
**Purpose of this PR**:

Current mono_debugger_disconnect implementation is trying to stop the debugger thread and start it again, this approach is not working as expected since it creates a deadlock. 

Since the debugger the thread is blocked in the RECV method the new approach is just to shutdown the debugger client connection socket so the client disconnects and the debugger_thread loop already handles the debugger client disconnection properly.

**Testing status**:

Florence has tested the disconnection feature in the `scripting/no-cost-editor-attaching-disconnect-fix` branch.
