### PR TITLE
Fixes for HttpUtility.UrlEncode for Unity aot and jit profiles (case 1296177)

### DIFF
--- a/mcs/class/Facades/netstandard/Makefile
+++ b/mcs/class/Facades/netstandard/Makefile
@@ -23,7 +23,9 @@ LIB_MCS_FLAGS = $(SIGN_FLAGS) $(EXTRA_LIB_MCS_FLAGS)
 ifeq ($(PROFILE),xammac_net_4_5)
 LIB_REFS += System.Web.Services
 else ifeq (2.1, $(FRAMEWORK_VERSION))
-ifneq ($(PROFILE),unityaot)
+ifeq ($(PROFILE),unityaot)
+LIB_REFS += System.Web
+else
 LIB_REFS += System.Web.Services
 endif
 else

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -363,6 +363,7 @@ unityaot_dirs := \
 		System.Runtime.CompilerServices.Unsafe, $(mobile_common_dirs))	\
 	System.Drawing			\
 	System.Data.DataSetExtensions \
+	System.Web \
 	$(pcl_facade_dirs)
 
 xbuild_2_0_dirs := \

--- a/mcs/class/System.Web/Assembly/AssemblyInfo.cs
+++ b/mcs/class/System.Web/Assembly/AssemblyInfo.cs
@@ -37,7 +37,9 @@ using System.Security;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if !UNITY_AOT
 using System.Web.UI;
+#endif
 
 // General Information about the System.Web assembly
 
@@ -56,7 +58,9 @@ using System.Web.UI;
 [assembly: NeutralResourcesLanguage("en-US")]
 
 [assembly: AllowPartiallyTrustedCallers()]
+#if !UNITY_AOT
 [assembly: TagPrefix("System.Web.UI.WebControls", "asp")]
+#endif
 #if !(TARGET_DOTNET)
 [assembly: AssemblyDelaySign(true)]
 
@@ -65,6 +69,7 @@ using System.Web.UI;
 [assembly: Dependency ("System", LoadHint.Always)]
 [assembly: SecurityRules (SecurityRuleSet.Level2, SkipVerificationInFullTrust=true)]
 
+#if !UNITY_AOT
 [assembly: TypeForwardedTo (typeof (System.Web.Security.MembershipPasswordException))]
 [assembly: TypeForwardedTo (typeof (System.Web.Security.RoleProvider))]
 [assembly: TypeForwardedTo (typeof (System.Web.Security.MembershipCreateStatus))]
@@ -76,6 +81,7 @@ using System.Web.UI;
 [assembly: TypeForwardedTo (typeof (System.Web.Security.MembershipUserCollection))]
 [assembly: TypeForwardedTo (typeof (System.Web.Security.MembershipProviderCollection))]
 [assembly: TypeForwardedTo (typeof (System.Web.Security.MembershipProvider))]
+#endif
 
 [assembly: InternalsVisibleTo ("Microsoft.Web.Infrastructure, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 
@@ -87,6 +93,7 @@ using System.Web.UI;
 [assembly: InternalsVisibleTo ("net_4_x_System.Web_test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 // Resources
 
+#if !UNITY_AOT
 [assembly: WebResource ("TreeView_noexpand.gif", "image/gif")]
 [assembly: WebResource ("TreeView_dash.gif", "image/gif")]
 [assembly: WebResource ("TreeView_dashminus.gif", "image/gif")]
@@ -131,3 +138,4 @@ using System.Web.UI;
 [assembly: WebResource ("GridView.js", "text/javascript")]
 [assembly: WebResource ("webform.js", "text/javascript")]
 [assembly: WebResource ("WebUIValidation_2.0.js", "text/javascript")]
+#endif

--- a/mcs/class/System.Web/Makefile
+++ b/mcs/class/System.Web/Makefile
@@ -255,6 +255,12 @@ ifneq (plainweb/,$(intermediate))
 LIB_REFS += System.Web.Services plaindesign/System.Design
 LIB_MCS_FLAGS += -define:WEBSERVICES_DEP
 
+# The unityaot profile only compile in 3 classes : strip out references and resources that do not need to be there at this time.
+ifeq (unityaot, $(PROFILE))
+LIB_REFS:=$(filter-out System.EnterpriseServices System.Runtime.Serialization.Formatters.Soap System.Web.ApplicationServices System.Configuration plaindesign/System.Design, $(LIB_REFS))
+OTHER_RES:=$(filter-out $(RESOURCE_FILES_1) $(RESOURCE_FILES_2) $(RESOURCE_FILES_4), $(OTHER_RES))
+endif
+
 all-local: System.Web/UplevelHelper.cs 
 
 endif

--- a/mcs/class/System.Web/System.Web.Util/HttpEncoder.cs
+++ b/mcs/class/System.Web/System.Web.Util/HttpEncoder.cs
@@ -167,6 +167,12 @@ namespace System.Web.Util
 			return defaultEncoder.Value;
 #else
 			var cfg = HttpRuntime.Section;
+			// The unityjit profile is only built once for desktop and mobile.
+			// When the jit profile is running on a mobile platform (aka Android) this returns null.
+			// We will simply return the default encoder.
+			if(cfg == null)
+				return Default;
+
 			string typeName = cfg.EncoderType;
 
 			if (String.Compare (typeName, "System.Web.Util.HttpEncoder", StringComparison.OrdinalIgnoreCase) == 0)

--- a/mcs/class/System.Web/unityaot_System.Web.dll.sources
+++ b/mcs/class/System.Web/unityaot_System.Web.dll.sources
@@ -1,0 +1,9 @@
+Assembly/AssemblyInfo.cs
+../../build/common/Consts.cs
+../../build/common/Locale.cs
+../../build/common/MonoTODOAttribute.cs
+../System/System/MonoToolsLocator.cs
+
+System.Web/HttpUtility.cs
+System.Web.Util/Helpers.cs
+System.Web.Util/HttpEncoder.cs

--- a/mcs/class/System/unityaot_System.dll.sources
+++ b/mcs/class/System/unityaot_System.dll.sources
@@ -1,7 +1,4 @@
 #include mobile_System.dll.sources
-../System.Web/System.Web/HttpUtility.cs
-../System.Web/System.Web.Util/Helpers.cs
-../System.Web/System.Web.Util/HttpEncoder.cs
 System.CodeDom/CodeCompileUnit.cs
 System.CodeDom/CodeTypeDeclaration.cs
 


### PR DESCRIPTION
For aot, this commit moves the HttpUtility back to the System.Web dll. We are keeping a small footprint for System.Web, only what is needed for this class. 

Also the netstandard facade has been updated to include System.Web.

For the Jit profile a change is needed in GetCustomEncoderFromConfig for Android. The jit version of System.Web does not use the MOBILE define as the jit profile is typically used for desktop? This check gives Android a safe fallback.

Fixed case 1296177:
Scripting: Fixing HttpUtility.UrlEncode runtime exceptions
* il2cpp with netstandard : "Error: called non-existent method"
* mono runtime on Android : "NullReferenceException: Object reference not set to an instance of an object"
