### PR TITLE
[runtime] Magic interfaces requires the complex stelemref to handle a…

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9837,6 +9837,11 @@ get_virtual_stelemref_kind (MonoClass *element_class)
 		return STELEMREF_OBJECT;
 	if (is_monomorphic_array (element_class))
 		return STELEMREF_SEALED_CLASS;
+
+	/* magic ifaces requires aditional checks for when the element type is an array */
+	if (MONO_CLASS_IS_INTERFACE (element_class) && element_class->is_array_special_interface)
+		return STELEMREF_COMPLEX;
+
 	/* Compressed interface bitmaps require code that is quite complex, so don't optimize for it. */
 	if (MONO_CLASS_IS_INTERFACE (element_class) && !mono_class_has_variant_generic_params (element_class))
 #ifdef COMPRESSED_INTERFACE_BITMAP

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Reflection;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
@@ -1826,6 +1827,30 @@ ncells ) {
 			object o = __refvalue (r, object);
 		} catch (InvalidCastException) {
 		}
+
+		return 0;
+	}
+
+	public interface IFoo
+	{
+	  int MyInt { get; }
+	}
+
+	public class IFooImpl : IFoo
+	{
+	  public int MyInt => 0;
+	}
+
+	//gh 6266
+	public static int test_0_store_to_magic_iface_array ()
+	{
+		ICollection<IFoo> arr1 = new IFooImpl[1] { new IFooImpl() };
+		ICollection<IFoo> arr2 = new IFooImpl[1] { new IFooImpl() };
+
+		ICollection<IFoo>[] a2d = new ICollection<IFoo>[2] {
+			arr1,
+			arr2,
+		};
 
 		return 0;
 	}


### PR DESCRIPTION
…rrays. Fixes gh #6266 (#7038) (FB: case 1235903)

Release note: Fixing case where ArrayTypeMismatchException was being thrown incorrectly.