### PR TITLE
Custom tls chain impl to fix callback issue and avoid copying

### DIFF
--- a/mcs/class/System/Mono.UnityTls/CertHelper.cs
+++ b/mcs/class/System/Mono.UnityTls/CertHelper.cs
@@ -31,25 +31,6 @@ namespace Mono.Unity
 				}
 			}
 		}
-
-		public static X509CertificateCollection NativeChainToManagedCollection (UnityTls.unitytls_x509list_ref nativeCertificateChain, UnityTls.unitytls_errorstate* errorState)
-		{
-			X509CertificateCollection certificates = new X509CertificateCollection ();
-
-			var cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)0, errorState);
-			for (int i = 0; cert.handle != UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE; ++i) {
-				size_t certBufferSize = UnityTls.NativeInterface.unitytls_x509_export_der (cert, null, (size_t)0, errorState);
-				var certBuffer = new byte[(int)certBufferSize];	// Need to reallocate every time since X509Certificate constructor takes no length but only a byte array.
-				fixed(byte* certBufferPtr = certBuffer) {
-					UnityTls.NativeInterface.unitytls_x509_export_der (cert, certBufferPtr, certBufferSize, errorState);
-				}
-				certificates.Add (new X509Certificate (certBuffer));
-
-				cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)i, errorState);
-			}
-
-			return certificates;
-		}
 	}
 }
 #endif

--- a/mcs/class/System/Mono.UnityTls/UnityTlsContext.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsContext.cs
@@ -448,11 +448,11 @@ namespace Mono.Unity
 			try {
 				using (var chainImpl = new X509ChainImplUnityTls(chain))
 				using (var managedChain = new X509Chain (chainImpl)) {
-					var leaf = managedChain.ChainElements[0].Certificate;
+					remoteCertificate = managedChain.ChainElements[0].Certificate;
 
 					// Note that the overload of this method that takes a X509CertificateCollection will not pass on the chain to 
 					// user callbacks like ServicePointManager.ServerCertificateValidationCallback which can cause issues along the line.
-					if (ValidateCertificate (leaf, managedChain))
+					if (ValidateCertificate (remoteCertificate, managedChain))
 						return UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_SUCCESS;
 					else
 						return UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_FLAG_NOT_TRUSTED;

--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -53,19 +53,26 @@ namespace Mono.Unity
 			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
 			ref MonoSslPolicyErrors errors, ref int status11)
 		{
-			bool hasUnityTlsChain = (chain != null && chain.Impl is X509ChainImplUnityTls);
+			var errorState = UnityTls.NativeInterface.unitytls_errorstate_create ();
 
-			if (certificates == null && !hasUnityTlsChain) {
-				errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
-				return false;
+			var unityTlsChainImpl = chain.Impl as X509ChainImplUnityTls;
+			if (unityTlsChainImpl == null)
+			{
+				if (certificates == null || certificates.Count == 0) {
+					errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
+					return false;
+				}
+
+				if (wantsChain)
+					chain = MNS.SystemCertificateValidator.CreateX509Chain (certificates);
 			}
-
-			if (wantsChain && !hasUnityTlsChain)
-				chain = MNS.SystemCertificateValidator.CreateX509Chain (certificates);
-
-			if (certificates == null || certificates.Count == 0) {
-				errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
-				return false;
+			else
+			{
+				var cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (unityTlsChainImpl.NativeCertificateChain, (size_t)0, &errorState);
+				if (cert.handle == UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE) {
+					errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
+					return false;
+				}
 			}
 
 			// fixup targetHost name by removing port
@@ -76,7 +83,6 @@ namespace Mono.Unity
 			}
 
 			// convert cert to native
-			var errorState = UnityTls.NativeInterface.unitytls_errorstate_create ();
 			var result = UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE;
 			UnityTls.unitytls_x509list* certificatesNative = null;
 			try
@@ -88,14 +94,14 @@ namespace Mono.Unity
 				//validator.Settings.CertificateSearchPaths				// currently only used by MonoBtlsProvider
 
 				UnityTls.unitytls_x509list_ref certificatesNativeRef;
-				if (!hasUnityTlsChain)
+				if (unityTlsChainImpl == null)
 				{
 					certificatesNative = UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
 					CertHelper.AddCertificatesToNativeChain (certificatesNative, certificates, &errorState);
 					certificatesNativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (certificatesNative, &errorState);
 				}
 				else
-					certificatesNativeRef = ((X509ChainImplUnityTls)chain.Impl).NativeCertificateChain;
+					certificatesNativeRef = unityTlsChainImpl.NativeCertificateChain;
 				
 				var targetHostUtf8 = Encoding.UTF8.GetBytes (targetHost);
 

--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -82,7 +82,7 @@ namespace Mono.Unity
 					targetHost = targetHost.Substring (0, pos);
 			}
 
-			// convert cert to native
+			// convert cert to native or extract from unityTlsChainImpl.
 			var result = UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE;
 			UnityTls.unitytls_x509list* certificatesNative = null;
 			try

--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -53,12 +53,14 @@ namespace Mono.Unity
 			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
 			ref MonoSslPolicyErrors errors, ref int status11)
 		{
-			if (certificates == null) {
+			bool hasUnityTlsChain = (chain != null && chain.Impl is X509ChainImplUnityTls);
+
+			if (certificates == null && !hasUnityTlsChain) {
 				errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
 				return false;
 			}
 
-			if (wantsChain)
+			if (wantsChain && !hasUnityTlsChain)
 				chain = MNS.SystemCertificateValidator.CreateX509Chain (certificates);
 
 			if (certificates == null || certificates.Count == 0) {
@@ -75,8 +77,8 @@ namespace Mono.Unity
 
 			// convert cert to native
 			var errorState = UnityTls.NativeInterface.unitytls_errorstate_create ();
-			var certificatesNative = UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
 			var result = UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE;
+			UnityTls.unitytls_x509list* certificatesNative = null;
 			try
 			{
 				// Things the validator provides that we might want to make use of here:
@@ -85,28 +87,40 @@ namespace Mono.Unity
 				//validator.Settings.CertificateValidationTime
 				//validator.Settings.CertificateSearchPaths				// currently only used by MonoBtlsProvider
 
-				CertHelper.AddCertificatesToNativeChain (certificatesNative, certificates, &errorState);
-				var certificatesNativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (certificatesNative, &errorState);
+				UnityTls.unitytls_x509list_ref certificatesNativeRef;
+				if (!hasUnityTlsChain)
+				{
+					certificatesNative = UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
+					CertHelper.AddCertificatesToNativeChain (certificatesNative, certificates, &errorState);
+					certificatesNativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (certificatesNative, &errorState);
+				}
+				else
+					certificatesNativeRef = ((X509ChainImplUnityTls)chain.Impl).NativeCertificateChain;
+				
 				var targetHostUtf8 = Encoding.UTF8.GetBytes (targetHost);
 
 				if (validator.Settings.TrustAnchors != null) {
-					var trustCAnative = UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
-					CertHelper.AddCertificatesToNativeChain (trustCAnative, validator.Settings.TrustAnchors, &errorState);
-					var trustCAnativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (certificatesNative, &errorState);
+					UnityTls.unitytls_x509list* trustCAnative = null;
+					try
+					{
+						trustCAnative = UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
+						CertHelper.AddCertificatesToNativeChain (trustCAnative, validator.Settings.TrustAnchors, &errorState);
+						var trustCAnativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (trustCAnative, &errorState);
 
-					fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
-						result = UnityTls.NativeInterface.unitytls_x509verify_explicit_ca (certificatesNativeRef, trustCAnativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
+						fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
+							result = UnityTls.NativeInterface.unitytls_x509verify_explicit_ca (certificatesNativeRef, trustCAnativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
+						}
 					}
-
-					UnityTls.NativeInterface.unitytls_x509list_free (trustCAnative);
+					finally {
+						UnityTls.NativeInterface.unitytls_x509list_free (trustCAnative);
+					}
 				} else {
 					fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
 						result = UnityTls.NativeInterface.unitytls_x509verify_default_ca (certificatesNativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
 					}
 				}
 			}
-			finally
-			{
+			finally	{
 				UnityTls.NativeInterface.unitytls_x509list_free (certificatesNative);
 			}
 

--- a/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
@@ -81,6 +81,12 @@ namespace Mono.Unity
 				elements = null;
 			}
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			Reset();
+			base.Dispose (disposing);
+		}
 	}
 }
 

--- a/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
@@ -1,3 +1,5 @@
+#if SECURITY_DEP
+
 using System;
 using System.Text;
 using System.Security;
@@ -81,3 +83,5 @@ namespace Mono.Unity
 		}
 	}
 }
+
+#endif

--- a/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using size_t = System.IntPtr;
+
+namespace Mono.Unity
+{
+	// Follows mostly X509ChainImplBtls
+	class X509ChainImplUnityTls : X509ChainImpl
+	{
+		X509ChainElementCollection elements;
+		UnityTls.unitytls_x509list_ref nativeCertificateChain;
+		X509ChainPolicy policy = new X509ChainPolicy ();
+
+		internal X509ChainImplUnityTls (UnityTls.unitytls_x509list_ref nativeCertificateChain)
+		{
+			this.elements = null;
+			this.nativeCertificateChain = nativeCertificateChain;
+		}
+
+		public override bool IsValid {
+			get { return nativeCertificateChain.handle != UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE; }
+		}
+
+		public override IntPtr Handle {
+			get { return new IntPtr((long)nativeCertificateChain.handle); }
+		}
+
+		internal UnityTls.unitytls_x509list_ref NativeCertificateChain => nativeCertificateChain;
+
+		public override X509ChainElementCollection ChainElements {
+			get {
+				ThrowIfContextInvalid ();
+				if (elements != null)
+					return elements;
+
+				unsafe
+				{
+					elements = new X509ChainElementCollection ();
+					UnityTls.unitytls_errorstate errorState = UnityTls.NativeInterface.unitytls_errorstate_create ();
+					var cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)0, &errorState);
+					for (int i = 0; cert.handle != UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE; ++i) {
+						size_t certBufferSize = UnityTls.NativeInterface.unitytls_x509_export_der (cert, null, (size_t)0, &errorState);
+						var certBuffer = new byte[(int)certBufferSize];	// Need to reallocate every time since X509Certificate constructor takes no length but only a byte array.
+						fixed(byte* certBufferPtr = certBuffer) {
+							UnityTls.NativeInterface.unitytls_x509_export_der (cert, certBufferPtr, certBufferSize, &errorState);
+						}
+						elements.Add (new X509Certificate2 (certBuffer));
+
+						cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)i, &errorState);
+					}
+				}
+
+				return elements;
+			}
+		}
+
+		public override X509ChainPolicy ChainPolicy {
+			get { return policy; }
+			set { policy = value; }
+		}
+
+		public override X509ChainStatus[] ChainStatus {
+			get { throw new NotImplementedException (); }
+		}
+
+		public override bool Build (X509Certificate2 certificate)
+		{
+			return false;
+		}
+
+		public override void Reset ()
+		{
+			if (elements != null) {
+				nativeCertificateChain.handle = UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE;
+				elements.Clear ();
+				elements = null;
+			}
+		}
+	}
+}

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -261,6 +261,7 @@ Mono.UnityTls/UnityTlsProvider.cs
 Mono.UnityTls/UnityTlsStream.cs
 Mono.UnityTls/UnityTlsContext.cs
 Mono.UnityTls/UnityTlsConversions.cs
+Mono.UnityTls/X509ChainImplUnityTls.cs
 Mono.UnityTls/Debug.cs
 Mono.UnityTls/CertHelper.cs
 


### PR DESCRIPTION
Introduces a custom x509 chain impl. This allows us to preserve the native handle during the validation process which means that we don't need to recreate a native x509 chain during validation.

The original motivation however is quite distinct from that and sparked by https://fogbugz.unity3d.com/f/cases/1191987/ (for which this is a fix):
Depending on the used overload of MobileTlsContext.ValidateCertificate, the user does not receive any certificate in callbacks like `ServicePointManager.ServerCertificateValidationCallback`. Essentially the implementation fails to pass through the certificate if a X509CertificateCollection is provided, but works fine if a X509Chain is passed in (which is why this PR implements a X509ChainImpl)
The AppleTls implementation (on which the UnityTls backend is based) has the same issue. See here https://github.com/mono/mono/issues/10198


I added a regression test on https://github.cds.internal.unity3d.com/unity/unity/tree/platform/foundation/tls/regression-test-1191987 which passes with Mono built from this branch but not before
(Ideally we merge this alongside the next mono update in trunk cc: @joncham )