### PR TITLE
2020.2: Fix an issue with System.XML and the Registry

### DIFF
--- a/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlReaderSettings.cs
+++ b/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlReaderSettings.cs
@@ -729,46 +729,9 @@ namespace System.Xml {
                 return s_enableLegacyXmlSettings.Value;
             }
 
-            bool enableSettings = false; // default value
-#if !MOBILE
-            if (!ReadSettingsFromRegistry(Registry.LocalMachine, ref enableSettings))
-            {
-                // still ok if this call return false too as we'll use the default value which is false
-                ReadSettingsFromRegistry(Registry.CurrentUser, ref enableSettings);
-            }
-#endif
-
-            s_enableLegacyXmlSettings = enableSettings;
+            s_enableLegacyXmlSettings = false;
             return s_enableLegacyXmlSettings.Value;
         }
-
-#if !MOBILE
-        [RegistryPermission(SecurityAction.Assert, Unrestricted = true)]
-        [SecuritySafeCritical]
-        private static bool ReadSettingsFromRegistry(RegistryKey hive, ref bool value)
-        {
-            const string regValueName = "EnableLegacyXmlSettings";
-            const string regValuePath = @"SOFTWARE\Microsoft\.NETFramework\XML";
-
-            try
-            {                                                                     
-                using (RegistryKey xmlRegKey = hive.OpenSubKey(regValuePath, false))
-                {
-                    if (xmlRegKey != null)
-                    {
-                        if (xmlRegKey.GetValueKind(regValueName) == RegistryValueKind.DWord)
-                        {
-                            value = ((int)xmlRegKey.GetValue(regValueName)) == 1;
-                            return true;
-                        }
-                    }
-                }
-            }
-            catch { /* use the default if we couldn't read the key */ }
-
-            return false;
-        }
-#endif // MOBILE
 
 #endif // SILVERLIGHT
         


### PR DESCRIPTION
Pulling in change mono#12008 removes the dependency on the registry for System.XML which causes issues for macOS because the way this works creates a file inside a .app file which invalidates the notarization and signing of the application.

Release notes:
Case 1292941
Fixing an issue with System.XML depending on writing/reading from the registry caused macOS Notarization to fail

Parent case 1292941.
Backport case 1308277.

Trunk PR: https://github.com/Unity-Technologies/mono/pull/1361