### PR TITLE
Repackage stevedore artifact to remove builds in folder structure

### DIFF
--- a/external/buildscripts/Build.bee.cs
+++ b/external/buildscripts/Build.bee.cs
@@ -49,7 +49,7 @@ namespace BuildProgram
 		{
 			Artifacts.Add("MonoBleedingEdge",
 				new Tuple<string, string>(
-					"MonoBleedingEdge/fd0d97a7a35_5d627f842afebea942027a7fe8a590effb76deaf44736482b8bbcfae58316d42.7z",
+					"MonoBleedingEdge/f6eb9e15148_2a5566bb437c65d9af40d5f0f7fa4c2cc0f6e6efa243ae673bde2f5b29b03f08.7z",
 					"unity-internal"));
 
 			Artifacts.Add("reference-assemblies",

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -329,12 +329,7 @@ if ($build)
 		{
 			print(">>> External mono found at : $existingExternalMono\n");
 
-			if (-d "$existingExternalMono/builds")
-			{
-				print(">>> Mono found at at : $existingExternalMono/builds\n");
-			}
-
-			$existingMonoRootPath = "$existingExternalMono/builds/monodistribution";
+			$existingMonoRootPath = "$existingExternalMono/monodistribution";
 		}
 		else
 		{

--- a/external/buildscripts/collect_allbuilds.pl
+++ b/external/buildscripts/collect_allbuilds.pl
@@ -53,12 +53,6 @@ chdir("collectedbuilds");
 
 rmove('versions-aggregated.txt', 'versions.txt');
 
-open(MYFILE,">built_by_teamcity.txt");
-print MYFILE "These builds were created by teamcity from svn revision $ENV{BUILD_VCS_NUMBER}\n";
-print MYFILE "TC projectname was: $ENV{TEAMCITY_PROJECT_NAME}\n";
-print MYFILE "TC buildconfigname was: $ENV{TEAMCITY_BUILDCONF_NAME}\n";
-close(MYFILE);
-
 my $externalBuildDeps = "$monoroot/external/buildscripts/artifacts/Stevedore";
 my $externalzip = "";
 if($^O eq "linux")
@@ -77,12 +71,11 @@ if($^O eq "linux" || $^O eq 'darwin')
 {
 	rmtree("../stevedore");
 	my $stevedoreMbePath = "../stevedore/MonoBleedingEdge";
-	my $stevedoreMbeBuildsPath = "../stevedore/MonoBleedingEdge/builds";
 	my $stevedoreMbe7z = "../stevedore/MonoBleedingEdge.7z";
 	my $stevedoreMbeArtifactID = "../stevedore/artifactid.txt";
 
-	system("mkdir -p $stevedoreMbeBuildsPath") eq 0 or die("failed to mkdir $stevedoreMbeBuildsPath");
-	system("cp -r * $stevedoreMbeBuildsPath/") eq 0 or die ("failed copying builds to $stevedoreMbeBuildsPath\n");
+	system("mkdir -p $stevedoreMbePath") eq 0 or die("failed to mkdir $stevedoreMbePath");
+	system("cp -r * $stevedoreMbePath/") eq 0 or die ("failed copying builds to $stevedoreMbePath\n");
 	if(-f $externalzip)
 	{
 		system("$externalzip a $stevedoreMbe7z $stevedoreMbePath/* -sdel") eq 0 or die("failed 7z up $stevedoreMbePath");


### PR DESCRIPTION
To comply with packaging rules for public stevedore repo, repackage stevedore mbe to remove builds in folder structure.
Delete Teamcity version file, it has no relevant information.
