### PR TITLE
Origin/remove redundant gc collect

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2622,8 +2622,6 @@ unload_thread_main (void *arg)
 
 	mono_domain_free (domain, FALSE);
 
-	mono_gc_collect (mono_gc_max_generation ());
-
 	mono_atomic_store_release (&data->done, TRUE);
 	unload_data_unref (data);
 	return 0;

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2603,7 +2603,10 @@ unload_thread_main (void *arg)
 	 */
 	for (i = 0; i < domain->class_vtable_array->len; ++i)
 		zero_static_data ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
+	/* Boehm does not use remsets, therefore it seems safe to ifdef it out */
+#if !HAVE_BOEHM_GC
 	mono_gc_collect (0);
+#endif
 	for (i = 0; i < domain->class_vtable_array->len; ++i)
 		clear_cached_vtable ((MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i));
 	deregister_reflection_info_roots (domain);


### PR DESCRIPTION
During unload_thread_main, we call mono_gc_collect 3 times.

First: https://github.com/mono/mono/blob/280e9d2423549d86686716f0818bcdbac9702ea1/mono/metadata/gc.c#L455

Second: https://github.com/mono/mono/blob/b4c506c3045516349d03ce8f3fe9fa5b79a7271c/mono/metadata/appdomain.c#L3305

Third: https://github.com/mono/mono/blob/b4c506c3045516349d03ce8f3fe9fa5b79a7271c/mono/metadata/appdomain.c#L3324

This PR #ifdefs the Second GC Collect because Boehm does not use remsets, and the comment explaining it mentions that
>  We need to make sure that we don't have any remsets pointing into static data...(cont)
However, Unity uses Boehm so it can be defined out.

There seems to be no good reason for the third GC collect, as it is already called before in **mono_domain_finalize**



