### PR TITLE
Gather callstack even if instruction pointer is null.

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2727,7 +2727,7 @@ mono_unity_backtrace_from_context (void* context, void* array[], int count)
 	ip = (void*)MONO_CONTEXT_GET_IP(&mctx);
 	bp = (void**)MONO_CONTEXT_GET_BP(&mctx);
 
-	while(ip && bp && count-- > 0)
+	while(bp && count-- > 0)
 	{
 		array[idx++] = ip;
 


### PR DESCRIPTION
Address this issue https://unity3d.atlassian.net/browse/DOTS-1997

This change allows a full callstack to be obtained even if IP is NULL. I encountered this issue while working on a CI failure https://unity3d.atlassian.net/browse/DOTS-1866 that caused the editor to crash and the logs showed `Obtained 0 stack frames.`. In this failure, some external function pointers were not always being set which allowed an indirect jump to NULL. Since no callstack was printed, debugging this issue was more difficult.