### PR TITLE
The fix for 1256569 broke a test. Partial revert

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.WinRT.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.WinRT.cs
@@ -359,6 +359,17 @@ namespace System
 				// EnumDynamicTimeZoneInformation() might not be available.
 			}
 
+			// If we are in this function we know that TimeZoneKey is null and need to use the fallback
+			// Adding Local here will cause a stack overflow
+			if (result.Count == 0)
+			{
+				var l = GetLocalTimeZoneInfoWinRTFallback();
+				if (Interlocked.CompareExchange (ref local, l, null) != null)
+					l = local;
+
+				result.Add(l);
+			}
+
 			return result;
 		}
 	}

--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -787,10 +787,6 @@ namespace System
 			if (systemTimeZones == null) {
 				var tz = new List<TimeZoneInfo> ();
 				GetSystemTimeZonesCore (tz);
-				// Don't want to return an empty list if we can help it
-				// but we don't want to stack overflow via a CreateLocal loop
-				if (tz.Count == 0 && local != null)
-					tz.Add(Local);
 				Interlocked.CompareExchange (ref systemTimeZones, new ReadOnlyCollection<TimeZoneInfo> (tz), null);
 			}
 


### PR DESCRIPTION
Reverting most of that change and breaking the CreateLocal -> WinRTFallback -> CreateLocal loop by calling GetLocalTimeZoneInfoWinRTFallback instead of accessing Local from within FindSystemTimeZoneByIdWinRTFallback fixes both issues.

Partial revert of: https://github.com/Unity-Technologies/mono/pull/1310/files