### PR TITLE
Wait for debugger thread to exit (case 1180399, case 1189077)

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1842,6 +1842,8 @@ stop_debugger_thread (void)
 				mono_coop_cond_wait (&debugger_thread_exited_cond, &debugger_thread_exited_mutex);
 			mono_coop_mutex_unlock (&debugger_thread_exited_mutex);
 		} while (!debugger_thread_exited);
+
+		mono_native_thread_join (debugger_thread_id);
 	}
 
 	transport_close2 ();


### PR DESCRIPTION
There is logic to ensure debugger thread is shutting down
before we continue, but thread has not actually exited. This
leaves us open to race conditions in profiler events and
thread info machinery that are cleaned up by runtime shutdown.

Release Notes:
case 1180399 - Fix crash on shutdown in debugger thread.
case 1189077 - Fix crash on shutdown in mono_profiler_raise_thread_stopped.