### PR TITLE
Fix handling invalid Windows proxy config

### DIFF
--- a/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
+++ b/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
@@ -131,7 +131,11 @@ namespace System.Net
 				
 				string strProxyServer = (string)Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", "ProxyServer", null);
 				string strProxyOverrride = (string)Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", "ProxyOverride", null);
-				
+
+				if(strProxyServer == null) {
+					return null;
+				}
+
 				if (strProxyServer.Contains ("=")) {
 					foreach (string strEntry in strProxyServer.Split (new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
 						if (strEntry.StartsWith ("http=")) {


### PR DESCRIPTION
source: https://github.com/mono/mono/pull/12595

Re-adding whitespace to reduce diff noise and make future cherrypicks easier.

Unity original PR: https://github.com/Unity-Technologies/mono/pull/1330 via user @iRebbok

fixes case 1269569

Release Note: Invalid windows proxy configuration will no longer cause a NullReferenceException to be thrown in AutoWebProxyScriptEngine::InitializeRegistryGlobalProxy