### PR TITLE
Run codesign after otool

### DIFF
--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -181,10 +181,10 @@ sub MergeIntoFatBinary
 
 	if ($isExe)
 	{
-		system("codesign", "--entitlements", $buildscriptsdir . "/entitlements.plist", "-s", "-", "$binaryOutput") eq 0 or die("Failed to codesign $binaryOutput!");
+		system("codesign", "--entitlements", $buildscriptsdir . "/entitlements.plist", "-s", "-", "-f", "$binaryOutput") eq 0 or die("Failed to codesign $binaryOutput!");
 	}
 	else
 	{
-		system("codesign", "-s", "-", "$binaryOutput") eq 0 or die("Failed to codesign $binaryOutput!");
+		system("codesign", "-s", "-", "-f", "$binaryOutput") eq 0 or die("Failed to codesign $binaryOutput!");
 	}
 }

--- a/external/buildscripts/perl_lib/Tools.pm
+++ b/external/buildscripts/perl_lib/Tools.pm
@@ -22,6 +22,9 @@ sub InstallNameTool
   system("install_name_tool -id $pathtoburnin $target") eq 0 or die("Failed running install_name_tool");
   print "running otool after:\n";
   system("otool","-L",$target);
+
+  print "running codesign on $target:\n";
+  system("codesign", "-s", "-", "-f", $target);
 }
 
 sub GitClone


### PR DESCRIPTION
My previous PR made changes to build scripts that signed universal builds after lipo-ing them together: https://github.com/Unity-Technologies/mono/pull/1346. However, when testing I forgot to check whether non-universal builds ran and turns out they didn't. Normally, the linker signs the binaries as it produces them, however, as part of our mac build scripts we run "otool" to patch dylibs and that invalidates the signature, causing ARM64 binaries to have an invalid signature and in result macOS killing the process when you try to load them.

This PR simply makes us resign those binaries after running otool. These changes are needed to fix case 1278359.

Release notes:

• Fixed macOS Standalone player built for Apple silicon architecture crashing on startup with Mono scripting backend when running on macOS Big Sur Beta 6 or later (case 1278359).