### PR TITLE
Fixing issue with debugger CREATE_BOXED_VALUE command. case 1169306.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -9539,6 +9539,9 @@ domain_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		// FIXME:
 		g_assert (domain == domain2);
 
+		if (!klass->valuetype)
+			return ERR_INVALID_ARGUMENT;
+
 		o = mono_object_new_checked (domain, klass, &error);
 		mono_error_assert_ok (&error);
 


### PR DESCRIPTION
Rider was sending a CMD_APPDOMAIN_CREATE_BOXED_VALUE command to the
debugger agent when hovering over certain values in the debugger, which
resulted in a class argument that was not a value type.  The debugger
tried to create an object of this type and unbox it, but asserted
because it is not a value type.  Catching this issue before the unbox
call and returning an error prevents the Editor from crashing, but
the debugger still cannot evaluate the value while hovering.  However,
the values can still be inspected using the locals window.