### PR TITLE
Add `mono_unity_gc_set_mode` API 

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -913,6 +913,34 @@ mono_unity_get_unitytls_interface()
 }
 
 // gc
+MONO_API void mono_unity_gc_set_mode(MonoGCMode mode)
+{
+#if HAVE_BDWGC_GC
+	switch (mode)
+	{
+		case MONO_GC_MODE_ENABLED:
+			if (GC_is_disabled())
+				GC_enable();
+			GC_set_disable_automatic_collection(FALSE);
+			break;
+
+		case MONO_GC_MODE_DISABLED:
+			if (!GC_is_disabled())
+				GC_disable();
+			break;
+
+		case MONO_GC_MODE_MANUAL:
+			if (GC_is_disabled())
+				GC_enable();
+			GC_set_disable_automatic_collection(TRUE);
+			break;
+	}
+#else
+	g_assert_not_reached ();
+#endif
+}
+
+// Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API void mono_unity_gc_enable()
 {
 #if HAVE_BDWGC_GC
@@ -922,6 +950,7 @@ MONO_API void mono_unity_gc_enable()
 #endif
 }
 
+// Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API void mono_unity_gc_disable()
 {
 #if HAVE_BDWGC_GC
@@ -931,6 +960,7 @@ MONO_API void mono_unity_gc_disable()
 #endif
 }
 
+// Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API int mono_unity_gc_is_disabled()
 {
 #if HAVE_BDWGC_GC

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -152,9 +152,22 @@ MONO_API unitytls_interface_struct* mono_unity_get_unitytls_interface();
 MONO_API void mono_unity_install_unitytls_interface(unitytls_interface_struct* callbacks);
 
 // gc
+typedef enum
+{
+	MONO_GC_MODE_DISABLED = 0,
+	MONO_GC_MODE_ENABLED = 1,
+	MONO_GC_MODE_MANUAL = 2
+}  MonoGCMode;
+
+MONO_API void mono_unity_gc_set_mode(MonoGCMode mode);
+
+// Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API void mono_unity_gc_enable();
+// Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API void mono_unity_gc_disable();
+// Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API int mono_unity_gc_is_disabled();
+
 
 //misc
 MonoAssembly* mono_unity_assembly_get_mscorlib();


### PR DESCRIPTION
to replace `mono_unity_gc_enable`/`mono_unity_gc_disable`/`mono_unity_gc_is_disabled`

This will allow - beyond simply disabling the GC - to set the GC into "manual" mode, where GC is still possible (including incremental gc), but only when explicitly triggered. This allows content to take over managing collection frequency.