### PR TITLE
Fix abort behavior on Windows

### DIFF
--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -31,6 +31,10 @@
 #include <stdlib.h>
 #include <glib.h>
 
+#ifdef G_OS_WIN32
+#include <windows.h>
+#endif
+
 /* The current fatal levels, error is always fatal */
 static GLogLevelFlags fatal = G_LOG_LEVEL_ERROR;
 static GLogFunc default_log_func;
@@ -233,7 +237,11 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 	if (log_level & fatal) {
 		fflush (stdout);
 		fflush (stderr);
+#ifdef G_OS_WIN32
+		RaiseException (0xE0000001, EXCEPTION_NONCONTINUABLE, 0, NULL);
+#else
 		abort ();
+#endif
 	}
 }
 

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -25,6 +25,7 @@
 #include <sys/time.h>
 #else
 #include <process.h>
+#include <Windows.h>
 #endif
 #include "mono-logger-internals.h"
 #include "mono-proclib.h"
@@ -131,8 +132,13 @@ mono_log_write_logfile (const char *log_domain, GLogLevelFlags level, mono_bool 
 
 	fflush(logFile);
 
-	if (level & G_LOG_LEVEL_ERROR)
-		abort();
+	if (level & G_LOG_LEVEL_ERROR) {
+#ifdef HOST_WIN32
+		RaiseException (0xE0000001, EXCEPTION_NONCONTINUABLE, 0, NULL);
+#else
+		abort ();
+#endif
+	}
 }
 
 /**


### PR DESCRIPTION
We statically link the C runtime on Windows and abort handlers are part of the C runtime. This means that Unity's abort handler is not connected to the C runtime in Mono, and when an abort happens we get the default behavior instead of proper chaining/handling to our bug reporter.

RaiseException and SEH is process wide. Use RaiseException to force crash instead of abort.

Release Notes:
Improved
Scripting: Invoke Unity crash handler when internal abort in Mono is triggered on Windows.

Backporting:
We should backport to all LTS releases for new version of Unity.