### PR TITLE
[Android] Fixing problem with toLanguageTag for API < 21

### DIFF
--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -574,12 +574,18 @@ get_android_locale (void)
             const char *nativeTag;
             jobject def = (*env)->CallStaticObjectMethod(env, localeClass, getDefault);
             toLanguageTag = (*env)->GetMethodID(env, localeClass, "toLanguageTag", "()Ljava/lang/String;");
-            tag = (jstring)(*env)->CallObjectMethod(env, def, toLanguageTag);
-            nativeTag = (*env)->GetStringUTFChars(env, tag, NULL);
-            __android_log_print(ANDROID_LOG_INFO, "Mono", "Locale %s", nativeTag);
-            cached_locale = g_strdup (nativeTag);
-            (*env)->ReleaseStringUTFChars(env, tag, nativeTag);
+            // toLanguageTag is available since API 21 only, so returning default locale for Android 4.4
+            if (toLanguageTag != NULL) {
+                tag = (jstring)(*env)->CallObjectMethod(env, def, toLanguageTag);
+                nativeTag = (*env)->GetStringUTFChars(env, tag, NULL);
+                __android_log_print(ANDROID_LOG_INFO, "Mono", "Locale %s", nativeTag);
+                cached_locale = g_strdup (nativeTag);
+                (*env)->ReleaseStringUTFChars(env, tag, nativeTag);
+            }
         }
+    }
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
     }
 
     if (detached)


### PR DESCRIPTION
**toLanguageTag** is available only since API 21. For earlier devices (Android 4.4) getting locale will use **get_posix_locale** method which will return default value. 
Proper workaround for Android 4.4 requires implementing quite complex code, and I don't see much sense in doing this.