### PR TITLE
Compile Mono on macOS and Linux with DISABLE_COM set

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1076,6 +1076,7 @@ if ($build)
 
 		push @configureparams, "--host=$monoHostArch-pc-linux-gnu";
 		push @configureparams, "--disable-parallel-mark";  #this causes crashes
+		push @configureparams, "--enable-minimal=com";
 
 		my $archflags = '';
 		if ($arch32)
@@ -1179,7 +1180,7 @@ if ($build)
 
 		# Need to define because Apple's SIP gets in the way of us telling mono where to find this
 		push @configureparams, "--with-libgdiplus=$addtoresultsdistdir/lib/libgdiplus.dylib";
-		push @configureparams, "--enable-minimal=shared_perfcounters";
+		push @configureparams, "--enable-minimal=com,shared_perfcounters";
 		push @configureparams, "--disable-parallel-mark";
 		push @configureparams, "--enable-verify-defines";
 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -780,8 +780,8 @@ NOHANDLES(ICALL(MARSHAL_11, "GetLastWin32Error", ves_icall_System_Runtime_Intero
 HANDLES(MARSHAL_53, "GetNativeActivationFactory", ves_icall_System_Runtime_InteropServices_Marshal_GetNativeActivationFactory, MonoObject, 1, (MonoObject))
 HANDLES(MARSHAL_47, "GetObjectForCCW", ves_icall_System_Runtime_InteropServices_Marshal_GetObjectForCCW, MonoObject, 1, (gpointer))
 HANDLES(MARSHAL_54, "GetRawIUnknownForComObjectNoAddRef", ves_icall_System_Runtime_InteropServices_Marshal_GetRawIUnknownForComObjectNoAddRef, gpointer, 1, (MonoObject))
-#endif
 HANDLES(MARSHAL_48, "IsComObject", ves_icall_System_Runtime_InteropServices_Marshal_IsComObject, MonoBoolean, 1, (MonoObject))
+#endif
 HANDLES(MARSHAL_48a, "IsPinnableType", ves_icall_System_Runtime_InteropServices_Marshal_IsPinnableType, MonoBoolean, 1, (MonoReflectionType))
 HANDLES(MARSHAL_12, "OffsetOf", ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf, int, 2, (MonoReflectionType, MonoString))
 HANDLES(MARSHAL_13, "Prelink", ves_icall_System_Runtime_InteropServices_Marshal_Prelink, void, 1, (MonoReflectionMethod))


### PR DESCRIPTION
This define disables COM code in the runtime. If COM is enabled, then
`mono_class_try_get_com_object_class` assumes that the
`System.__ComObject` type exists in the class library code. When
experimental stripping is enabled, `System.__ComObject` is removed, so
the Mono runtime code asserts.

By disabling COM support in the runtime, this assert does not occur, and
UnityLinker tests can pass on macOS.