### PR TITLE
Move HttpUtility from System.Web.Services to System.Web

### DIFF
--- a/mcs/class/System.Web.Services/System.Web.Services.Protocols/UrlEncodedParameterWriter.cs
+++ b/mcs/class/System.Web.Services/System.Web.Services.Protocols/UrlEncodedParameterWriter.cs
@@ -71,19 +71,26 @@ namespace System.Web.Services.Protocols {
 
 		protected void Encode (TextWriter writer, string name, object value)
 		{
+			writer.Write (UrlEncode (name));
+			writer.Write ("=");
+			writer.Write (UrlEncode (ObjToString (value)));
+		}
+
+		private string UrlEncode (string value)
+		{
 			if (requestEncoding != null)
 			{
-				writer.Write (HttpUtility.UrlEncode (name, requestEncoding));
-				writer.Write ("=");
-				writer.Write (HttpUtility.UrlEncode (ObjToString (value), requestEncoding));
+#if UNITY_AOT && FULL_AOT_RUNTIME
+				return UrlEncoder.UrlEscapeString (value, requestEncoding);
+#else
+				return HttpUtility.UrlEncode (value, requestEncoding);
+#endif
 			}
-			else
-			{
-				writer.Write (HttpUtility.UrlEncode (name));
-				writer.Write ("=");
-				writer.Write (HttpUtility.UrlEncode (ObjToString (value)));
-			}
-				
+#if UNITY_AOT && FULL_AOT_RUNTIME
+				return UrlEncoder.UrlEscapeStringUnicode (value);
+#else
+				return HttpUtility.UrlEncode (value);
+#endif
 		}
 
 		public override object GetInitializer (LogicalMethodInfo methodInfo)

--- a/mcs/class/System.Web.Services/unityaot_System.Web.Services.dll.exclude.sources
+++ b/mcs/class/System.Web.Services/unityaot_System.Web.Services.dll.exclude.sources
@@ -1,0 +1,3 @@
+../System.Web/System.Web.Util/Helpers.cs
+../System.Web/System.Web.Util/HttpEncoder.cs
+../System.Web/System.Web/HttpUtility.cs

--- a/mcs/class/System.Web.Services/unityaot_System.Web.Services.dll.sources
+++ b/mcs/class/System.Web.Services/unityaot_System.Web.Services.dll.sources
@@ -1,1 +1,3 @@
 #include mobile_System.Web.Services.dll.sources
+ReferenceSources/Res.cs
+../referencesource/System.Web.Services/System/Web/Services/Protocols/Scalars.cs


### PR DESCRIPTION
This is a followup to my previous PR where I moved HttpUtility from
System to System.Web. What we found in il2cpp testing is that
HttpUtility was also in System.Web.Services.

This PR removes the duplicate classes from System.Web.Services. However
there UrlEncodedParameterWriter inside System.Web.Services needs a
UrlEncode method.

To solve this dependency this commits follows the code from corefx and
uses an existing helper class within. Bringing in Scalars.cs to
accomplish this.