### PR TITLE
Add Apple silicon slice to Mono runtime built for macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -355,6 +355,9 @@ case "$host" in
 				platform_ios=yes
 				has_dtrace=no
 				;;
+			aarch64*-darwinmacos*)
+				support_boehm=no
+				;;
 			aarch64*-darwin*)
 				platform_ios=yes
 				;;
@@ -3434,6 +3437,16 @@ case "$host" in
 		ACCESS_UNALIGNED="no"
 		CPPFLAGS="$CPPFLAGS -D__ARM_EABI__"
 		;;
+	aarch64-*-darwinmacos*)
+		TARGET_SYS=MACOS
+		TARGET=ARM64
+		arch_target=arm64
+		boehm_supported=false
+		AOT_SUPPORTED="yes"
+		BTLS_SUPPORTED=yes
+		BTLS_PLATFORM=aarch64
+		AC_CHECK_HEADER(stdalign.h,[],[BTLS_SUPPORTED=no])
+		;;
 	aarch64-*)
 		# https://lkml.org/lkml/2012/7/15/133
 		TARGET=ARM64
@@ -3727,8 +3740,8 @@ if test "x$target_mach" = "xyes"; then
 	  CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_WATCHOS"
 	  CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_WATCHOS"
 	  BTLS_SUPPORTED=no
-   elif test "x$TARGET" = "xARM" -o "x$TARGET" = "xARM64"; then
-   	  AC_DEFINE(TARGET_IOS,1,[The JIT/AOT targets iOS])
+   elif test "x$TARGET" = "xARM" -o "x$TARGET" = "xARM64" -a "x$TARGET_SYS" != "xMACOS"; then
+	  AC_DEFINE(TARGET_IOS,1,[The JIT/AOT targets iOS])
 	  CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_IOS"
 	  CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_IOS"
 	  BTLS_SUPPORTED=no

--- a/configure.ac
+++ b/configure.ac
@@ -1620,22 +1620,27 @@ if test x$host_win32 = xno; then
 		LIBS="$LIBS $DL_LIB"
 		AC_DEFINE(HAVE_DL_LOADER,1,[dlopen-based dynamic loader available])
 		dnl from glib's configure.ac
-		AC_CACHE_CHECK([for preceeding underscore in symbols],
-			mono_cv_uscore,[
-			AC_TRY_RUN([#include <dlfcn.h>
-			int mono_underscore_test (void) { return 42; }
-			int main() {
-			  void *f1 = (void*)0, *f2 = (void*)0, *handle;
-			  handle = dlopen ((void*)0, 0);
-			  if (handle) {
-			    f1 = dlsym (handle, "mono_underscore_test");
-			    f2 = dlsym (handle, "_mono_underscore_test");
-			  } return (!f2 || f1);
-			}],
+		if test "x$cross_compiling" = "xyes"; then
+		   AC_MSG_RESULT(cross compiling, assuming no)
+		   mono_cv_uscore=no
+		else
+			AC_CACHE_CHECK([for preceeding underscore in symbols],
+			  mono_cv_uscore,[
+			  AC_TRY_RUN([#include <dlfcn.h>
+			  int mono_underscore_test (void) { return 42; }
+			  int main() {
+			    void *f1 = (void*)0, *f2 = (void*)0, *handle;
+			    handle = dlopen ((void*)0, 0);
+			    if (handle) {
+			      f1 = dlsym (handle, "mono_underscore_test");
+			      f2 = dlsym (handle, "_mono_underscore_test");
+			    } return (!f2 || f1);
+			  }],
 				[mono_cv_uscore=yes],
 				[mono_cv_uscore=no],
-			[])
-		])
+			  [])
+		  ])
+		fi
 		if test "x$mono_cv_uscore" = "xyes"; then
 			MONO_DL_NEED_USCORE=1
 		else

--- a/external/buildscripts/Build.bee.cs
+++ b/external/buildscripts/Build.bee.cs
@@ -75,7 +75,7 @@ namespace BuildProgram
 
 			Artifacts.Add("MacBuildEnvironment",
 				new Tuple<string, string>(
-					"MacBuildEnvironment/9df1e3b3b120_2fc8e616a2e5dfb7907fc42d9576b427e692223c266dc3bc305de4bf03714e30.7z",
+					"mac-toolchain-11_0/12.0-12A8158a_2b346a6c93e9c82250a1d88c02f24a5dea9f0bd1aa2ef44109896a44800e8c68.zip",
 					"unity-internal"));
 
 			Artifacts.Add("mono-build-tools-extra",

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -52,6 +52,7 @@ my $forceDefaultBuildDeps=0;
 my $existingMonoRootPath = '';
 my $sdk = '';
 my $arch32 = 0;
+my $targetArch = "";
 my $winPerl = "";
 my $winMonoRoot = "";
 my $msBuildVersion = "14.0";
@@ -97,6 +98,7 @@ GetOptions(
 	'runtimetests=i'=>\$runRuntimeTests,
 	'classlibtests=i'=>\$runClasslibTests,
 	'arch32=i'=>\$arch32,
+	'targetarch=s'=>\$targetArch,
 	'jobs=i'=>\$jobs,
 	'sdk=s'=>\$sdk,
 	'existingmono=s'=>\$existingMonoRootPath,
@@ -206,9 +208,15 @@ if($^O eq "linux")
 }
 elsif($^O eq 'darwin')
 {
-	$monoHostArch = $arch32 ? "i386" : "x86_64";
+	$monoHostArch = "x86_64";
 	$existingExternalMono = "$existingExternalMonoRoot";
 	$existingExternalMonoBinDir = "bin";
+
+	if ($targetArch eq "arm64")
+	{
+		$disableMcs = 1;
+		$test = 0;
+	}
 
 	# From Massi: I was getting failures in install_name_tool about space
 	# for the commands being too small, and adding here things like
@@ -447,22 +455,12 @@ if ($build)
 	}
 
 	my $macSdkPath = "";
-	my $macversion = '10.8';
+	my $macversion = '10.12';
 	my $darwinVersion = "10";
 	if ($^O eq 'darwin')
 	{
-		if ($sdk eq '')
-		{
-			$sdk='10.11';
-		}
-
-		my $macBuildEnvDir = "$externalBuildDeps/MacBuildEnvironment";
-		$macSdkPath = "$macBuildEnvDir/builds/MacOSX$sdk.sdk";
-		if (! -d $macSdkPath)
-		{
-			print(">>> Unzipping mac build toolchain\n");
-			system("unzip", '-qd', "$macBuildEnvDir", "$macBuildEnvDir/builds.zip") eq 0 or die ("failed unzipping mac build toolchain\n");
-		}
+		$sdk='11.0';
+		$macSdkPath = "$externalBuildDeps/mac-toolchain-11_0/MacOSX$sdk.sdk";
 	}
 
 	if ($iphone || $iphoneSimulator)
@@ -1156,20 +1154,37 @@ if ($build)
 			$existingMonoRootPath = "$monoInstalls/$monoVersionToUse";
 		}
 
+		if ($targetArch eq "arm64")
+		{
+			$macversion = "11.0"; # To build on ARM64, we need to specify min OS version as 11.0 as we need to use new APIs from 11.0
+		}
+
 		$mcs = "EXTERNAL_MCS=$existingMonoRootPath/bin/mcs";
 
 		$ENV{'CC'} = "$macSdkPath/../usr/bin/clang";
 		$ENV{'CXX'} = "$macSdkPath/../usr/bin/clang++";
-		$ENV{'CFLAGS'} = $ENV{MACSDKOPTIONS} = "-D_XOPEN_SOURCE -I$macBuildEnvDir/builds/usr/include -mmacosx-version-min=$macversion -isysroot $macSdkPath";
+		$ENV{'CFLAGS'} = $ENV{MACSDKOPTIONS} = "-mmacosx-version-min=$macversion -isysroot $macSdkPath -g";
 
-		$ENV{CFLAGS} = "$ENV{CFLAGS} -g -O0" if $debug;
+		$ENV{CFLAGS} = "$ENV{CFLAGS} -O0" if $debug;
 		$ENV{CFLAGS} = "$ENV{CFLAGS} -Os" if not $debug; #optimize for size
 
-		$ENV{CC} = "$ENV{CC} -arch $monoHostArch";
-		$ENV{CXX} = "$ENV{CXX} -arch $monoHostArch";
+		$ENV{CC} = "$ENV{CC} -arch $targetArch";
+		$ENV{CXX} = "$ENV{CXX} -arch $targetArch";
 
 		# Add OSX specific autogen args
-		push @configureparams, "--host=$monoHostArch-apple-darwin12.2.0";
+
+		if ($targetArch eq "x86_64")
+		{
+			push @configureparams, "--host=x86_64-apple-darwin12.2.0";
+		}
+		elsif ($targetArch eq "arm64")
+		{
+			push @configureparams, "--host=aarch64-apple-darwinmacos12.2.0";
+		}
+		else
+		{
+			die("Unsupported macOS architecture: $targetArch");
+		}
 
 		# Need to define because Apple's SIP gets in the way of us telling mono where to find this
 		push @configureparams, "--with-libgdiplus=$addtoresultsdistdir/lib/libgdiplus.dylib";
@@ -1507,10 +1522,9 @@ if ($artifact)
 	}
 	elsif($^O eq 'darwin')
 	{
-		# Note these tmp directories will get merged into a single 'osx' directory later by a parent script
-		$embedDirArchDestination = "$embedDirRoot/osx-tmp-$monoHostArch";
-		$distDirArchBin = "$distdir/bin-osx-tmp-$monoHostArch";
-		$versionsOutputFile = $arch32 ? "$buildsroot/versions-osx32.txt" : "$buildsroot/versions-osx64.txt";
+		$embedDirArchDestination = "$embedDirRoot/osx-tmp-$targetArch";
+		$distDirArchBin = "$distdir/bin-osx-tmp-$targetArch";
+		$versionsOutputFile = "$buildsroot/versions-macos-$targetArch.txt";
 	}
 	else
 	{

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -4,6 +4,8 @@ use Getopt::Long;
 use File::Basename;
 use File::Path;
 use lib ('external/buildscripts', "../../Tools/perl_lib","perl_lib", 'external/buildscripts/perl_lib');
+use strict;
+use warnings;
 use Tools qw(InstallNameTool);
 
 print ">>> PATH in Build All = $ENV{PATH}\n\n";
@@ -11,7 +13,7 @@ print ">>> PATH in Build All = $ENV{PATH}\n\n";
 my $currentdir = getcwd();
 
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
-my $monoroot = abs_path($monoroot);
+$monoroot = abs_path($monoroot);
 
 my $buildscriptsdir = "$monoroot/external/buildscripts";
 my $addtoresultsdistdir = "$buildscriptsdir/add_to_build_results/monodistribution";
@@ -294,7 +296,7 @@ if ($build)
 			}
 			else
 			{
-				if (not $checkoutonthefly)
+				if (not $checkoutOnTheFly)
 				{
 					print(">>> No external build deps found.  Might as well try to check them out.  If it fails, we'll continue and trust mono is in your PATH\n");
 				}
@@ -681,7 +683,6 @@ if ($build)
 		my $platformRootPostfix = "";
 		my $useKraitPatch = 1;
 		my $kraitPatchPath = "$monoroot/../../android_krait_signal_handler/build";
-		my $toolChainExtension = "";
 
 		$ENV{ANDROID_PLATFORM} = "android-$apiLevel";
 
@@ -759,8 +760,6 @@ if ($build)
 
 		if ($runningOnWindows)
 		{
-			$toolChainExtension = ".exe";
-
 			$androidPlatformRoot = `cygpath -w $androidPlatformRoot`;
 			# clean up trailing new lines that end up in the output from cygpath.
 			$androidPlatformRoot =~ s/\n+$//;
@@ -968,8 +967,6 @@ if ($build)
 
 		if ($runningOnWindows)
 		{
-			$toolChainExtension = ".exe";
-
 			$tizenPlatformRoot = `cygpath -w $tizenPlatformRoot`;
 			# clean up trailing new lines that end up in the output from cygpath.
 			$tizenPlatformRoot =~ s/\n+$//;
@@ -1598,7 +1595,7 @@ if ($artifact)
 			system("ln","-f", "$monoroot/mono/mini/.libs/libmonosgen-2.0.dylib","$embedDirArchDestination/libmonosgen-2.0.dylib") eq 0 or die ("failed symlinking libmonosgen-2.0.dylib\n");
 
 			print "Hardlinking libMonoPosixHelper.dylib\n";
-			system("ln","-f", "$monoroot/support/.libs/libMonoPosixHelper.dylib","$embedDirArchDestination/libMonoPosixHelper.dylib") eq 0 or die ("failed symlinking $libtarget/libMonoPosixHelper.dylib\n");
+			system("ln","-f", "$monoroot/support/.libs/libMonoPosixHelper.dylib","$embedDirArchDestination/libMonoPosixHelper.dylib") eq 0 or die ("failed symlinking $embedDirArchDestination/libMonoPosixHelper.dylib\n");
 
 			InstallNameTool("$embedDirArchDestination/libmonobdwgc-2.0.dylib", "\@executable_path/../Frameworks/MonoEmbedRuntime/osx/libmonobdwgc-2.0.dylib");
 			InstallNameTool("$embedDirArchDestination/libmonosgen-2.0.dylib", "\@executable_path/../Frameworks/MonoEmbedRuntime/osx/libmonosgen-2.0.dylib");
@@ -1691,9 +1688,9 @@ else
 
 if ($test)
 {
+	my $runtimeTestsDir = "$monoroot/mono/mini";
 	if ($runRuntimeTests)
 	{
-		my $runtimeTestsDir = "$monoroot/mono/mini";
 		chdir("$runtimeTestsDir") eq 1 or die ("failed to chdir");
 		print("\n>>> Calling make check in $runtimeTestsDir\n\n");
 		system("make","check") eq 0 or die ("runtime tests failed\n");

--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -62,48 +62,29 @@ if ($buildUsAndBoo)
 }
 
 print(">>> Building x86_64\n");
-system("perl", "$buildscriptsdir/build.pl", "--clean=1", "--classlibtests=0", @passAlongArgs) eq 0 or die ('failing building x86_64');
+system("perl", "$buildscriptsdir/build.pl", "--clean=1", "--classlibtests=0", "--targetarch=x86_64", @passAlongArgs) eq 0 or die ('failing building x86_64');
+
+print(">>> Building ARM64\n");
+system("perl", "$buildscriptsdir/build.pl", "--clean=1", "--classlibtests=0", "--targetarch=arm64", @passAlongArgs) eq 0 or die ("failing building ARM64");
 
 if ($artifact)
 {
 	print(">>> Moving built binaries to final output directories\n");
-	# Merge stuff in the embedruntimes directory
+
+	# Copy stuff in the embedruntimes directory
 	my $embedDirRoot = "$buildsroot/embedruntimes";
-	my $embedDirDestination = "$embedDirRoot/osx";
-	my $embedDirSource64 = "$embedDirRoot/osx-tmp-x86_64";
+	my $embedDirSourceX64 = "$embedDirRoot/osx-tmp-x86_64";
+	my $embedDirSourceARM64 = "$embedDirRoot/osx-tmp-arm64";
 
-	system("mkdir -p $embedDirDestination");
-
-	if (!(-d $embedDirSource64))
-	{
-		die("Expected source directory not found : $embedDirSource64\n");
-	}
-
-	for my $file ('libmonobdwgc-2.0.dylib','libmonosgen-2.0.dylib','libMonoPosixHelper.dylib')
-	{
-		print(">>> cp $embedDirSource64/$file $embedDirDestination/$file\n\n");
-		system ('cp', "$embedDirSource64/$file", "$embedDirDestination/$file");
-	}
-
-	if (not $buildMachine)
-	{
-		print(">>> Doing non-build machine stuff...\n");
-		for my $file ('libmonobdwgc-2.0.dylib','libmonosgen-2.0.dylib','libMonoPosixHelper.dylib')
-		{
-			print(">>> Removing $embedDirDestination/$file.dSYM\n");
-			rmtree ("$embedDirDestination/$file.dSYM");
-			print(">>> 'dsymutil $embedDirDestination/$file\n");
-			system ('dsymutil', "$embedDirDestination/$file") eq 0 or warn ("Failed creating $embedDirDestination/$file.dSYM");
-		}
-
-		print(">>> Done with non-build machine stuff\n");
-	}
+	CopyEmbedRuntimeBinaries($embedDirSourceX64, "$embedDirRoot/osx");
+	CopyEmbedRuntimeBinaries($embedDirSourceARM64, "$embedDirRoot/osx-arm64");
 
 	# Merge stuff in the monodistribution directory
 	my $distDirRoot = "$buildsroot/monodistribution";
 	my $distDirDestinationBin = "$buildsroot/monodistribution/bin";
 	my $distDirDestinationLib = "$buildsroot/monodistribution/lib";
-	my $distDirSourceBin64 = "$distDirRoot/bin-osx-tmp-x86_64";
+	my $distDirSourceBinX64 = "$distDirRoot/bin-osx-tmp-x86_64";
+	my $distDirSourceBinARM64 = "$distDirRoot/bin-osx-tmp-arm64";
 
 	# Should always exist because build_all would have put stuff in it, but in some situations
 	# depending on the options it may not.  So create it if it does not exist
@@ -117,27 +98,79 @@ if ($artifact)
 		system("mkdir -p $distDirDestinationLib");
 	}
 
-	if (!(-d $distDirSourceBin64))
+	if (!(-d $distDirSourceBinX64))
 	{
-		die("Expected source directory not found : $distDirSourceBin64\n");
+		die("Expected source directory not found : $distDirSourceBinX64\n");
 	}
 
-	for my $file ('mono','pedump')
+	if (!(-d $distDirSourceBinARM64))
 	{
-		system ('mv', "$distDirSourceBin64/$file", "$distDirDestinationBin/$file");
+		die("Expected source directory not found : $distDirSourceBinARM64\n");
+	}
+
+	for my $file ('mono')
+	{
+		MergeIntoFatBinary("$distDirSourceBinX64/$file", "$distDirSourceBinARM64/$file", "$distDirDestinationBin/$file");
+	}
+
+	for my $file ('pedump')
+	{
+		# pedump doens't get cross-compiled
+		system ('mv', "$distDirSourceBinX64/$file", "$distDirDestinationBin/$file") eq 0 or die ("Failed to move '$distDirSourceBinX64/$file' to '$distDirDestinationBin/$file'.");
 	}
 
 	for my $file ('libMonoPosixHelper.dylib')
 	{
-		print(">>> cp $embedDirSource64/$file $distDirDestinationLib/$file\n\n");
-		system ('cp', "$embedDirSource64/$file", "$distDirDestinationLib/$file");
+		MergeIntoFatBinary("$embedDirSourceX64/$file", "$embedDirSourceARM64/$file", "$distDirDestinationLib/$file");
 	}
 
 	if ($buildMachine)
 	{
 		print(">>> Clean up temporary arch specific build directories\n");
 
-		rmtree("$distDirSourceBin64");
-		rmtree("$embedDirSource64");
+		rmtree("$distDirSourceBinX64");
+		rmtree("$distDirSourceBinARM64");
+		rmtree("$embedDirSourceX64");
+		rmtree("$embedDirSourceARM64");
 	}
+}
+
+sub CopyEmbedRuntimeBinaries
+{
+	my ($embedDirSource, $embedDirDestination) = @_;
+
+	system("mkdir -p $embedDirDestination");
+
+	if (!(-d $embedDirSource))
+	{
+		die("Expected source directory not found : $embedDirSource\n");
+	}
+
+	for my $file ('libmonobdwgc-2.0.dylib','libmonosgen-2.0.dylib','libMonoPosixHelper.dylib')
+	{
+		print(">>> cp $embedDirSource/$file $embedDirDestination/$file\n\n");
+		system('cp', "$embedDirSource/$file", "$embedDirDestination/$file") eq 0 or die("Failed to copy '$embedDirSource/$file' to '$embedDirDestination/$file'.");
+	}
+
+	if (not $buildMachine)
+	{
+		print(">>> Doing non-build machine stuff...\n");
+		for my $file ('libmonobdwgc-2.0.dylib','libmonosgen-2.0.dylib','libMonoPosixHelper.dylib')
+		{
+			print(">>> Removing $embedDirDestination/$file.dSYM\n");
+			rmtree("$embedDirDestination/$file.dSYM");
+			print(">>> 'dsymutil $embedDirDestination/$file\n");
+			system('dsymutil', "$embedDirDestination/$file") eq 0 or warn("Failed creating $embedDirDestination/$file.dSYM");
+		}
+
+		print(">>> Done with non-build machine stuff\n");
+	}
+}
+
+sub MergeIntoFatBinary
+{
+	my ($binary1, $binary2, $binaryOutput) = @_;
+
+	print(">>> Merging '$binary1' and '$binary2' into '$binaryOutput'\n\n");
+	system('lipo', "$binary1", "$binary2", "-create", "-output", "$binaryOutput") eq 0 or die("Failed to run lipo!");
 }

--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -34,6 +34,7 @@ system(
 	"--build=$build",
 	"--clean=$clean",
 	"--mcsonly=$mcsOnly",
+	"--targetarch=x86_64",
 	"--skipmonomake=$skipMonoMake",
 	"--artifact=1",
 	"--artifactscommon=1",

--- a/libgc/gcj_mlc.c
+++ b/libgc/gcj_mlc.c
@@ -50,6 +50,8 @@ int GC_gcj_debug_kind;	/* The kind of objects that is always marked 	*/
 ptr_t * GC_gcjobjfreelist;
 ptr_t * GC_gcjdebugobjfreelist;
 
+void GC_start_debugging();
+
 /* Caller does not hold allocation lock. */
 void GC_init_gcj_malloc(int mp_index, void * /* really GC_mark_proc */mp)
 {

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -36,6 +36,7 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 
 	size = 256;
 	code = start = mono_global_codeman_reserve (size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	arm_movx (code, ARMREG_IP0, ARMREG_R0);
 	ctx_reg = ARMREG_IP0;
@@ -85,6 +86,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 
 	size = 512;
 	start = code = mono_global_codeman_reserve (size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* Compute stack frame size and offsets */
 	offset = 0;
@@ -171,6 +173,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	int i, offset, gregs_offset, fregs_offset, frame_size, num_fregs;
 
 	code = start = mono_global_codeman_reserve (size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* We are being called by JITted code, the exception object/type token is in R0 */
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -56,6 +56,10 @@ static gpointer bp_trampoline;
 
 static gboolean ios_abi;
 
+#if defined(__APPLE__)
+__thread jit_protect_mode arm_current_jit_protect_mode = JPM_NONE;
+#endif
+
 static __attribute__ ((__warn_unused_result__)) guint8* emit_load_regset (guint8 *code, guint64 regs, int basereg, int offset);
 
 const char*
@@ -99,6 +103,8 @@ static gpointer
 get_delegate_invoke_impl (gboolean has_target, gboolean param_count, guint32 *code_size)
 {
 	guint8 *code, *start;
+
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	if (has_target) {
 		start = code = mono_global_codeman_reserve (12);
@@ -5009,6 +5015,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 	else
 		buf = mono_domain_code_reserve (domain, buf_len);
 	code = buf;
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/*
 	 * We are called by JITted code, which passes in the IMT argument in

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -248,7 +248,7 @@ mono_arch_init (void)
 
 	mono_arm_gsharedvt_init ();
 
-#if defined(TARGET_IOS)
+#if defined(TARGET_IOS) || defined(TARGET_OSX)
 	ios_abi = TRUE;
 #endif
 }
@@ -757,7 +757,7 @@ mono_arm_emit_aotconst (gpointer ji, guint8 *code, guint8 *code_start, int dreg,
 gboolean
 mono_arch_have_fast_tls (void)
 {
-#ifdef TARGET_IOS
+#if defined(TARGET_IOS) || defined(TARGET_OSX)
 	return FALSE;
 #else
 	return TRUE;

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -154,7 +154,7 @@ typedef struct {
 #define MONO_ARCH_HAVE_OPCODE_NEEDS_EMULATION 1
 #define MONO_ARCH_HAVE_DECOMPOSE_LONG_OPTS 1
 
-#ifdef TARGET_IOS
+#if defined(TARGET_IOS) || defined(TARGET_OSX)
 
 #define MONO_ARCH_REDZONE_SIZE 128
 
@@ -164,7 +164,7 @@ typedef struct {
 
 #endif
 
-#if defined(TARGET_APPLETVOS) || defined(TARGET_IOS)
+#if defined(TARGET_IOS) || defined(TARGET_APPLETV) || defined(TARGET_OSX)
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1
 #endif
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2173,6 +2173,8 @@ lookup_start:
 gpointer
 mono_jit_compile_method (MonoMethod *method, MonoError *error)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	gpointer code;
 
 	code = mono_jit_compile_method_with_opt (method, mono_get_optimizations_for_method (method, default_opt), FALSE, error);
@@ -2804,6 +2806,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		if (!is_ok (error))
 			return NULL;
 	} else {
+		MONO_SCOPE_ENABLE_JIT_EXEC();
 		runtime_invoke = (MonoObject *(*)(MonoObject *, void **, MonoObject **, void *))info->runtime_invoke;
 
 		result = runtime_invoke ((MonoObject *)obj, params, exc, info->compiled_method);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2223,6 +2223,8 @@ mono_codegen (MonoCompile *cfg)
 	MonoDomain *code_domain;
 	guint unwindlen = 0;
 
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	if (mono_using_xdebug)
 		/*
 		 * Recent gdb versions have trouble processing symbol files containing
@@ -3096,6 +3098,8 @@ init_backend (MonoBackend *backend)
 MonoCompile*
 mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFlags flags, int parts, int aot_method_index)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	MonoMethodHeader *header;
 	MonoMethodSignature *sig;
 	MonoError err;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2886,4 +2886,66 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 MonoGenericContext
 mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_info);
 
+#if defined(__APPLE__) && defined(__arm64__)
+
+typedef enum {
+	JPM_NONE,
+	JPM_ENABLED,
+	JPM_DISABLED,
+} jit_protect_mode;
+
+extern __thread jit_protect_mode arm_current_jit_protect_mode;
+
+static void mono_arm_jit_write_protect_enable()
+{
+	if (__builtin_available(macOS 11, *)) {
+		if (arm_current_jit_protect_mode != JPM_ENABLED) {
+			pthread_jit_write_protect_np(1);
+			arm_current_jit_protect_mode = JPM_ENABLED;
+		}
+	}
+}
+
+static void mono_arm_jit_write_protect_disable()
+{
+	if (__builtin_available(macOS 11, *)) {
+		if (arm_current_jit_protect_mode != JPM_DISABLED) {
+			pthread_jit_write_protect_np(0);
+			arm_current_jit_protect_mode = JPM_DISABLED;
+		}
+	}
+}
+
+#define MONO_SCOPE_ENABLE_JIT_WRITE()					\
+	__attribute__((unused, cleanup(mono_arm_restore_jit_protect_mode))) \
+	jit_protect_mode scope_restrict_mode = arm_current_jit_protect_mode; \
+        mono_arm_jit_write_protect_disable();					\
+
+#define MONO_SCOPE_ENABLE_JIT_EXEC()					\
+	__attribute__((unused, cleanup(mono_arm_restore_jit_protect_mode))) \
+	jit_protect_mode scope_restrict_mode = arm_current_jit_protect_mode; \
+	mono_arm_jit_write_protect_enable();				\
+
+static void mono_arm_restore_jit_protect_mode(jit_protect_mode* previous_jit_protect_mode)
+{
+	if (*previous_jit_protect_mode == arm_current_jit_protect_mode)
+		return;
+
+	switch (*previous_jit_protect_mode)
+	{
+	case JPM_ENABLED:
+		mono_arm_jit_write_protect_enable();
+		break;
+	case JPM_DISABLED:
+	case JPM_NONE:
+	default:
+		mono_arm_jit_write_protect_disable();
+	}
+}
+
+#else
+#define MONO_SCOPE_ENABLE_JIT_WRITE()
+#define MONO_SCOPE_ENABLE_JIT_EXEC()
+#endif
+
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2886,65 +2886,11 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 MonoGenericContext
 mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_info);
 
-#if defined(__APPLE__) && defined(__arm64__)
-
-typedef enum {
-	JPM_NONE,
-	JPM_ENABLED,
-	JPM_DISABLED,
-} jit_protect_mode;
-
-extern __thread jit_protect_mode arm_current_jit_protect_mode;
-
-static void mono_arm_jit_write_protect_enable()
-{
-	if (__builtin_available(macOS 11, *)) {
-		if (arm_current_jit_protect_mode != JPM_ENABLED) {
-			pthread_jit_write_protect_np(1);
-			arm_current_jit_protect_mode = JPM_ENABLED;
-		}
-	}
-}
-
-static void mono_arm_jit_write_protect_disable()
-{
-	if (__builtin_available(macOS 11, *)) {
-		if (arm_current_jit_protect_mode != JPM_DISABLED) {
-			pthread_jit_write_protect_np(0);
-			arm_current_jit_protect_mode = JPM_DISABLED;
-		}
-	}
-}
-
-#define MONO_SCOPE_ENABLE_JIT_WRITE()					\
-	__attribute__((unused, cleanup(mono_arm_restore_jit_protect_mode))) \
-	jit_protect_mode scope_restrict_mode = arm_current_jit_protect_mode; \
-        mono_arm_jit_write_protect_disable();					\
-
-#define MONO_SCOPE_ENABLE_JIT_EXEC()					\
-	__attribute__((unused, cleanup(mono_arm_restore_jit_protect_mode))) \
-	jit_protect_mode scope_restrict_mode = arm_current_jit_protect_mode; \
-	mono_arm_jit_write_protect_enable();				\
-
-static void mono_arm_restore_jit_protect_mode(jit_protect_mode* previous_jit_protect_mode)
-{
-	if (*previous_jit_protect_mode == arm_current_jit_protect_mode)
-		return;
-
-	switch (*previous_jit_protect_mode)
-	{
-	case JPM_ENABLED:
-		mono_arm_jit_write_protect_enable();
-		break;
-	case JPM_DISABLED:
-	case JPM_NONE:
-	default:
-		mono_arm_jit_write_protect_disable();
-	}
-}
-
-#else
+#ifndef MONO_SCOPE_ENABLE_JIT_WRITE
 #define MONO_SCOPE_ENABLE_JIT_WRITE()
+#endif
+
+#ifndef MONO_SCOPE_ENABLE_JIT_EXEC
 #define MONO_SCOPE_ENABLE_JIT_EXEC()
 #endif
 

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -32,6 +32,8 @@
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	mono_arm_patch (code_ptr - 4, addr, MONO_R_ARM64_BL);
 	mono_arch_flush_icache (code_ptr - 4, 4);
 }
@@ -113,6 +115,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 
 	buf_len = 768;
 	buf = code = mono_global_codeman_reserve (buf_len);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/*
 	 * We are getting called by a specific trampoline, ip1 contains the trampoline argument.
@@ -328,6 +331,7 @@ mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_ty
 	 * Pass the argument in ip1, clobbering ip0.
 	 */
 	tramp = mono_get_trampoline_code (tramp_type);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	buf = code = mono_global_codeman_reserve (buf_len);
 
@@ -352,6 +356,8 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	MonoDomain *domain = mono_domain_get ();
 
 	start = code = mono_domain_code_reserve (domain, size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_addx_imm (code, ARMREG_R0, ARMREG_R0, sizeof (MonoObject));
 	arm_brx (code, ARMREG_IP0);
@@ -369,6 +375,8 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	MonoDomain *domain = mono_domain_get ();
 
 	start = code = mono_domain_code_reserve (domain, buf_len);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	code = mono_arm_emit_imm64 (code, MONO_ARCH_RGCTX_REG, (guint64)arg);
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_brx (code, ARMREG_IP0);
@@ -407,6 +415,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 
 	buf_size = 64 + 16 * depth;
 	code = buf = mono_global_codeman_reserve (buf_size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	rgctx_null_jumps = g_malloc0 (sizeof (guint8*) * (depth + 2));
 	njumps = 0;
@@ -493,6 +502,7 @@ mono_arch_create_general_rgctx_lazy_fetch_trampoline (MonoTrampInfo **info, gboo
 	tramp_size = 32;
 
 	code = buf = mono_global_codeman_reserve (tramp_size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	mono_add_unwind_op_def_cfa (unwind_ops, code, buf, ARMREG_SP, 0);
 
@@ -531,6 +541,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 	MonoJumpInfo *ji = NULL;
 
 	code = buf = mono_global_codeman_reserve (tramp_size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* Compute stack frame size and offsets */
 	offset = 0;
@@ -630,6 +641,8 @@ mono_arch_get_enter_icall_trampoline (MonoTrampInfo **info)
 
 	buf_len = 512 + 1024;
 	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
+
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* save FP and LR */
 	framesize += 2 * sizeof (mgreg_t);

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -518,8 +518,6 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				   mgreg_t **save_locations, int save_locations_len,
 				   guint8 **out_cfa)
 {
-	MONO_SCOPE_ENABLE_JIT_WRITE();
-
 	Loc locations [NUM_HW_REGS];
 	guint8 reg_saved [NUM_HW_REGS];
 	int pos, reg, hwreg, cfa_reg = -1, cfa_offset = 0, offset;

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -518,6 +518,8 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				   mgreg_t **save_locations, int save_locations_len,
 				   guint8 **out_cfa)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	Loc locations [NUM_HW_REGS];
 	guint8 reg_saved [NUM_HW_REGS];
 	int pos, reg, hwreg, cfa_reg = -1, cfa_offset = 0, offset;

--- a/mono/utils/mono-codeman.c
+++ b/mono/utils/mono-codeman.c
@@ -57,7 +57,7 @@ static MonoCodeManagerCallbacks code_manager_callbacks;
 #define MAX_WASTAGE 32
 #define MIN_BSIZE 32
 
-#ifdef __x86_64__
+#if defined(__x86_64__) && !defined(__APPLE__)
 #define ARCH_MAP_FLAGS MONO_MMAP_32BIT
 #else
 #define ARCH_MAP_FLAGS 0

--- a/mono/utils/mono-threads-mach-helper.c
+++ b/mono/utils/mono-threads-mach-helper.c
@@ -57,8 +57,13 @@ mono_dead_letter_dealloc (id self, SEL _cmd)
 {
 	struct objc_super super;
 	super.receiver = self;
+#if !defined(__cplusplus) && !__OBJC2__
 	super.class = nsobject;
-	objc_msgSendSuper (&super, dealloc);
+#else
+	super.super_class = nsobject;
+#endif
+	void (*objc_msgSendSuper_op)(struct objc_super *, SEL) = (void (*)(struct objc_super *, SEL)) objc_msgSendSuper;
+	objc_msgSendSuper_op (&super, dealloc);
 
 	mono_thread_info_detach ();
 }
@@ -75,19 +80,20 @@ mono_threads_install_dead_letter (void)
 	 * It doesn't hurt on other architectures either, so no need to #ifdef it only for ARM64.
 	 */
 
+	id (*id_objc_msgSend)(id, SEL) = (id (*)(id, SEL)) objc_msgSend;
 	id (*id_objc_msgSend_id)(id, SEL, id) = (id (*)(id, SEL, id)) objc_msgSend;
 	void (*objc_msgSend_id_id)(id, SEL, id, id) = (void (*)(id, SEL, id, id)) objc_msgSend;
 
-	cur = objc_msgSend ((id)nsthread, currentThread);
+	cur = id_objc_msgSend ((id)nsthread, currentThread);
 	if (!cur)
 		return;
-	dict = objc_msgSend (cur, threadDictionary);
+	dict = id_objc_msgSend (cur, threadDictionary);
 	if (dict && id_objc_msgSend_id (dict, objectForKey, mono_dead_letter_key) == nil) {
-		id value = objc_msgSend (objc_msgSend ((id)mono_dead_letter_class, alloc), init);
+		id value = id_objc_msgSend (id_objc_msgSend ((id)mono_dead_letter_class, alloc), init);
 
 		objc_msgSend_id_id (dict, setObjectForKey, value, mono_dead_letter_key);
 
-		objc_msgSend (value, release);
+		id_objc_msgSend (value, release);
 	}
 }
 
@@ -119,13 +125,15 @@ mono_threads_init_dead_letter (void)
 	class_addMethod (mono_dead_letter_class, dealloc, (IMP)mono_dead_letter_dealloc, "v@:");
 	objc_registerClassPair (mono_dead_letter_class);
 
+	id (*id_objc_msgSend)(id, SEL) = (id (*)(id, SEL)) objc_msgSend;
+
 	// create the dict key
-	pool = objc_msgSend (objc_msgSend (nsautoreleasepool, alloc), init);
+	pool = id_objc_msgSend (id_objc_msgSend (nsautoreleasepool, alloc), init);
 
 	id (*objc_msgSend_char)(id, SEL, const char*) = (id (*)(id, SEL, const char*)) objc_msgSend;
 	mono_dead_letter_key = objc_msgSend_char (nsstring, stringWithUTF8String, "mono-dead-letter");
 
-	objc_msgSend (mono_dead_letter_key, retain);
-	objc_msgSend (pool, release);
+	id_objc_msgSend (mono_dead_letter_key, retain);
+	id_objc_msgSend (pool, release);
 }
 #endif

--- a/support/sys-uio.c
+++ b/support/sys-uio.c
@@ -82,7 +82,7 @@ Mono_Posix_Syscall_writev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcn
 }
 #endif /* def HAVE_WRITEV */
 
-#ifdef HAVE_PREADV
+#if defined(HAVE_PREADV) && !defined(__APPLE__) // Configure incorrectly detects that this function is available on macOS SDK 11.0 (it is not)
 gint64
 Mono_Posix_Syscall_preadv (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcnt, gint64 off)
 {
@@ -100,9 +100,9 @@ Mono_Posix_Syscall_preadv (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcn
 	free (v);
 	return res;
 }
-#endif /* def HAVE_PREADV */
+#endif /* defined(HAVE_PREADV) && !defined(__APPLE__) */
 
-#ifdef HAVE_PWRITEV
+#if defined(HAVE_PWRITEV) && !defined(__APPLE__) // Configure incorrectly detects that this function is available on macOS SDK 11.0 (it is not)
 gint64
 Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovcnt, gint64 off)
 {
@@ -120,7 +120,7 @@ Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovc
 	free (v);
 	return res;
 }
-#endif /* def HAVE_PWRITEV */
+#endif /* defined(HAVE_PWRITEV) && !defined(__APPLE__) */
 
 
 /*


### PR DESCRIPTION
The Mono runtime changes were implemented & tested by Apple on Apple silicon hardware. I implemented the changes in our build scripts.

The biggest change in here is how JIT operates. On Apple silicon Macs, you're not allowed to both execute and write to write/execute pages at the same time. The way I understand it is that each thread has a state whether it can write or execute instructions in these pages. It is controlled using `pthread_jit_write_protect_np` function. Before the JIT can write to those pages, it needs to change the thread state to "non-protected". Before executing the JITed code, the thread state must be changed to "write-protected". This is handled using the new macros in `mono/mini.h`. They were implemented inline for performance reasons.

Other changes include adding ARM64 target to configure script and fixing build on the new SDK.

Please note that CI might fail - up until today I couldn't push the changes and could only run stuff locally (where it worked). I'm working on ironing out all the issues as we speak.

EDIT: CI is now green and we're producing all macOS binaries properly:

```
tautvydaszilys@Tautvydass-MacBook-Pro builds % file embedruntimes/osx/libMonoPosixHelper.dylib 
embedruntimes/osx/libMonoPosixHelper.dylib: Mach-O 64-bit dynamically linked shared library x86_64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file embedruntimes/osx/libmonobdwgc-2.0.dylib 
embedruntimes/osx/libmonobdwgc-2.0.dylib: Mach-O 64-bit dynamically linked shared library x86_64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file embedruntimes/osx/libmonosgen-2.0.dylib 
embedruntimes/osx/libmonosgen-2.0.dylib: Mach-O 64-bit dynamically linked shared library x86_64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file embedruntimes/osx-arm64/libMonoPosixHelper.dylib 
embedruntimes/osx-arm64/libMonoPosixHelper.dylib: Mach-O 64-bit dynamically linked shared library arm64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file embedruntimes/osx-arm64/libmonobdwgc-2.0.dylib 
embedruntimes/osx-arm64/libmonobdwgc-2.0.dylib: Mach-O 64-bit dynamically linked shared library arm64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file embedruntimes/osx-arm64/libmonosgen-2.0.dylib 
embedruntimes/osx-arm64/libmonosgen-2.0.dylib: Mach-O 64-bit dynamically linked shared library arm64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file monodistribution/bin/mono
monodistribution/bin/mono: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
monodistribution/bin/mono (for architecture x86_64):	Mach-O 64-bit executable x86_64
monodistribution/bin/mono (for architecture arm64):	Mach-O 64-bit executable arm64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file monodistribution/bin/pedump 
monodistribution/bin/pedump: Mach-O 64-bit executable x86_64
tautvydaszilys@Tautvydass-MacBook-Pro builds % file monodistribution/lib/libMonoPosixHelper.dylib 
monodistribution/lib/libMonoPosixHelper.dylib: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64]
monodistribution/lib/libMonoPosixHelper.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
monodistribution/lib/libMonoPosixHelper.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64
```