### PR TITLE
JIT code enumeration + PDB info

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -27,6 +27,7 @@ typedef struct _MonoJitInfo MonoJitInfo;
 
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
 typedef void (*MonoDomainAssemblyFunc) (MonoAssembly *assembly, void* user_data);
+typedef void (*MonoJitInfoFunc)(MonoDomain *domain, MonoMethod* method, MonoJitInfo* jinfo);
 typedef void (*MonoUnityExceptionFunc) (MonoObject* exc);
 
 MONO_API MonoDomain*
@@ -109,6 +110,9 @@ mono_domain_is_unloading   (MonoDomain *domain);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoDomain *
 mono_domain_from_appdomain (MonoAppDomain *appdomain);
+
+MONO_API void
+mono_domain_jit_foreach (MonoDomain *domain, MonoJitInfoFunc func, void *user_data);
 
 MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -27,7 +27,7 @@ typedef struct _MonoJitInfo MonoJitInfo;
 
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
 typedef void (*MonoDomainAssemblyFunc) (MonoAssembly *assembly, void* user_data);
-typedef void (*MonoJitInfoFunc)(MonoDomain *domain, MonoMethod* method, MonoJitInfo* jinfo);
+typedef void (*MonoJitInfoFunc)(MonoDomain *domain, MonoMethod* method, MonoJitInfo* jinfo, void* user_data);
 typedef void (*MonoUnityExceptionFunc) (MonoObject* exc);
 
 MONO_API MonoDomain*

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -54,6 +54,7 @@ typedef struct {
 	gint32 signature;
 	guint8 guid [16];
 	gint32 age;
+	char path [];
 } CodeviewDebugDirectory;
 
 typedef struct {
@@ -63,7 +64,7 @@ typedef struct {
 } PdbStreamHeader;
 
 static gboolean
-get_pe_debug_guid (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *out_timestamp)
+get_pe_debug_guid (MonoImage *image, const char** out_path, guint8 *out_guid, gint32 *out_age, gint32 *out_timestamp)
 {
 	MonoPEDirEntry *debug_dir_entry;
 	ImageDebugDirectory *debug_dir;
@@ -82,6 +83,11 @@ get_pe_debug_guid (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *
 			memcpy (out_guid, dir->guid, 16);
 			*out_age = dir->age;
 			*out_timestamp = debug_dir->time_date_stamp;
+
+			if (out_path != NULL) {
+				*out_path = g_strdup (dir->path);
+			}
+
 			return TRUE;
 		}
 	}
@@ -109,6 +115,12 @@ create_ppdb_file (MonoImage *ppdb_image)
 	return ppdb;
 }
 
+gboolean
+mono_ppdb_get_signature(MonoImage *image, const char** out_path, guint8 *out_guid, gint32 *out_age, gint32 *out_timestamp)
+{
+	return get_pe_debug_guid (image, out_path, out_guid, out_age, out_timestamp);
+}
+
 MonoPPDBFile*
 mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 {
@@ -118,7 +130,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 	MonoImageOpenStatus status;
 	guint8 pe_guid [16];
 	gint32 pe_age;
-	gint32 pe_timestamp;
+	gint32 pe_timestamp; 
 
 	if (image->tables [MONO_TABLE_DOCUMENT].rows) {
 		/* Embedded ppdb */
@@ -126,7 +138,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		return create_ppdb_file (image);
 	}
 
-	if (!get_pe_debug_guid (image, pe_guid, &pe_age, &pe_timestamp)) {
+	if (!get_pe_debug_guid (image, NULL, pe_guid, &pe_age, &pe_timestamp)) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Image '%s' has no debug directory.", image->name);
 		return NULL;
 	}

--- a/mono/metadata/debug-mono-ppdb.h
+++ b/mono/metadata/debug-mono-ppdb.h
@@ -17,6 +17,9 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/mono-debug.h>
 
+MONO_API gboolean
+mono_ppdb_get_signature (MonoImage *image, const char** out_path, guint8 *out_guid, gint32 *out_age, gint32 *out_timestamp);
+
 MonoPPDBFile*
 mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size);
 

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -492,7 +492,7 @@ void
 mono_jit_info_table_add    (MonoDomain *domain, MonoJitInfo *ji);
 
 void
-mono_jit_info_table_foreach (MonoDomain *domain, MonoDomainFunc func, void *user_data);
+mono_jit_info_table_foreach (MonoDomain *domain, MonoJitInfoFunc func, void *user_data);
 
 void
 mono_jit_info_table_remove (MonoDomain *domain, MonoJitInfo *ji);

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -492,6 +492,9 @@ void
 mono_jit_info_table_add    (MonoDomain *domain, MonoJitInfo *ji);
 
 void
+mono_jit_info_table_foreach (MonoDomain *domain, MonoDomainFunc func, void *user_data);
+
+void
 mono_jit_info_table_remove (MonoDomain *domain, MonoJitInfo *ji);
 
 void

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -987,6 +987,12 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 }
 
 MONO_API void
+mono_domain_jit_foreach (MonoDomain *domain, MonoJitInfoFunc func, void *user_data)
+{
+	mono_jit_info_table_foreach (domain, func, user_data);
+}
+
+MONO_API void
 mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, void* user_data)
 {
 	MonoAssembly* assembly;

--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -751,7 +751,7 @@ mono_jit_info_table_remove (MonoDomain *domain, MonoJitInfo *ji)
 }
 
 void
-mono_jit_info_table_foreach (MonoDomain *domain, MonoDomainFunc func, void *user_data)
+mono_jit_info_table_foreach (MonoDomain *domain, MonoJitInfoFunc func, void *user_data)
 {
 	mono_domain_lock (domain);
 
@@ -762,7 +762,7 @@ mono_jit_info_table_foreach (MonoDomain *domain, MonoDomainFunc func, void *user
 			if (IS_JIT_INFO_TOMBSTONE (ji) || ji->is_trampoline)
 				continue;
 
-			func (domain, ji->d.method, ji);
+			func (domain, ji->d.method, ji, user_data);
 		}
 	}
 

--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -751,6 +751,25 @@ mono_jit_info_table_remove (MonoDomain *domain, MonoJitInfo *ji)
 }
 
 void
+mono_jit_info_table_foreach (MonoDomain *domain, MonoDomainFunc func, void *user_data)
+{
+	mono_domain_lock (domain);
+
+	MonoJitInfoTable *table = domain->jit_info_table;
+	for (int chunk_index = 0; chunk_index < table->num_chunks; ++chunk_index) {
+		for (int info_index = 0; info_index < table->chunks[chunk_index]->num_elements; ++info_index) {
+			MonoJitInfo *ji = table->chunks[chunk_index]->data[info_index];
+			if (IS_JIT_INFO_TOMBSTONE (ji) || ji->is_trampoline)
+				continue;
+
+			func (domain, ji->d.method, ji);
+		}
+	}
+
+	mono_domain_unlock (domain);
+}
+
+void
 mono_jit_info_add_aot_module (MonoImage *image, gpointer start, gpointer end)
 {
 	MonoJitInfo *ji;

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -96,7 +96,7 @@ guint64 mono_unity_method_get_hash(MonoMethod *method, gboolean inflate);
 MonoMethod* mono_unity_method_get_aot_array_helper_from_wrapper(MonoMethod *method);
 MonoObject* mono_unity_method_convert_return_type_if_needed(MonoMethod *method, void *value);
 MONO_API gboolean unity_mono_method_is_inflated(MonoMethod* method);
-guint32 mono_unity_method_get_token(MonoMethod *method);
+MONO_API guint32 mono_unity_method_get_token(MonoMethod *method);
 
 //domain
 void mono_unity_domain_install_finalize_runtime_invoke(MonoDomain* domain, RuntimeInvokeFunction callback);


### PR DESCRIPTION
As discussed in our call yesterday, these are the minimal changes to Mono that we'd need to support Unity with Superluminal. While we're making these changes in the context of Superluminal, they should be useful for any profiler that wants to achieve similar things.

If approved, it would be great if these changes could be backported to 2018.

There are two main changes:

**JIT Code Enumeration**
In order to support 'attach' scenarios where the user would like to profile an already-running process, a profiler module needs to have the ability to emit information for JIT code that was compiled prior to the profiler 'attaching'. In order to do this, there needs to be a way to enumerate all JIT-compiled methods. We've added a function that can do this (commit a64696e): `mono_jit_info_table_foreach`. This function uses the domain's `jit_info_table` to iterate through all JIT code for that domain and then invokes the callback function for each method. 

For consistency with existing 'enumeration' functions in Mono like `mono_domain_foreach` and `mono_domain_assembly_foreach`, there is a new wrapper function `mono_domain_jit_foreach` that internally just forwards to `mono_jit_info_table_foreach`.

Questions we have with regards to this change:

- Is this thread-safe? Other code around the JIT table works with hazard pointers, but since we're taking the domain lock before iterating through the JIT table, my understanding is that we don't need to do that here. Is that correct?
- Does this cover all JIT cases? For example, does the JIT code for dynamic methods end up in the table?

**PDB Info**
Mono's debug layer (`mono_debug_find_method`, `mono_debug_lookup_source_location`, etc) allows you to lookup address-to-line mappings at runtime. However, this is extremely slow and can take several seconds for even small test programs. In order to be able to lookup address-to-line mappings offline, you need info about the PDB in order to find it (path, guid, age, timestamp). 

Mono already has such a function in `debug-mono-ppdb.h`: `get_pe_debug_guid`. It previously didn't return the PDB path, but we've updated it so it (optionally) does. Furthermore, a new function `mono_ppdb_get_signature` has been added that internally just calls `get_pe_debug_guid` but is exported.

The final piece of info you need to lookup address-to-line mappings in the PDB is the method token. There was already a function to get that, `mono_unity_method_get_token`, but it wasn't exported. We've changed it so that it is.




