### PR TITLE
Expose mono_class_is_open_constructed_type to Unity to allow us to ch…

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -287,7 +287,10 @@ MonoClass* mono_unity_class_get_generic_definition(MonoClass* klass)
 MonoClass* mono_unity_class_inflate_generic_class(MonoClass *gklass, MonoGenericContext *context)
 {
 	MonoError error;
-	return mono_class_inflate_generic_class_checked(gklass, context, &error);
+	MonoClass* klass;
+	klass = mono_class_inflate_generic_class_checked(gklass, context, &error);
+	mono_error_cleanup (&error);
+	return klass;
 }
 
 gboolean mono_unity_class_has_parent_unsafe(MonoClass *klass, MonoClass *parent)
@@ -1898,4 +1901,10 @@ MONO_API uint32_t
 mono_unity_allocation_granularity()
 {
 	return (uint32_t)(2 * sizeof(void *));
+}
+
+MONO_API gboolean
+mono_unity_class_is_open_constructed_type (MonoClass *klass)
+{
+	return mono_class_is_open_constructed_type (&klass->byval_arg);
 }

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -202,4 +202,6 @@ mono_unity_set_enable_handler_block_guards (mono_bool allow);
 mono_bool
 mono_unity_get_enable_handler_block_guards (void);
 
+MONO_API gboolean mono_unity_class_is_open_constructed_type (MonoClass *klass);
+
 #endif


### PR DESCRIPTION
…eck to see if the class is not yet fully instantiated prior to asttempting to call mono_object_new on it.

* Also cleaning up a minor leak of a MonoError in mono_unity_class_inflate_generic_class