### PR TITLE
Fix crashes caused by domain reload and incorrect image data (case 1224837)

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2095,10 +2095,6 @@ mono_image_close_except_pools (MonoImage *image)
 
 	mono_wrapper_caches_free (&image->wrapper_caches);
 
-	for (i = 0; i < image->gshared_types_len; ++i)
-		free_hash (image->gshared_types [i]);
-	g_free (image->gshared_types);
-
 	/* The ownership of signatures is not well defined */
 	g_hash_table_destroy (image->memberref_signatures);
 	g_hash_table_destroy (image->helper_signatures);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -406,11 +406,6 @@ struct _MonoImage {
 	/* Maps malloc-ed char* pinvoke scope -> malloced-ed char* filename */
 	GHashTable *pinvoke_scope_filenames;
 
-	/* Indexed by MonoGenericParam pointers */
-	GHashTable **gshared_types;
-	/* The length of the above array */
-	int gshared_types_len;
-
 	/* The loader used to load this image */
 	MonoImageLoader *loader;
 
@@ -449,6 +444,11 @@ typedef struct {
 	GHashTable *szarray_cache, *array_cache, *ptr_cache;
 
 	MonoWrapperCaches wrapper_caches;
+
+	/* Indexed by MonoGenericParam pointers */
+	GHashTable **gshared_types;
+	/* The length of the above array */
+	int gshared_types_len;
 
 	mono_mutex_t    lock;
 
@@ -728,6 +728,12 @@ char*
 mono_image_set_strdup (MonoImageSet *set, const char *s);
 
 void mono_metadata_image_set_foreach(MonoImageSetFunc func, gpointer user_data);
+
+MonoImageSet *
+mono_metadata_get_image_set_for_type (MonoType *type);
+
+MonoImageSet *
+mono_metadata_merge_image_sets (MonoImageSet *set1, MonoImageSet *set2);
 
 #define mono_image_set_new0(image,type,size) ((type *) mono_image_set_alloc0 (image, sizeof (type)* (size)))
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -3145,17 +3145,20 @@ MonoImageSet *
 mono_metadata_merge_image_sets (MonoImageSet *set1, MonoImageSet *set2)
 {
 	MonoImage **images = g_newa (MonoImage*, set1->nimages + set2->nimages);
+
+	/* Add images from set1 */
 	memcpy (images, set1->images, sizeof (MonoImage*) * set1->nimages);
 
 	int nimages = set1->nimages;
 	// FIXME: Quaratic
-	for (int i = 0; i < set1->nimages; ++i) {
+	/* Add images from set2 */
+	for (int i = 0; i < set2->nimages; ++i) {
 		int j;
-		for (j = 0; j < set2->nimages; ++j) {
-			if (set1->images [i] == set2->images [j])
+		for (j = 0; j < set1->nimages; ++j) {
+			if (set2->images [i] == set1->images [j])
 				break;
 		}
-		if (j == set2->nimages)
+		if (j == set1->nimages)
 			images [nimages ++] = set2->images [i];
 	}
 	return get_image_set (images, nimages);

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3460,11 +3460,14 @@ shared_gparam_equal (gconstpointer ka, gconstpointer kb)
 MonoType*
 mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 {
+	MonoImageSet *set;
 	MonoGenericParam *par = t->data.generic_param;
 	MonoGSharedGenericParam *copy, key;
 	MonoType *res;
 	MonoImage *image = NULL;
 	char *name;
+
+	set = mono_metadata_merge_image_sets (mono_metadata_get_image_set_for_type (t), mono_metadata_get_image_set_for_type (constraint));
 
 	memset (&key, 0, sizeof (key));
 	key.parent = par;
@@ -3477,23 +3480,24 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	 * Need a cache to ensure the newly created gparam
 	 * is unique wrt T/CONSTRAINT.
 	 */
-	mono_image_lock (image);
-	if (!image->gshared_types) {
-		image->gshared_types_len = MONO_TYPE_INTERNAL;
-		image->gshared_types = g_new0 (GHashTable*, image->gshared_types_len);
+	mono_image_set_lock (set);
+	if (!set->gshared_types) {
+		set->gshared_types_len = MONO_TYPE_INTERNAL;
+		set->gshared_types = g_new0 (GHashTable*, set->gshared_types_len);
 	}
-	if (!image->gshared_types [constraint->type])
-		image->gshared_types [constraint->type] = g_hash_table_new (shared_gparam_hash, shared_gparam_equal);
-	res = (MonoType *)g_hash_table_lookup (image->gshared_types [constraint->type], &key);
-	mono_image_unlock (image);
+	if (!set->gshared_types [constraint->type])
+		set->gshared_types [constraint->type] = g_hash_table_new (shared_gparam_hash, shared_gparam_equal);
+	res = (MonoType *)g_hash_table_lookup (set->gshared_types [constraint->type], &key);
+	mono_image_set_unlock (set);
 	if (res)
 		return res;
-	copy = (MonoGSharedGenericParam *)mono_image_alloc0 (image, sizeof (MonoGSharedGenericParam));
+	copy = (MonoGSharedGenericParam *)mono_image_set_alloc0 (set, sizeof (MonoGSharedGenericParam));
 	memcpy (&copy->param, par, sizeof (MonoGenericParamFull));
 	copy->param.info.pklass = NULL;
-	constraint = mono_metadata_type_dup (image, constraint);
+	// FIXME:
+	constraint = mono_metadata_type_dup (NULL, constraint);
 	name = get_shared_gparam_name (constraint->type, ((MonoGenericParamFull*)copy)->info.name);
-	copy->param.info.name = mono_image_strdup (image, name);
+	copy->param.info.name = mono_image_set_strdup (set, name);
 	g_free (name);
 
 	copy->param.param.owner = par->owner;
@@ -3503,12 +3507,10 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	res = mono_metadata_type_dup (NULL, t);
 	res->data.generic_param = (MonoGenericParam*)copy;
 
-	if (image) {
-		mono_image_lock (image);
-		/* Duplicates are ok */
-		g_hash_table_insert (image->gshared_types [constraint->type], copy, res);
-		mono_image_unlock (image);
-	}
+	mono_image_set_lock (set);
+	/* Duplicates are ok */
+	g_hash_table_insert (set->gshared_types [constraint->type], copy, res);
+	mono_image_set_unlock (set);
 
 	return res;
 }


### PR DESCRIPTION
Release note: Fixed crash that occurred during domain reload that was caused by image set data being stored in the wrong image.