### PR TITLE
Fixes issue in mono_class_init where we would return immediately inst…

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5168,9 +5168,8 @@ mono_class_init (MonoClass *klass)
 	locked = TRUE;
 
 	if (klass->inited || mono_class_has_failure (klass)) {
-		mono_loader_unlock ();
 		/* Somebody might have gotten in before us */
-		return !mono_class_has_failure (klass);
+		goto leave;
 	}
 
 	UnlockedIncrement (&mono_stats.initialized_class_count);


### PR DESCRIPTION
…ead of jumping to the cleanup routine. This would leave `init_list` in a dirty state for subsequent calls leading to recursive type definitions being thrown incorrectly. ([case 1191002](https://fogbugz.unity3d.com/f/cases/1191002/))

Release note:
Fix intermittent "TypeLoadException: Recursive type definition detected" that was being thrown on playmode start.