### PR TITLE
Fix JIT on macOS Big Sur beta 6 when running on Apple silicon

### DIFF
--- a/external/buildscripts/Build.bee.cs
+++ b/external/buildscripts/Build.bee.cs
@@ -75,7 +75,7 @@ namespace BuildProgram
 
 			Artifacts.Add("MacBuildEnvironment",
 				new Tuple<string, string>(
-					"mac-toolchain-11_0/12.0-12A8158a_2b346a6c93e9c82250a1d88c02f24a5dea9f0bd1aa2ef44109896a44800e8c68.zip",
+					"mac-toolchain-11_0/12.2-12B5018i_351c773fb8a192039fe0f0e962314b888102b0718c734ad54f3906c0caeed1c9.zip",
 					"unity-internal"));
 
 			Artifacts.Add("mono-build-tools-extra",

--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -110,7 +110,7 @@ if ($artifact)
 
 	for my $file ('mono')
 	{
-		MergeIntoFatBinary("$distDirSourceBinX64/$file", "$distDirSourceBinARM64/$file", "$distDirDestinationBin/$file");
+		MergeIntoFatBinary("$distDirSourceBinX64/$file", "$distDirSourceBinARM64/$file", "$distDirDestinationBin/$file", 1);
 	}
 
 	for my $file ('pedump')
@@ -121,7 +121,7 @@ if ($artifact)
 
 	for my $file ('libMonoPosixHelper.dylib')
 	{
-		MergeIntoFatBinary("$embedDirSourceX64/$file", "$embedDirSourceARM64/$file", "$distDirDestinationLib/$file");
+		MergeIntoFatBinary("$embedDirSourceX64/$file", "$embedDirSourceARM64/$file", "$distDirDestinationLib/$file", 0);
 	}
 
 	if ($buildMachine)
@@ -169,8 +169,17 @@ sub CopyEmbedRuntimeBinaries
 
 sub MergeIntoFatBinary
 {
-	my ($binary1, $binary2, $binaryOutput) = @_;
+	my ($binary1, $binary2, $binaryOutput, $isExe) = @_;
 
 	print(">>> Merging '$binary1' and '$binary2' into '$binaryOutput'\n\n");
 	system('lipo', "$binary1", "$binary2", "-create", "-output", "$binaryOutput") eq 0 or die("Failed to run lipo!");
+
+	if ($isExe)
+	{
+		system("codesign", "--entitlements", $buildscriptsdir . "/entitlements.plist", "-s", "-", "$binaryOutput") eq 0 or die("Failed to codesign $binaryOutput!");
+	}
+	else
+	{
+		system("codesign", "-s", "-", "$binaryOutput") eq 0 or die("Failed to codesign $binaryOutput!");
+	}
 }

--- a/external/buildscripts/entitlements.plist
+++ b/external/buildscripts/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>
+

--- a/mono/utils/dlmalloc.c
+++ b/mono/utils/dlmalloc.c
@@ -1314,7 +1314,14 @@ extern void*     sbrk(ptrdiff_t);
 #define MAP_ANONYMOUS        MAP_ANON
 #endif /* MAP_ANON */
 #ifdef MAP_ANONYMOUS
+
+#if defined(__APPLE__) && defined(__arm64__)
+/* macOS on ARM64 requires using MAP_JIT in order to allocate executable memory. */
+#define MMAP_FLAGS           (MAP_PRIVATE|MAP_ANONYMOUS|MAP_JIT)
+#else
 #define MMAP_FLAGS           (MAP_PRIVATE|MAP_ANONYMOUS)
+#endif
+
 #define CALL_MMAP(s)         mmap(0, (s), MMAP_PROT, MMAP_FLAGS, -1, 0)
 #else /* MAP_ANONYMOUS */
 /*

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -228,6 +228,13 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 	mflags |= MAP_ANONYMOUS;
 	mflags |= MAP_PRIVATE;
 
+#if defined(__APPLE__) && defined(__arm64__)
+	/* macOS on ARM64 requires using MAP_JIT in order
+	   to allocate executable memory. */
+	if (type == MONO_MEM_ACCOUNT_CODE)
+		mflags |= MAP_JIT;
+#endif
+
 	BEGIN_CRITICAL_SECTION;
 	ptr = mmap (addr, length, prot, mflags, -1, 0);
 	if (ptr == MAP_FAILED) {


### PR DESCRIPTION
macOS Big Sur beta 6 introduced two big changes for Apple silicon:

• All binaries (executables and dylibs) must now be signed. To make this easier, Apple made it so their clang/ld automatically sign the resulting binaries as they are built;
• In order to write to executable memory, you now need to declare `com.apple.security.cs.allow-jit` entitlement, and pass `MAP_JIT` flag to `mmap` when allocating memory that will be both executable and writable. 

To fix 1), I simply updated the Mac build environment that we use to build Mono from Stevedore. There's one caveat for fat binaries: you have to sign them manually after merging thin binaries as `lipo` seems to drop the signature.

To fix 2), I changed the two places that Mono calls `mmap` to get executable memory to include `MAP_JIT` flag. I also added `external/buildscripts/entitlements.plist` file which we use when signing `mono` executable to declare the appropriate entitlements.

I'll need to backport these changes to 2020.2. This PR addresses case 1278359.

Release notes:

• Fixed macOS Standalone player built for Apple silicon architecture crashing on startup with Mono scripting backend when running on macOS Big Sur Beta 6 or later (case 1278359).
