### PR TITLE
Added support to callback into Unity when a StackOverflowException si…

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -43,6 +43,8 @@
 
 #undef exit
 
+static MonoCriticalExceptionCallback gCriticalExceptionCallback = NULL;
+
 void unity_mono_exit( int code )
 {
 	//fprintf( stderr, "mono: exit called, code %d\n", code );
@@ -266,6 +268,11 @@ MonoObject* mono_unity_object_exchange(MonoObject **location, MonoObject *value)
 gboolean mono_unity_object_check_box_cast(MonoObject *obj, MonoClass *klass)
 {
 	return (obj->vtable->klass->element_class == klass->element_class);
+}
+
+MonoDomain* mono_unity_object_domain(MonoObject *obj)
+{
+	return mono_object_domain(obj);
 }
 
 //class
@@ -839,6 +846,11 @@ MonoType* mono_unity_generic_inst_get_type_argument(MonoGenericInst *inst, int i
 
 //exception
 
+const char* mono_unity_get_managed_backtrace(MonoException *exc)
+{
+	return mono_exception_get_managed_backtrace(exc);
+}
+
 MonoString* mono_unity_exception_get_message(MonoException *exc)
 {
 	return exc->message;
@@ -868,6 +880,22 @@ void mono_unity_exception_set_trace_ips(MonoException *exc, MonoArray *ips)
 MonoException* mono_unity_exception_get_marshal_directive(const char* msg)
 {
 	return mono_exception_from_name_msg(mono_get_corlib(), "System.Runtime.InteropServices", "MarshalDirectiveException", msg);
+}
+
+void
+mono_unity_exception_set_stacktrace_callback (MonoCriticalExceptionCallback callback)
+{
+	g_assert (callback);
+
+	gCriticalExceptionCallback = callback;
+}
+
+void
+mono_unity_exception_send_critical_stacktrace (MonoException* stacktrace)
+{
+	g_assert(stacktrace);
+
+	gCriticalExceptionCallback(stacktrace);
 }
 
 //defaults

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -56,6 +56,7 @@ MonoClass* mono_unity_object_get_class(MonoObject *obj);
 MonoObject* mono_unity_object_compare_exchange(MonoObject **location, MonoObject *value, MonoObject *comparand);
 MonoObject* mono_unity_object_exchange(MonoObject **location, MonoObject *value);
 gboolean mono_unity_object_check_box_cast(MonoObject *obj, MonoClass *klass);
+MONO_API MonoDomain* mono_unity_object_domain(MonoObject *obj);
 
 //class 
 const char* mono_unity_class_get_image_name(MonoClass* klass);
@@ -131,12 +132,19 @@ guint mono_unity_generic_inst_get_type_argc(MonoGenericInst *inst);
 MonoType* mono_unity_generic_inst_get_type_argument(MonoGenericInst *inst, int index);
 
 //exception
+MONO_API const char* mono_unity_get_managed_backtrace(MonoException *exc);
 MonoString* mono_unity_exception_get_message(MonoException *exc);
 MonoString* mono_unity_exception_get_stack_trace(MonoException *exc);
 MonoObject* mono_unity_exception_get_inner_exception(MonoException *exc);
 MonoArray* mono_unity_exception_get_trace_ips(MonoException *exc);
 void mono_unity_exception_set_trace_ips(MonoException *exc, MonoArray *ips);
 MonoException* mono_unity_exception_get_marshal_directive(const char* msg);
+
+typedef void (*MonoCriticalExceptionCallback) (MonoException* stackTrace);
+
+MONO_API void mono_unity_exception_set_stacktrace_callback (MonoCriticalExceptionCallback callback);
+
+MONO_API void mono_unity_exception_send_critical_stacktrace (MonoException* stacktrace);
 
 //defaults
 MonoClass* mono_unity_defaults_get_int_class();

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -64,6 +64,7 @@
 #include <mono/metadata/mono-endian.h>
 #include <mono/metadata/environment.h>
 #include <mono/metadata/mono-mlist.h>
+#include <mono/metadata/unity-utils.h>
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/utils/mono-error.h>
@@ -2008,6 +2009,12 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 
 		StackFrameInfo catch_frame;
 		res = handle_exception_first_pass (&ctx_cp, obj, &first_filter_idx, &ji, &prev_ji, non_exception, &catch_frame);
+
+		// trace IPs should be setup now that first pass was called
+		if (stack_overflow)
+		{
+			mono_unity_exception_send_critical_stacktrace ((MonoException *)obj);
+		}
 
 		if (!res) {
 			if (mini_get_debug_options ()->break_on_exc)


### PR DESCRIPTION
…tuation occurs to allow the exception backtrace to be logged on a watchman thread where there is plenty of stack room for walking and printing the backtrace.

using object variants to get domain and method name

Addresses issue: https://issuetracker.unity3d.com/issues/unity-editor-crashes-after-using-circular-dependency