### PR TITLE
Optimize Enum.HasFlags ().

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1201,6 +1201,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 		if (cfg->verbose_level > 2) mono_print_bb (bb, "BEFORE LOWER-VTYPE-OPTS ");
 
 		cfg->cbb->code = cfg->cbb->last_ins = NULL;
+		cfg->cbb->out_of_line = bb->out_of_line;
 		restart = TRUE;
 
 		while (restart) {
@@ -1426,6 +1427,30 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 						}
 						ins->dreg = -1;
 					}
+					break;
+				}
+				case OP_BOX:
+				case OP_BOX_ICONST: {
+					MonoInst *src;
+
+					/* Temporary value required by emit_box () */
+					if (ins->opcode == OP_BOX_ICONST) {
+						NEW_ICONST (cfg, src, ins->inst_c0);
+						src->klass = ins->klass;
+						MONO_ADD_INS (cfg->cbb, src);
+					} else {
+						MONO_INST_NEW (cfg, src, OP_LOCAL);
+						src->type = STACK_MP;
+						src->klass = ins->klass;
+						src->dreg = ins->sreg1;
+					}
+					MonoInst *tmp = mini_emit_box (cfg, src, ins->klass, mini_class_check_context_used (cfg, ins->klass));
+					g_assert (tmp);
+
+					MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, ins->dreg, tmp->dreg);
+
+					/* This might be decomposed into other vtype opcodes */
+					restart = TRUE;
 					break;
 				}
 				default:

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -42,6 +42,9 @@ MINI_OP(OP_CHECK_THIS,	"checkthis", NONE, IREG, NONE)
 MINI_OP(OP_SEQ_POINT, "seq_point", NONE, NONE, NONE)
 MINI_OP(OP_IL_SEQ_POINT, "il_seq_point", NONE, NONE, NONE)
 MINI_OP(OP_IMPLICIT_EXCEPTION, "implicit_exception", NONE, NONE, NONE)
+MINI_OP(OP_BOX, "box", IREG, IREG, NONE)
+/* A box of the int value in inst_c0 */
+MINI_OP(OP_BOX_ICONST, "box_iconst", IREG, NONE, NONE)
 
 /* CALL opcodes need to stay together, see MONO_IS_CALL macro */
 MINI_OP(OP_VOIDCALL,	"voidcall", NONE, NONE, NONE)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1446,6 +1446,7 @@ typedef struct {
 	guint            gsharedvt : 1;
 	guint            r4fp : 1;
 	guint            llvm_only : 1;
+	guint            domainvar_inited : 1;
 	int              r4_stack_type;
 	gpointer         debug_info;
 	guint32          lmf_offset;
@@ -2263,6 +2264,7 @@ void              mono_local_regalloc (MonoCompile *cfg, MonoBasicBlock *bb);
 MonoInst         *mono_branch_optimize_exception_target (MonoCompile *cfg, MonoBasicBlock *bb, const char * exname);
 void              mono_remove_critical_edges (MonoCompile *cfg);
 gboolean          mono_is_regsize_var (MonoType *t);
+MonoInst *        mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used);
 void              mini_emit_memcpy (MonoCompile *cfg, int destreg, int doffset, int srcreg, int soffset, int size, int align);
 void              mini_emit_memset (MonoCompile *cfg, int destreg, int offset, int size, int val, int align);
 void              mini_emit_stobj (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, gboolean native);
@@ -2277,6 +2279,7 @@ void              mini_emit_memory_store (MonoCompile *cfg, MonoType *type, Mono
 void              mini_emit_memory_copy_bytes (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoInst *size, int ins_flag);
 void              mini_emit_memory_init_bytes (MonoCompile *cfg, MonoInst *dest, MonoInst *value, MonoInst *size, int ins_flag);
 void              mini_emit_memory_copy (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, gboolean native, int ins_flag);
+MonoInst *        mini_handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, int enum_val_reg, MonoInst *enum_flag);
 
 MonoMethod*       mini_get_memcpy_method (void);
 MonoMethod*       mini_get_memset_method (void);


### PR DESCRIPTION
Manually applied cherry-pick of https://github.com/mono/mono/pull/8428

Unity:
*Release Notes*:
Fixed case 1211643:
Scripting: Avoid allocation in Enum.HasFlags.

Backporting:
2020.1, 2019.4, and perhaps 2018.4

* [jit] Decompose some CEE_BOX opcodes later to allow more optimizations.

Optimize a code sequence emitted for Enum.HasFlag () by newer csc versions.
Also mark the temporary bblocks used by decompose_vtypes () as out-of-line if
the bblock under processing is out-of-line. Mark the domainvar as volatile to avoid
optimizing it away since references to it can now be generated later from the
decomposition of OP_BOX.

* [jit] Check that the enum types are the same.

* [jit] Fix support for generic enums.

* [jit] Disable the optimization with 64 bit enums on 32 bit platforms.