### PR TITLE
Obtain mono-build-tools-extra from Stevedore

### DIFF
--- a/external/buildscripts/Build.bee.cs
+++ b/external/buildscripts/Build.bee.cs
@@ -82,6 +82,11 @@ namespace BuildProgram
 				new Tuple<string, string>(
 					"MacBuildEnvironment/9df1e3b3b120_2fc8e616a2e5dfb7907fc42d9576b427e692223c266dc3bc305de4bf03714e30.7z",
 					"testing"));
+
+			Artifacts.Add("mono-build-tools-extra",
+				new Tuple<string, string>(
+					"mono-build-tools-extra/70f9c4060363d11b3e69f000c8ff2c9ac8112bc2_e66148037ab6371658815c726e27e7ee7bdfdd705fb734708d07cbdfe7d8141e.7z",
+					"testing"));
 		}
 
 		private static void RegisterLinuxArtifacts()

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -190,8 +190,6 @@ print(">>> External build deps = $externalBuildDeps\n");
 # abs_path ends up returning an empty string
 $externalBuildDeps = abs_path($externalBuildDeps) if (-d $externalBuildDeps);
 
-my $extraBuildTools = "$monoroot/../../mono-build-tools-extra/build";
-
 my $existingExternalMonoRoot = "$externalBuildDeps/MonoBleedingEdge";
 my $existingExternalMono = "";
 my $existingExternalMonoBinDir = "";
@@ -279,23 +277,6 @@ if ($build)
 	if ($isDesktopBuild)
 	{
 		push @configureparams, "--with-monotouch=no";
-	}
-
-	if (!(-d "$extraBuildTools"))
-	{
-		# Check out on the fly
-		print(">>> Checking out mono build tools extra to : $extraBuildTools\n");
-		my $repo = 'git@github.cds.internal.unity3d.com:unity/mono-build-tools-extra.git';
-		print(">>> Cloning $repo at $extraBuildTools\n");
-		my $checkoutResult = system("git", "clone", "--recurse-submodules", $repo, "$extraBuildTools");
-
-		if ($checkoutResult ne 0)
-		{
-			die("Failed to checkout mono build tools extra\n");
-		}
-
-		# Only clean up if the dir exists.   Otherwise abs_path will return empty string
-		$extraBuildTools = abs_path($extraBuildTools) if (-d $extraBuildTools);
 	}
 
 	if ($existingMonoRootPath eq "")

--- a/external/buildscripts/stub_classlibs.pl
+++ b/external/buildscripts/stub_classlibs.pl
@@ -11,18 +11,7 @@ if($^O ne "darwin")
 
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
-my $extraBuildTools = "$monoroot/../../mono-build-tools-extra/build";
-
-print ">>> Building the ProfileStubber utility\n";
-
-my $result = system("xbuild",
-					"$extraBuildTools/mono-build-tools-extra.sln",
-					"/p:Configuration=Release");
-
-if ($result ne 0)
-{
-	die("Failed to build ProfileStubber utility\n");
-}
+my $extraBuildTools = "$monoroot/external/buildscripts/artifacts/Stevedore/mono-build-tools-extra";
 
 my $profileRoot = "tmp/lib/mono";
 my $referenceProfile = "$profileRoot/4.7.1-api";
@@ -30,7 +19,7 @@ my $referenceProfile = "$profileRoot/4.7.1-api";
 print ">>> Modifying the unityjit profile to match the .NET 4.7.1 API\n";
 
 $result = system("mono",
-					"$extraBuildTools/build/ProfileStubber.exe",
+					"$extraBuildTools/ProfileStubber.exe",
 					"--reference-profile=$referenceProfile",
 					"--stub-profile=$profileRoot/unityjit");
 
@@ -42,7 +31,7 @@ if ($result ne 0)
 print ">>> Modifying the unityaot profile to match the .NET 4.7.1 API\n";
 
 $result = system("mono",
-					"$extraBuildTools/build/ProfileStubber.exe",
+					"$extraBuildTools/ProfileStubber.exe",
 					"--reference-profile=$referenceProfile",
 					"--stub-profile=$profileRoot/unityaot");
 


### PR DESCRIPTION
Instead of cloning the mono-build-tools-extra and building the tools in
it, now get the binaries from Stevedore. These are only used on macOS
builds of Mono.