### PR TITLE
Avoid using StringBuilder marshaling  Win32 (case 1211367).

### DIFF
--- a/mcs/class/System/ReferenceSources/Win32Exception.cs
+++ b/mcs/class/System/ReferenceSources/Win32Exception.cs
@@ -14,7 +14,9 @@ namespace System.ComponentModel
 #if !MOBILE
 		[DllImport ("Kernel32", CharSet = CharSet.Unicode)]
 		static extern int FormatMessage(int dwFlags, IntPtr lpSource, uint dwMessageId, int dwLanguageId,
-			[Out] StringBuilder lpBuffer, int nSize, IntPtr[] arguments);
+			[Out] char[] lpBuffer, int nSize, IntPtr[] arguments);
+
+		const int MAX_MESSAGE_LENGTH = 256;
 #endif
 
 #if UNITY
@@ -26,15 +28,15 @@ namespace System.ComponentModel
 		{
 #if !MOBILE
 			if (Environment.IsRunningOnWindows) {
-				StringBuilder sb = new StringBuilder (256);
+				char[] messageArray = new char[MAX_MESSAGE_LENGTH];
 
 				int result = FormatMessage (0x1200 /* FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_FROM_SYSTEM */,
-					IntPtr.Zero, (uint)error, 0, sb, sb.Capacity, null);
+					IntPtr.Zero, (uint)error, 0, messageArray, MAX_MESSAGE_LENGTH, null);
 
 				if (result == 0)
 					return "Error looking up error string";
 
-				return sb.ToString ();
+				return new string(messageArray);
 			}
 #endif
 #if UNITY


### PR DESCRIPTION
Unity: case 1211367 - Fixes StringBuilder marshaling leak with exceptions on win32.

In mono they do not free up memory allocated by a string builder, when we hit a win32 exception, we are leaking memory. Changed the managed code to pinvoke a char array into the Kernel32 function instead.