### PR TITLE
Adding check to avoid processing pdbs that have zero sequence points …

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -415,6 +415,9 @@ mono_ppdb_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrAr
 
 	method_idx = mono_metadata_token_index (method->token);
 
+	if (tables [MONO_TABLE_METHODBODY].rows == 0)
+		return;
+
 	mono_metadata_decode_row (&tables [MONO_TABLE_METHODBODY], method_idx-1, cols, MONO_METHODBODY_SIZE);
 
 	docidx = cols [MONO_METHODBODY_DOCUMENT];


### PR DESCRIPTION
…(case 1241344)

Release note:
Fixed crash that was occurred when the managed debugger would attempt to load a pdb that had zero sequence points.