### PR TITLE
Exposing functions: mono_custom_attrs_construct_by_type and mono_unit…

### DIFF
--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1215,7 +1215,7 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	HANDLE_FUNCTION_RETURN_OBJ (obj);
 }
 
-static MonoArray*
+MonoArray*
 mono_custom_attrs_construct_by_type (MonoCustomAttrInfo *cinfo, MonoClass *attr_klass, MonoError *error)
 {
 	MonoArray *result;

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -90,6 +90,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoCustomAttrInfo* mono_reflection_get_custom_attrs_info (MonoObject *obj);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoArray*  mono_custom_attrs_construct (MonoCustomAttrInfo *cinfo);
+MONO_API MonoArray* mono_custom_attrs_construct_by_type (MonoCustomAttrInfo *cinfo, MonoClass *attr_klass, MonoError *error);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoCustomAttrInfo* mono_custom_attrs_from_index    (MonoImage *image, uint32_t idx);
 MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -870,6 +870,11 @@ MonoException* mono_unity_exception_get_marshal_directive(const char* msg)
 	return mono_exception_from_name_msg(mono_get_corlib(), "System.Runtime.InteropServices", "MarshalDirectiveException", msg);
 }
 
+MonoException* mono_unity_error_convert_to_exception (MonoError *error)
+{
+	return mono_error_convert_to_exception (error);
+}
+
 //defaults
 
 MonoClass* mono_unity_defaults_get_int_class()

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -137,6 +137,7 @@ MonoObject* mono_unity_exception_get_inner_exception(MonoException *exc);
 MonoArray* mono_unity_exception_get_trace_ips(MonoException *exc);
 void mono_unity_exception_set_trace_ips(MonoException *exc, MonoArray *ips);
 MonoException* mono_unity_exception_get_marshal_directive(const char* msg);
+MONO_API MonoException* mono_unity_error_convert_to_exception(MonoError *error);
 
 //defaults
 MonoClass* mono_unity_defaults_get_int_class();


### PR DESCRIPTION
…y_error_convert_to_exception

* mono_custom_attrs_construct_by_type allows unity to have a chance at handling the error if one arises instead of fatally asserting
* mono_unity_error_convert_to_exception allows unity to take the provided MonoError and fetch the MonoException object within to log into the editor as the exception that was thrown.

Release note: Fixed crash that would occur when an exception was thrown during the initialization of a custom attribute.

This change has associated unity changes in order to fix (case 1255935)