### PR TITLE
Unity 2017.4 fix macos not

### DIFF
--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -15,8 +15,8 @@ my $lib = "$monodistro/lib";
 my $libmono = "$lib/mono";
 my $monoprefix = "$root/tmp/monoprefix";
 my $xcodePath = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform';
-my $macversion = '10.5';
-my $sdkversion = '10.6';
+my $macversion = '10.6';
+my $sdkversion = '10.11';
 my $externalBuildDeps = "$root/../../mono-build-deps/build";
 
 my $dependencyBranchToUse = "unity3.0";

--- a/external/buildscripts/build_runtime_osx.pl
+++ b/external/buildscripts/build_runtime_osx.pl
@@ -145,15 +145,12 @@ if ($iphone_simulator || $minimal) {
 	@arches = ('i386');
 }
 
-for my $arch (@arches)
+my $arch = 'x86_64';
 {
 	print "Building for architecture: $arch\n";
 
-	my $macversion = '10.5';
-	my $sdkversion = '10.6';
-	if ($arch eq 'x86_64') {
-		$macversion = '10.6';
-	}
+	my $macversion = '10.6';
+	my $sdkversion = '10.11';
 
 	# Set up clang toolchain
 	$sdkPath = "$externalBuildDeps/MacBuildEnvironment/builds/MacOSX$sdkversion.sdk";
@@ -166,8 +163,8 @@ for my $arch (@arches)
 	$ENV{'CXX'} = "$sdkPath/../usr/bin/clang++";
 
 	# Make architecture-specific targets and lipo at the end
-	my $bintarget = "$root/builds/monodistribution/bin-$arch";
-	my $libtarget = "$root/builds/embedruntimes/osx-$arch";
+	my $bintarget = "$root/builds/monodistribution/bin";
+	my $libtarget = "$root/builds/embedruntimes/osx";
 	my $sdkoptions = '';
 
 	if ($minimal)
@@ -282,27 +279,4 @@ for my $arch (@arches)
 
 	system("ln","-f","$root/mono/mini/mono","$bintarget/mono") eq 0 or die("failed symlinking mono executable");
 	system("ln","-f","$root/mono/metadata/pedump","$bintarget/pedump") eq 0 or die("failed symlinking pedump executable");
-}
-
-# Create universal binaries
-mkpath ("$root/builds/embedruntimes/osx");
-for $file ('libmono.0.dylib','libmono.a','libMonoPosixHelper.dylib') {
-	system ('lipo', "$root/builds/embedruntimes/osx-i386/$file", "$root/builds/embedruntimes/osx-x86_64/$file", '-create', '-output', "$root/builds/embedruntimes/osx/$file");
-}
-system('cp', "$root/builds/embedruntimes/osx-i386/MonoBundleBinary", "$root/builds/embedruntimes/osx/MonoBundleBinary");
-
-# Create universal binaries
-mkpath ("$root/builds/embedruntimes/osx");
-for $file ('libmono.0.dylib','libmono.a','libMonoPosixHelper.dylib') {
-	system ('lipo', "$root/builds/embedruntimes/osx-i386/$file", "$root/builds/embedruntimes/osx-x86_64/$file", '-create', '-output', "$root/builds/embedruntimes/osx/$file");
-}
-system('cp', "$root/builds/embedruntimes/osx-i386/MonoBundleBinary", "$root/builds/embedruntimes/osx/MonoBundleBinary-i386");
-system('cp', "$root/builds/embedruntimes/osx-x86_64/MonoBundleBinary", "$root/builds/embedruntimes/osx/MonoBundleBinary-x86_64");
-
-if ($ENV{"UNITY_THISISABUILDMACHINE"}) {
-	# Clean up temporary arch-specific directories
-	rmtree("$root/builds/embedruntimes/osx-i386");
-	rmtree("$root/builds/embedruntimes/osx-x86_64");
-	rmtree("$root/builds/monodistribution/bin-i386");
-	rmtree("$root/builds/monodistribution/bin-x86_64");
 }

--- a/external/buildscripts/build_runtime_osx_all.pl
+++ b/external/buildscripts/build_runtime_osx_all.pl
@@ -434,13 +434,13 @@ sub build_osx
 		print "Building $os for architecture: $arch\n";
 
 		my $macversion = '10.7';
-		my $sdkversion = '10.7';
+		my $sdkversion = '10.11';
 
 		if ($ENV{"UNITY_THISISABUILDMACHINE"}) {
 			$macversion = '10.4' unless $arch eq 'x86_64';
 			$sdkversion = '10.4u' unless $arch eq 'x86_64';
 			$macversion = '10.6' if $arch eq 'x86_64';
-			$sdkversion = '10.6' if $arch eq 'x86_64';
+			$sdkversion = '10.11' if $arch eq 'x86_64';
 		}
 
 		# Make architecture-specific targets and lipo at the end
@@ -504,7 +504,7 @@ sub build_osx
 
 	# Create universal binaries
 	for my $file ('libmono.0.dylib','libmono.a','libMonoPosixHelper.dylib') {
-		system ('lipo', "$embeddir/$os-i386/$file", "$embeddir/$os-x86_64/$file", '-create', '-output', "$embeddir/$os/$file");
+		system ('cp', "$embeddir/$os-x86_64/$file", "$embeddir/$os/$file");
 	}
 
 	if (not $ENV{"UNITY_THISISABUILDMACHINE"})
@@ -519,9 +519,7 @@ sub build_osx
 
 	mkpath ("$distdir");
 	for my $file ('mono','pedump') {
-		system ('lipo', "$distdir-i386/$file", '-create', '-output', "$distdir/$file");
-		# Don't add 64bit executables for now...
-		# system ('lipo', "$buildsroot/monodistribution/bin-i386/$file", "$buildsroot/monodistribution/bin-x86_64/$file", '-create', '-output', "$buildsroot/monodistribution/bin/$file");
+		system ('lipo', "$buildsroot/monodistribution/bin-i386/$file", "$buildsroot/monodistribution/bin-x86_64/$file", '-create', '-output', "$buildsroot/monodistribution/bin/$file");
 	}
 
 	if ($ENV{"UNITY_THISISABUILDMACHINE"}) {


### PR DESCRIPTION
macOS has a min SDK target for notarization which is 10.9, the build tooling has either macOS 10.6 or 10.11 so we updated to 10.11 (which is fine since macOS minos is still 10.9).

This also fixes an issue where 2017.4 was unable to build on macOS 10.15 due to mono still having some 32bit elements to it, as well as resolved an issue for users who are still using UnityScript in their projects(which is still supported in 2017) which could not build on 10.15 because of 32bit elements. 

I verified this build worked and ABV passed.