### PR TITLE
Increase max size of localloc and localloc_imm on amd64. (#15374)

### DIFF
--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -112,7 +112,7 @@ cgt: dest:c len:8
 cgt.un: dest:c len:8
 clt: dest:c len:8
 clt.un: dest:c len:8
-localloc: dest:i src1:i len:96
+localloc: dest:i src1:i len:120
 compare: src1:i src2:i len:3
 lcompare: src1:i src2:i len:3
 icompare: src1:i src2:i len:3
@@ -561,7 +561,7 @@ vcall2_membase: src1:b len:64 clob:c
 
 dyn_call: src1:i src2:i len:192 clob:c
 
-localloc_imm: dest:i len:96
+localloc_imm: dest:i len:120
 
 load_mem: dest:i len:16
 loadi8_mem: dest:i len:16


### PR DESCRIPTION
Unity: case 1172987 - Fix crash that may occur when using stackalloc.

We hit the following assert when doing full AOT of some assemblies:

wrong maximal instruction length of instruction localloc (expected 96, got 99)
Assertion: should not be reached at mono\mono\mini\mini-amd64.c:6801

Turns out that that size could be hit when a couple of things happens as part
of lowering OP_LOCALLOC and OP_LOCALLOC_IMM:

sreg1 is not RAX, RCX or RDI
dreg is not RAX, RCX or RDI
cfg->param_area is bigger than 127

Fix is to increase max size of the instruction, from 96 -> 120 (same as x86).