### PR TITLE
Avoid using StringBuilder marshalling which leaks memory on Win32 (ca…

### DIFF
--- a/mcs/class/System/ReferenceSources/Win32Exception.cs
+++ b/mcs/class/System/ReferenceSources/Win32Exception.cs
@@ -24,7 +24,7 @@ namespace System.ComponentModel
 
 		internal static string GetErrorMessage (int error)
 		{
-#if !MOBILE
+#if !UNITY && !MOBILE
 			if (Environment.IsRunningOnWindows) {
 				StringBuilder sb = new StringBuilder (256);
 


### PR DESCRIPTION
Unity: case 1211367 - Fixes StringBuilder marshaling leak with exceptions on win32.

In mono they do not free up memory allocated by a string builder, when we hit a win32 exception, we are leaking memory.   Changed the managed code to not so that when UNITY is defined.