### PR TITLE
Use new mac and linux images

### DIFF
--- a/.yamato/build_android.yml
+++ b/.yamato/build_android.yml
@@ -1,8 +1,8 @@
-name: build_android
+git submodule name: build_android
 
 agent:
   type: Unity::VM::osx
-  image: buildfarm/mac:stable
+  image: platform-foundation/mac-bokken:latest
   flavor: m1.mac
 
 commands:

--- a/.yamato/build_android.yml
+++ b/.yamato/build_android.yml
@@ -1,4 +1,4 @@
-git submodule name: build_android
+name: build_android
 
 agent:
   type: Unity::VM::osx

--- a/.yamato/build_linux_x64.yml
+++ b/.yamato/build_linux_x64.yml
@@ -2,7 +2,7 @@ name: build_linux_x64
 
 agent:
   type: Unity::VM
-  image: cds-ops/ubuntu-18.04-agent:v1.0.11-765607
+  image: platform-foundation/linux-ubuntu-18.04-mono-bokken:latest
   flavor: b1.large
 
 commands:

--- a/.yamato/build_linux_x86.sh
+++ b/.yamato/build_linux_x86.sh
@@ -1,15 +1,3 @@
-sudo dpkg --add-architecture i386
-sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
-sudo apt-get install -y schroot
-sudo apt-get install -y binutils debootstrap
-sudo apt-get install -y m4
-sudo apt-get install -y libc6-i386
-sudo apt-get install -y libc6-dev-i386
-sudo apt-get install -y zlib1g:i386
-sudo apt-get install -y zlib1g-dev:i386
-sudo apt-get install -y libstdc++6:i386
-sudo apt-get install -y libncurses5:i386
-sudo apt-get install -y libncurses5-dev:i386
 git submodule update --init --recursive
 export UNITY_THISISABUILDMACHINE=1
 # try again in case previous update failed

--- a/.yamato/build_linux_x86.yml
+++ b/.yamato/build_linux_x86.yml
@@ -2,7 +2,7 @@ name: build_linux_x86
 
 agent:
   type: Unity::VM
-  image: cds-ops/ubuntu-18.04-agent:v1.0.11-765607
+  image: platform-foundation/linux-ubuntu-18.04-mono-bokken:latest
   flavor: b1.large
 
 commands:

--- a/.yamato/build_osx_classlibs.yml
+++ b/.yamato/build_osx_classlibs.yml
@@ -2,7 +2,7 @@ name: build_osx_classlibs
 
 agent:
   type: Unity::VM::osx
-  image: buildfarm/mac:latest
+  image: platform-foundation/mac-bokken:latest
   flavor: m1.mac
 
 commands:

--- a/.yamato/build_osx_runtime.yml
+++ b/.yamato/build_osx_runtime.yml
@@ -2,7 +2,7 @@ name: build_osx_runtime
 
 agent:
   type: Unity::VM::osx
-  image: buildfarm/mac:latest
+  image: platform-foundation/mac-bokken:latest
   flavor: m1.mac
 
 commands:


### PR DESCRIPTION
Use new slough macs `platform-foundation/mac-bokken` - hopefully we won't see resource not available errors that we frequently saw on buildfarm/mac.

Use new linux image with pre-installed packages `platform-foundation/linux-ubuntu-18.04-mono-bokken` - Saves about 10 minutes for linux-x86 build and 3 minutes for linux-x64 build.

https://yamato.prd.cds.internal.unity3d.com/jobs/81-mono/tree/test-yamato/.yamato%252Fcollate_builds.yml/501068/job/pipeline