### PR TITLE
Fix TLS offset lookup on macOS ARM64

### DIFF
--- a/mono/utils/mach-support-arm64.c
+++ b/mono/utils/mach-support-arm64.c
@@ -29,9 +29,13 @@
 
 
 static const int known_tls_offsets[] = {
+#if defined(TARGET_OSX)
+	0xE0, /* macOS 11.0 on Apple silicon */
+#else
 	0x48, /*Found on iOS 6 */
 	0xA4,
 	0xA8,
+#endif // defined(HOST_OSX)
 };
 
 #define TLS_PROBE_COUNT (sizeof (known_tls_offsets) / sizeof (int))


### PR DESCRIPTION
Currently, when running Mono on macOS ARM64, this message appears in the log:

`Found new TLS offset at 224
`

Turns out, Mono hardcodes a byte offset into internal pthread TLS data structure in order to be able to retrieve TLS values from within other threads. This change merely updates the hardcoded offset on macOS to match the reality. This change affects _only_ macOS ARM64 builds.

This whole code has been removed from upstream, so when we merge, we don't need to reapply this change.