### PR TITLE
The NetworkChange event is not supported on Windows (case 1278048)

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/NetworkChange.cs
@@ -107,6 +107,8 @@ namespace System.Net.NetworkInformation {
 			if (networkChange != null)
 				return;
 
+			if (IsWindows)
+				throw new PlatformNotSupportedException ("NetworkInformation.NetworkChange is not supported on the current platform.");
 			try {
 				networkChange = new MacNetworkChange ();
 			} catch {
@@ -115,6 +117,21 @@ namespace System.Net.NetworkInformation {
 #endif
 			}
 #endif // MONOTOUCH_WATCH
+		}
+
+		static bool IsWindows
+		{
+			get
+			{
+				PlatformID platform = Environment.OSVersion.Platform;
+				if (platform == PlatformID.Win32S ||
+					platform == PlatformID.Win32Windows ||
+					platform == PlatformID.Win32NT ||
+					platform == PlatformID.WinCE) {
+					return true;
+				}
+				return false;
+			}
 		}
 
 		static void MaybeDispose ()


### PR DESCRIPTION
Provide a proper `PlatformNotSupported` exception for the
`NetworkChange` event on Windows, as it is not currently supported.

No release notes - this was reporting internally. We will not back port this change.