### PR TITLE
Valuetype ref return x64jit fix

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12458,7 +12458,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				CHECK_OPSIZE (4);
 				n = read16 (ip + 2);
 				CHECK_LOCAL (n);
-				if ((ip [4] == CEE_LDFLD) && ip_in_bb (cfg, cfg->cbb, ip + 4) && header->locals [n]->type == MONO_TYPE_VALUETYPE) {
+				if ((ip [4] == CEE_LDFLD) && ip_in_bb (cfg, cfg->cbb, ip + 4) && header->locals [n]->type == MONO_TYPE_VALUETYPE && !header->locals [n]->byref) {
 					/* Avoid loading a struct just to load one of its fields */
 					EMIT_NEW_LOCLOADA (cfg, ins, n);
 				} else {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12458,7 +12458,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				CHECK_OPSIZE (4);
 				n = read16 (ip + 2);
 				CHECK_LOCAL (n);
-				if ((ip [4] == CEE_LDFLD) && ip_in_bb (cfg, cfg->cbb, ip + 4) && header->locals [n]->type == MONO_TYPE_VALUETYPE && !header->locals [n]->byref) {
+				if ((ip [4] == CEE_LDFLD) && ip_in_bb (cfg, cfg->cbb, ip + 4) && MONO_TYPE_ISSTRUCT (header->locals [n])) {
 					/* Avoid loading a struct just to load one of its fields */
 					EMIT_NEW_LOCLOADA (cfg, ins, n);
 				} else {


### PR DESCRIPTION
When we have the following sequence:

```
    ldloc n
    ldfld valuetype [Unity.Mathematics]Unity.Mathematics.int2 Foo::bar
```
and `local n` is a reference to value, when walking the instructions in
mono_method_to_ir, we generally try to avoid loading a whole value
type just to load one of the fields.  I believe this is an
optimization.

The test here is not quite complete, though, as we have ref valuetypes
where the object stored at the location is actually an address, in
which case we still need to treat it as we would a normal reference.

This optimization isn't present in the ldloc.n coded forms and is
written in a slightly more robust way in ldloc.s, so no changes are
necessary there.

As an alternative to this commit, we might adopt a simplified version of the ldloc.s test for
ldloc as well, or merge in
https://github.com/mono/mono/commit/29428d951637ff85b593ea5c9cc5d5236579906d/mono/mini/method-to-ir.c
from master which encapsulates much the same intent.

Associated bug: https://fogbugz.unity3d.com/f/cases/1252663/
