### PR TITLE
After adding the concept of a pending threads join list boehm was not…

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -567,8 +567,7 @@ mono_gc_thread_detach_with_lock (MonoThreadInfo *p)
 
 	tid = mono_thread_info_get_tid (p);
 
-	if (p->runtime_thread)
-		mono_threads_add_joinable_thread ((gpointer)tid);
+	mono_threads_add_joinable_runtime_thread(p);
 
 	mono_handle_stack_free (p->handle_stack);
 	p->handle_stack = NULL;


### PR DESCRIPTION
… removing the threads from that list on detach as sgen was in sgen_client_thread_detach_with_lock. This change brings boehm in line with sgen to remove threads from the pending join list on detach to avoid waiting the full 2 seconds on runtime shutdown.

Previous change (https://github.com/Unity-Technologies/mono/pull/1343) relied on previous fix that had a sgen specific component that caused threads to be removed on detach here: https://github.com/Unity-Technologies/mono/commit/ed1884bb9b43ddd69daba52302494ad2d02bbbd9#diff-61c9ab3b5bc3dc4eb8da24ab56cc2987593537bc604d1d5717755014f95a7d23R2264

I've tested this locally and we no longer wait the full 2 second timeout before exiting with this change.

Release note:
Fixed regression where we would wait a full 2 second timeout on shutdown  (case 1295072)