### PR TITLE
[IO] Remove read-only logic in mono_w32_get_disk_free_space (#17177)

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4196,7 +4196,6 @@ mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_byte
 #elif defined(HAVE_STATFS)
 	struct statfs fsstat;
 #endif
-	gboolean isreadonly;
 	gchar *utf8_path_name;
 	gint ret;
 	unsigned long block_size;
@@ -4223,17 +4222,11 @@ mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_byte
 		MONO_ENTER_GC_SAFE;
 		ret = statvfs (utf8_path_name, &fsstat);
 		MONO_EXIT_GC_SAFE;
-		isreadonly = ((fsstat.f_flag & ST_RDONLY) == ST_RDONLY);
 		block_size = fsstat.f_frsize;
 #elif defined(HAVE_STATFS)
 		MONO_ENTER_GC_SAFE;
 		ret = statfs (utf8_path_name, &fsstat);
 		MONO_EXIT_GC_SAFE;
-#if defined (MNT_RDONLY)
-		isreadonly = ((fsstat.f_flags & MNT_RDONLY) == MNT_RDONLY);
-#elif defined (MS_RDONLY)
-		isreadonly = ((fsstat.f_flags & MS_RDONLY) == MS_RDONLY);
-#endif
 		block_size = fsstat.f_bsize;
 #endif
 	} while(ret == -1 && errno == EINTR);
@@ -4247,13 +4240,9 @@ mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_byte
 	}
 
 	/* total number of free bytes for non-root */
+
 	if (free_bytes_avail != NULL) {
-		if (isreadonly) {
-			*free_bytes_avail = 0;
-		}
-		else {
-			*free_bytes_avail = block_size * (guint64)fsstat.f_bavail;
-		}
+		*free_bytes_avail = block_size * (guint64)fsstat.f_bavail;
 	}
 
 	/* total number of bytes available for non-root */
@@ -4262,13 +4251,9 @@ mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_byte
 	}
 
 	/* total number of bytes available for root */
+
 	if (total_number_of_free_bytes != NULL) {
-		if (isreadonly) {
-			*total_number_of_free_bytes = 0;
-		}
-		else {
-			*total_number_of_free_bytes = block_size * (guint64)fsstat.f_bfree;
-		}
+		*total_number_of_free_bytes = block_size * (guint64)fsstat.f_bfree;
 	}
 	
 	return(TRUE);


### PR DESCRIPTION
Unity: case 1221933- Fixes Catalina OSX returning 0 for disk space on read only drives.

Cherry-picked from upstream, fixes mono returning 0 on drives marked as read only.  This turned out to be a bigger problem on Catalina than other systems.


Alex tested for me on his Catalina macbook
output before fix   
Volume: / -- Available space: 0 bytes

output after fix 
Volume: / -- Available space: 51340992921