### PR TITLE
Add ability to turn on just the portable executable verifier to catch…

### DIFF
--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -3967,7 +3967,7 @@ mono_verifier_verify_pe_data (MonoImage *image, GSList **error_list)
 {
 	VerifyContext ctx;
 
-	if (!mono_verifier_is_enabled_for_image (image))
+	if (!mono_verifier_is_enabled_for_image (image) && !mono_verifier_is_enabled_for_pe_only())
 		return TRUE;
 
 	init_verify_context (&ctx, image, error_list != NULL);

--- a/mono/metadata/verify-internals.h
+++ b/mono/metadata/verify-internals.h
@@ -14,6 +14,7 @@ G_BEGIN_DECLS
 
 typedef enum {
 	MONO_VERIFIER_MODE_OFF,
+	MONO_VERIFIER_PE_ONLY,
 	MONO_VERIFIER_MODE_VALID,
 	MONO_VERIFIER_MODE_VERIFIABLE,
 	MONO_VERIFIER_MODE_STRICT
@@ -25,6 +26,7 @@ void mono_verifier_enable_verify_all (void);
 gboolean mono_verifier_is_enabled_for_image (MonoImage *image);
 gboolean mono_verifier_is_enabled_for_method (MonoMethod *method);
 gboolean mono_verifier_is_enabled_for_class (MonoClass *klass);
+gboolean mono_verifier_is_enabled_for_pe_only ();
 
 gboolean mono_verifier_is_method_full_trust (MonoMethod *method);
 gboolean mono_verifier_is_class_full_trust (MonoClass *klass);

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -6134,13 +6134,19 @@ mono_verifier_is_enabled_for_method (MonoMethod *method)
 gboolean
 mono_verifier_is_enabled_for_class (MonoClass *klass)
 {
-	return verify_all || (verifier_mode > MONO_VERIFIER_MODE_OFF && !(klass->image->assembly && klass->image->assembly->in_gac) && klass->image != mono_defaults.corlib);
+	return verify_all || (verifier_mode > MONO_VERIFIER_PE_ONLY && !(klass->image->assembly && klass->image->assembly->in_gac) && klass->image != mono_defaults.corlib);
 }
 
 gboolean
 mono_verifier_is_enabled_for_image (MonoImage *image)
 {
-	return verify_all || verifier_mode > MONO_VERIFIER_MODE_OFF;
+	return verify_all || verifier_mode > MONO_VERIFIER_PE_ONLY;
+}
+
+gboolean
+mono_verifier_is_enabled_for_pe_only ()
+{
+	return verify_all || verifier_mode == MONO_VERIFIER_PE_ONLY;
 }
 
 /*


### PR DESCRIPTION
… corrupted dlls.

Ran editor startup perf tests and they pass.

Release Note:
Enabled portable executable verification to prevent corrupted dlls from being loaded and crashing the editor.

**NOTE** There are associated unity repo changes for this on branch: `scripting/mono/enable_security`

fixes (case 1231038)