### PR TITLE
Avoid exceeding the mark stack limit (case 1235202)

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -160,7 +160,7 @@ static mse * GC_gcj_vector_proc (word * addr, mse * mark_stack_ptr,
 	/* end at last element or max chunk size */
 	word *actual_end = actual_start + length * words_per_element;
 
-	return GC_gcj_vector_mark_proc (mark_stack_ptr, element_desc, start, actual_end, words_per_element);
+	return GC_gcj_vector_mark_proc (mark_stack_ptr, mark_stack_limit, element_desc, start, actual_end, words_per_element);
 }
 
 #endif


### PR DESCRIPTION
Large diff in bdwgc is because we haven't updated the submodule in a while.

Fix case: 1235202
Scripting: Fix crash/hang when large number of arrays are allocated

Backporting:
2020.1