### PR TITLE
2020.2 : Unity master fix case 1273662 

### DIFF
--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1906,6 +1906,7 @@ mono_wrapper_caches_free (MonoWrapperCaches *cache)
 	free_hash (cache->runtime_invoke_vtype_cache);
 	
 	free_hash (cache->delegate_abstract_invoke_cache);
+	free_hash (cache->delegate_bound_static_invoke_cache);
 
 	free_hash (cache->runtime_invoke_direct_cache);
 	free_hash (cache->managed_wrapper_cache);
@@ -2076,7 +2077,6 @@ mono_image_close_except_pools (MonoImage *image)
 		g_hash_table_destroy (image->name_cache);
 	}
 
-	free_hash (image->delegate_bound_static_invoke_cache);
 	free_hash (image->runtime_invoke_vcall_cache);
 	free_hash (image->ldfld_wrapper_cache);
 	free_hash (image->ldflda_wrapper_cache);

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1976,10 +1976,6 @@ mono_free_method  (MonoMethod *method)
 {
 	MONO_PROFILER_RAISE (method_free, (method));
 	
-	/* FIXME: This hack will go away when the profiler will support freeing methods */
-	if (G_UNLIKELY (mono_profiler_installed ()))
-		return;
-	
 	if (method->signature) {
 		/* 
 		 * FIXME: This causes crashes because the types inside signatures and

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -125,6 +125,7 @@ typedef struct {
 	 * indexed by SignaturePointerPair
 	 */
 	GHashTable *delegate_abstract_invoke_cache;
+	GHashTable *delegate_bound_static_invoke_cache;
 
 	/*
 	 * indexed by MonoMethod pointers
@@ -339,7 +340,6 @@ struct _MonoImage {
 	/*
 	 * indexed by SignaturePointerPair
 	 */
-	GHashTable *delegate_bound_static_invoke_cache;
 	GHashTable *native_func_wrapper_cache;
 
 	/*


### PR DESCRIPTION
case 1273662  : The issue was that the Unity editor crashed randomly due to mono_metadata_class_equal while entering the playmode. This was due to corruption in mscorlib's image table on domain reload as dynamic methods from other images were not being cleaned up.

Have cherry picked the changes from https://github.com/Unity-Technologies/mono/pull/1341