### PR TITLE
2019.4: Add option to ignore versions when loading strong named assemblies

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -98,6 +98,16 @@ static MonoAssembly *
 mono_domain_assembly_search (MonoAssemblyName *aname,
 							 gpointer user_data);
 
+
+
+static gboolean ignore_version_and_key_when_finding_assemblies_already_loaded = FALSE;
+
+void
+mono_set_ignore_version_and_key_when_finding_assemblies_already_loaded(gboolean value)
+{
+	ignore_version_and_key_when_finding_assemblies_already_loaded = value;
+}
+
 static void
 mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data);
 
@@ -2085,7 +2095,7 @@ mono_domain_assembly_search (MonoAssemblyName *aname,
 	/* If it's not a strong name, any version that has the right simple
 	 * name is good enough to satisfy the request.  .NET Framework also
 	 * ignores case differences in this case. */
-	const MonoAssemblyNameEqFlags eq_flags = strong_name ? MONO_ANAME_EQ_IGNORE_CASE :
+	const MonoAssemblyNameEqFlags eq_flags = (strong_name && !ignore_version_and_key_when_finding_assemblies_already_loaded)  ? MONO_ANAME_EQ_IGNORE_CASE :
 	(MONO_ANAME_EQ_IGNORE_PUBKEY | MONO_ANAME_EQ_IGNORE_VERSION | MONO_ANAME_EQ_IGNORE_CASE);
 
 	mono_domain_assemblies_lock (domain);

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -119,6 +119,9 @@ mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, v
 MONO_API MonoAssembly *
 mono_domain_assembly_open  (MonoDomain *domain, const char *name);
 
+MONO_API void
+mono_set_ignore_version_and_key_when_finding_assemblies_already_loaded(mono_bool value);
+
 MONO_API mono_bool
 mono_domain_finalize       (MonoDomain *domain, uint32_t timeout);
 


### PR DESCRIPTION
Add Mono API to ignore version for strong named assemblies. This is for solving #1335
Will also need changes to the Editor to toggle the option

Reintroduce 6c41f64#diff-0ff844e784e15d2542b71c85d2c0133e

Adding a option to ignore versions when resolving strong named assemblies.