### PR TITLE
Instead of dumping a backtrace on every StackOverflowException we now…

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1802,6 +1802,9 @@ ves_icall_Mono_Runtime_GetNativeStackTrace (MonoExceptionHandle exc, MonoError *
 char *
 mono_exception_get_managed_backtrace (MonoException *exc);
 
+const char*
+mono_print_target_thread_dump (void* thread);
+
 void
 mono_copy_value (MonoType *type, void *dest, void *value, int deref_pointer);
 

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -43,6 +43,8 @@
 
 #undef exit
 
+static MonoSegFaultCallback gSegFaultCallback = NULL;
+
 void unity_mono_exit( int code )
 {
 	//fprintf( stderr, "mono: exit called, code %d\n", code );
@@ -145,6 +147,12 @@ MONO_API void
 mono_unity_g_free(void *ptr)
 {
 	g_free (ptr);
+}
+
+MONO_API const char*
+mono_unity_dump_thread(void* threadPtr)
+{
+	return mono_print_target_thread_dump(threadPtr);
 }
 
 
@@ -868,6 +876,22 @@ void mono_unity_exception_set_trace_ips(MonoException *exc, MonoArray *ips)
 MonoException* mono_unity_exception_get_marshal_directive(const char* msg)
 {
 	return mono_exception_from_name_msg(mono_get_corlib(), "System.Runtime.InteropServices", "MarshalDirectiveException", msg);
+}
+
+void
+mono_unity_exception_set_segfault_callback (MonoSegFaultCallback callback)
+{
+	g_assert (callback);
+
+	gSegFaultCallback = callback;
+}
+
+void
+mono_unity_exception_send_segfault_alert (MonoInternalThread* thread)
+{
+	g_assert(gSegFaultCallback);
+
+	gSegFaultCallback(thread);
 }
 
 //defaults

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -138,6 +138,10 @@ MonoArray* mono_unity_exception_get_trace_ips(MonoException *exc);
 void mono_unity_exception_set_trace_ips(MonoException *exc, MonoArray *ips);
 MonoException* mono_unity_exception_get_marshal_directive(const char* msg);
 
+typedef void (*MonoSegFaultCallback) (void* thread);
+MONO_API void mono_unity_exception_set_segfault_callback (MonoSegFaultCallback callback);
+MONO_API void mono_unity_exception_send_segfault_alert (MonoInternalThread* thread);
+
 //defaults
 MonoClass* mono_unity_defaults_get_int_class();
 MonoClass* mono_unity_defaults_get_stack_frame_class();
@@ -174,6 +178,8 @@ MONO_API char* mono_unity_get_data_dir();
 MONO_API MonoClass* mono_unity_class_get(MonoImage* image, guint32 type_token);
 MONO_API gpointer mono_unity_alloc(gsize size);
 MONO_API void mono_unity_g_free (void *ptr);
+
+MONO_API const char* mono_unity_dump_thread(void* threadPtr);
 
 MONO_API MonoClass* mono_custom_attrs_get_attrs (MonoCustomAttrInfo *ainfo, gpointer *iter);
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3090,7 +3090,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	}
 #endif
 
-	/* The thread might no be registered with the runtime */
+	/* The thread might not be registered with the runtime */
 	if (!mono_domain_get () || !jit_tls) {
 		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
 			return;
@@ -3140,6 +3140,11 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	if (!ji) {
 		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
 			return;
+
+#if defined(HOST_WIN32)
+		// Let Unity know which MonoInternalThread is suffering a sigsegv
+		mono_unity_exception_send_segfault_alert(mono_thread_internal_current ());
+#endif
 
 		mono_handle_native_crash ("SIGSEGV", ctx, info);
 


### PR DESCRIPTION
… trigger Unity's watchman to dump the backtrace of the thread that triggers a segfault signal.