### PR TITLE
[debugger] Fix NOT_IMPLEMENTED while debugging. (#19248)

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -393,6 +393,9 @@ namespace Mono.Debugger.Soft
 		public ErrorCode ErrorCode {
 			get; set;
 		}
+		public string ErrorMessage {
+			get; set;
+		}
 	}
 
 	/*
@@ -751,10 +754,12 @@ namespace Mono.Debugger.Soft
 
 				// For reply packets
 				offset = 0;
-				ReadInt (); // length
+				var len = ReadInt (); // length
 				ReadInt (); // id
 				ReadByte (); // flags
 				ErrorCode = ReadShort ();
+				if (ErrorCode == (int)Mono.Debugger.Soft.ErrorCode.INVALID_ARGUMENT && len > offset)
+					ErrorMsg = ReadString ();
 			}
 
 			public CommandSet CommandSet {
@@ -767,6 +772,10 @@ namespace Mono.Debugger.Soft
 
 			public int ErrorCode {
 				get; set;
+			}
+
+			public string ErrorMsg {
+				get; internal set;
 			}
 
 			public int Offset {
@@ -1570,7 +1579,7 @@ namespace Mono.Debugger.Soft
 							LogPacket (packetId, encoded_packet, reply, command_set, command, watch);
 						if (r.ErrorCode != 0) {
 							if (ErrorHandler != null)
-								ErrorHandler (this, new ErrorHandlerEventArgs () { ErrorCode = (ErrorCode)r.ErrorCode });
+								ErrorHandler (this, new ErrorHandlerEventArgs () { ErrorCode = (ErrorCode)r.ErrorCode, ErrorMessage = r.ErrorMsg});
 							throw new NotImplementedException ("No error handler set.");
 						} else {
 							return r;

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -347,7 +347,7 @@ namespace Mono.Debugger.Soft
 			case ErrorCode.NO_SEQ_POINT_AT_IL_OFFSET:
 				throw new ArgumentException ("Cannot set breakpoint on the specified IL offset.");
 			default:
-				throw new CommandException (args.ErrorCode);
+				throw new CommandException (args.ErrorCode, args.ErrorMessage);
 			}
 		}
 
@@ -792,12 +792,17 @@ namespace Mono.Debugger.Soft
 
 	public class CommandException : Exception {
 
-		internal CommandException (ErrorCode error_code) : base ("Debuggee returned error code " + error_code + ".") {
+		internal CommandException (ErrorCode error_code, string error_message) : base ("Debuggee returned error code " + error_code + (error_message == null || error_message.Length == 0 ? "." : " - " + error_message + ".")) {
 			ErrorCode = error_code;
+			ErrorMessage = error_message;
 		}
 
 		public ErrorCode ErrorCode {
 			get; set;
+		}
+
+		public string ErrorMessage {
+			get; internal set;
 		}
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -365,12 +365,19 @@ public class Tests : TestsBase, ITest2
 		if (args.Length > 0 && args [0] == "invoke-abort")
 			new Tests ().invoke_abort ();
 		new Tests ().evaluate_method ();
+
+		test_invalid_argument_assembly_get_type ();
+
 		return 3;
 	}
 
 	public static void local_reflect () {
 		//Breakpoint line below, and reflect someField via ObjectMirror;
 		LocalReflectClass.RunMe ();
+	}
+
+	public static void test_invalid_argument_assembly_get_type () {
+
 	}
 
 	public static void breakpoints () {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4431,5 +4431,18 @@ public class DebuggerTests
 		AssertValue (1, mirror["i"]);
 		AssertValue (2.0, mirror["d"]);
 	}
+
+	[Test]
+	public void InvalidArgumentAssemblyGetType () {
+		Event e = run_until ("test_invalid_argument_assembly_get_type");
+		var assembly = entry_point.DeclaringType.Assembly;
+		try {
+			var type = assembly.GetType ("System.Collections.Generic.Dictionary<double, float>.Main");
+		}
+		catch (CommandException ex) {
+			Assert.AreEqual(ex.ErrorMessage, "Unexpected assembly-qualified type \"System.Collections.Generic.Dictionary<double, float>.Main\" was provided");
+		}
+	}
+
 } // class DebuggerTests
 } // namespace


### PR DESCRIPTION
- Changed the behavior on debugger-agent, if we can't parse the new behavior is to return invalid_argument and not assert and stop debugging
- Changed the mono_domain_set_fast before return from assembly_commands.
- Add error message when return INVALID_ARGUMENT

Fixes #19146

Fixes case [1197204](https://issuetracker.unity3d.com/issues/crash-when-declaring-a-replacement-variable-with-using-that-encompasses-any-kind-of-dictionary)