### PR TITLE
Unity master new unitychanges linux

### DIFF
--- a/.yamato/collate_builds.yml
+++ b/.yamato/collate_builds.yml
@@ -8,7 +8,6 @@ agent:
 dependencies:
   - .yamato/build_android.yml
   - .yamato/build_linux_x64.yml
-  - .yamato/build_linux_x86.yml
   - .yamato/build_osx_classlibs.yml
   - .yamato/build_osx_runtime.yml
   - .yamato/build_win.yml


### PR DESCRIPTION
Changed to support Linux against the current sysroot instead of the Linux SDK Chroot. This also removes the building of 32bit linux for mono on yamato. 