### PR TITLE
X509ChainImplUnityTls reports status now

### DIFF
--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -131,6 +131,12 @@ namespace Mono.Unity
 			}
 
 			errors = UnityTlsConversions.VerifyResultToPolicyErrror(result);
+			// There should be a status per certificate, but once again we're following closely the BTLS implementation
+			// https://github.com/mono/mono/blob/1553889bc54f87060158febca7e6b8b9910975f8/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs#L180
+			// which also provides only a single status for the entire chain.
+			// It is notoriously tricky to implement in OpenSSL to get a status for all invididual certificates without finishing the handshake in the process.
+			// This is partially the reason why unitytls_x509verify_X doesn't expose it (TODO!) and likely the reason Mono's BTLS impl ignores this.
+			unityTlsChainImpl?.AddStatus(UnityTlsConversions.VerifyResultToChainStatus(result));
 			return result == UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_SUCCESS && 
 					errorState.code == UnityTls.unitytls_error_code.UNITYTLS_SUCCESS;
 		}

--- a/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
@@ -1,6 +1,7 @@
 #if SECURITY_DEP
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Security;
 using System.Security.Cryptography;
@@ -12,9 +13,10 @@ namespace Mono.Unity
 	// Follows mostly X509ChainImplBtls
 	class X509ChainImplUnityTls : X509ChainImpl
 	{
-		X509ChainElementCollection elements;
-		UnityTls.unitytls_x509list_ref nativeCertificateChain;
-		X509ChainPolicy policy = new X509ChainPolicy ();
+		private X509ChainElementCollection elements;
+		private UnityTls.unitytls_x509list_ref nativeCertificateChain;
+		private X509ChainPolicy policy = new X509ChainPolicy ();
+		private List<X509ChainStatus> chainStatusList;
 
 		internal X509ChainImplUnityTls (UnityTls.unitytls_x509list_ref nativeCertificateChain)
 		{
@@ -64,8 +66,13 @@ namespace Mono.Unity
 			set { policy = value; }
 		}
 
-		public override X509ChainStatus[] ChainStatus {
-			get { throw new NotImplementedException (); }
+		public override X509ChainStatus[] ChainStatus => chainStatusList?.ToArray() ?? new X509ChainStatus[0];
+
+		public void AddStatus (X509ChainStatusFlags errorCode)
+		{
+			if (chainStatusList == null)
+				chainStatusList = new List<X509ChainStatus>();
+			chainStatusList.Add (new X509ChainStatus(errorCode));
 		}
 
 		public override bool Build (X509Certificate2 certificate)


### PR DESCRIPTION
Fixes Fogbugz ticket 1261388.
Impl sticks close to current Mono Btls implementation on _master_ - the implementation on our fork has the same issues as prior to this fix and throws `NotImplementedException`. For compatibility with upcoming mono update I used a method(-name) that is going to be abstract in the `X509ChainImpl` baseclass :).

Needs to be backported to 2020.1 (according to fogbugz ticket prior to that we didn't have that issue - I vaguely remember that we didn't backport the custom unitytls certificate impl)

As always with these, I extended the playmode tests in Unity to include this:
https://github.cds.internal.unity3d.com/unity/unity/commit/47271815fbefdb7f1520e423fe70db8767781286
(this one sadly needs manual activation and doesn't run on CI right now because it accesses external servers)