### PR TITLE
[Debugger] Fix crash when there is a generic struct with a field that…

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7889,6 +7889,12 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				g_free (name);
 				return ERR_INVALID_ARGUMENT;
 			}
+		} else if ((t->type == MONO_TYPE_GENERICINST) && 
+					mono_metadata_generic_class_is_valuetype (t->data.generic_class) &&
+					t->data.generic_class->container_class->enumtype){
+			err = decode_vtype (t, domain, addr, buf, &buf, limit);
+			if (err != ERR_NONE)
+				return err;
 		} else {
 			NOT_IMPLEMENTED;
 		}


### PR DESCRIPTION
… is an enumerator. (#12368) Unity: (case [1210416](https://fogbugz.unity3d.com/f/cases/1210416/))

* [Debugger]  Debugger crashes when inside a class, there is an internal struct, with a field that is an enumerator.
files.myBucket.GetEnumerator().get_Current().Key
Fixes #10735

* [Debugger] Debugger crashes when there is a generic struct with a field that is an enumerator.
Example: files.get_Current().Key
A unit test that reproduces this crash was added too.
Fixes #10735

* Removing the extra space.

* @UnityAlex cherry-pick modification: Removed tests