### PR TITLE
Allow different enums as return type in CreateDelegate (case 1288796)

### DIFF
--- a/mcs/class/corlib/System/Delegate.cs
+++ b/mcs/class/corlib/System/Delegate.cs
@@ -158,6 +158,17 @@ namespace System
 				// Delegate covariance
 				if (!returnType.IsValueType && delReturnType.IsAssignableFrom (returnType))
 					returnMatch = true;
+				else
+				{
+					bool isDelArgEnum = delReturnType.IsEnum;
+					bool isArgEnum = returnType.IsEnum;
+					if (isArgEnum && isDelArgEnum)
+						returnMatch = Enum.GetUnderlyingType(delReturnType) == Enum.GetUnderlyingType(returnType);
+					else if (isDelArgEnum && Enum.GetUnderlyingType(delReturnType) == returnType)
+						returnMatch = true;
+					else if (isArgEnum && Enum.GetUnderlyingType(returnType) == delReturnType)
+						returnMatch = true;
+				}
 			}
 
 			return returnMatch;


### PR DESCRIPTION
Allow `CreateDelegate` to have return type covariance with methods that
return `enum` or `int` types.

This is from the upstream change at https://github.com/mono/mono/commit/122494330d635205b0a8766deaeafd0d79bd3d60.

Release notes:

Fix case 1288796:
Mono: Allow CreateDelegate to work when the delegate type returns an integer, but the method type returns an enum.