### PR TITLE
Unity 2018.4 fix macos not

### DIFF
--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -16,7 +16,7 @@ my $libmono = "$lib/mono";
 my $monoprefix = "$root/tmp/monoprefix";
 my $xcodePath = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform';
 my $macversion = '10.6';
-my $sdkversion = '10.6';
+my $sdkversion = '10.11';
 my $externalBuildDeps = "$root/../../mono-build-deps/build";
 
 my $dependencyBranchToUse = "unity3.0";
@@ -188,7 +188,7 @@ if (not $skipbuild)
 		print(">>>Calling autoreconf in mono\n");
 		system("autoreconf -i");
 		print(">>>Calling configure in mono\n");
-		system("./configure","--prefix=$monoprefix","--with-monotouch=$withMonotouch","-with-unity=$withUnity", "--with-glib=embedded","--with-mcs-docs=no","--with-macversion=10.5", "--disable-nls") eq 0 or die ("failing autogenning mono");
+		system("./configure","--prefix=$monoprefix","--with-monotouch=$withMonotouch","-with-unity=$withUnity", "--with-glib=embedded","--with-mcs-docs=no","--with-macversion=10.9", "--disable-nls") eq 0 or die ("failing autogenning mono");
 		print("calling make clean in mono\n");
 		system("make","clean");
 	}

--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -188,7 +188,7 @@ if (not $skipbuild)
 		print(">>>Calling autoreconf in mono\n");
 		system("autoreconf -i");
 		print(">>>Calling configure in mono\n");
-		system("./configure","--prefix=$monoprefix","--with-monotouch=$withMonotouch","-with-unity=$withUnity", "--with-glib=embedded","--with-mcs-docs=no","--with-macversion=10.9", "--disable-nls") eq 0 or die ("failing autogenning mono");
+		system("./configure","--prefix=$monoprefix","--with-monotouch=$withMonotouch","-with-unity=$withUnity", "--with-glib=embedded","--with-mcs-docs=no","--with-macversion=10.6", "--disable-nls") eq 0 or die ("failing autogenning mono");
 		print("calling make clean in mono\n");
 		system("make","clean");
 	}

--- a/external/buildscripts/build_runtime_osx.pl
+++ b/external/buildscripts/build_runtime_osx.pl
@@ -151,7 +151,7 @@ my $arch = 'x86_64';
 	print "Building for architecture: $arch\n";
 
 	my $macversion = '10.6';
-	my $sdkversion = '10.6';
+	my $sdkversion = '10.11';
 
 	# Set up clang toolchain
 	$sdkPath = "$externalBuildDeps/MacBuildEnvironment/builds/MacOSX$sdkversion.sdk";


### PR DESCRIPTION
macOS has a min SDK target for notarization which is 10.9, the build tooling has either macOS 10.6 or 10.11 so we updated to 10.11 (which is fine since macOS minos is still 10.9)

I verified this build worked and ABV passed. 