### PR TITLE
Fixing hang that would occur when a Debugger.Break would be triggered…

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -268,6 +268,14 @@ public class Tests : TestsBase, ITest2
 
 #pragma warning restore 0414
 
+	public string BreakInField
+	{
+		get {
+			Debugger.Break ();
+			return "Foo";
+		}
+	}
+
 	public class NestedClass {
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -1671,7 +1671,7 @@ public class DebuggerTests
 		t = frame.Method.GetParameters ()[7].ParameterType;
 
 		var props = t.GetProperties ();
-		Assert.AreEqual (3, props.Length);
+		Assert.AreEqual (4, props.Length);
 		foreach (PropertyInfoMirror prop in props) {
 			ParameterInfoMirror[] indexes = prop.GetIndexParameters ();
 
@@ -4452,6 +4452,23 @@ public class DebuggerTests
 		e = step_in_await ("MoveNext", e);
 		e = step_in_await ("MoveNext", e);
 		e = step_in_await ("MoveNext", e);
+	}
+
+	[Test]
+	public void DebuggerBreakInFieldDoesNotHang () {
+		vm.EnableEvents (EventType.UserBreak);
+		Event e = run_until ("o1");
+
+		StackFrame frame = e.Thread.GetFrames () [0];
+		object val = frame.GetThis ();
+		Assert.IsTrue (val is ObjectMirror);
+		Assert.AreEqual ("Tests", (val as ObjectMirror).Type.Name);
+		ObjectMirror o = (val as ObjectMirror);
+		TypeMirror t = o.Type;
+
+		MethodMirror m = t.GetProperty ("BreakInField").GetGetMethod();
+		Value v = o.InvokeMethod (e.Thread, m, null, InvokeOptions.DisableBreakpoints);
+		AssertValue ("Foo", v);
 	}
 } // class DebuggerTests
 } // namespace

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4162,8 +4162,15 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 			keepalive_obj = ei->exc;
 			break;
 		}
-		case EVENT_KIND_USER_BREAK:
+		case EVENT_KIND_USER_BREAK: {
+			DebuggerTlsData* tls;
+			tls = (DebuggerTlsData*)mono_native_tls_get_value(debugger_tls_id);
+			g_assert(tls);
+			// We are already processing a breakpoint event
+			if (tls->disable_breakpoints)
+				return;
 			break;
+		}
 		case EVENT_KIND_USER_LOG: {
 			DebuggerEventInfo *ei = (DebuggerEventInfo *)arg;
 			buffer_add_int (&buf, ei->level);


### PR DESCRIPTION
… while we are already processing a breakpoint. (case 1254123)

Adding test for debugger hang fix to case 1254123

upstream PR: https://github.com/mono/mono/pull/20211

Release Note: Fixed hang that would occur when a `Debugger.Break` was in the accessor of a field.