### PR TITLE
Origin/multithreaded liveness

### DIFF
--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -41,8 +41,8 @@ typedef struct _custom_block_array_iterator {
 } custom_block_array_iterator;
 
 
-typedef void (*register_object_callback) (gpointer *arr, int size, void *callback_userdata);
-typedef void (*WorldStateChanged) ();
+typedef void(*register_object_callback) (gpointer *arr, int size, void *callback_userdata);
+typedef void(*WorldStateChanged) ();
 typedef void *(*ReallocateArray) (void *ptr, int size, void *callback_userdata);
 
 struct _LivenessState {
@@ -60,27 +60,25 @@ struct _LivenessState {
 	guint traverse_depth; // track recursion. Prevent stack overflow by limiting recursion
 };
 
-custom_growable_block_array *
-block_array_create (LivenessState *state)
+custom_growable_block_array * block_array_create(LivenessState *state)
 {
-	custom_growable_block_array *array = g_new0 (custom_growable_block_array, 1);
-	array->current_block = state->reallocateArray (NULL, k_block_size, state->callback_userdata);
+	custom_growable_block_array *array = g_new0(custom_growable_block_array, 1);
+	array->current_block = state->reallocateArray(NULL, k_block_size, state->callback_userdata);
 	array->current_block->next_block = NULL;
 	array->current_block->next_item = array->current_block->p_data;
 	array->first_block = array->current_block;
 
-	array->iterator = g_new0 (custom_block_array_iterator, 1);
+	array->iterator = g_new0(custom_block_array_iterator, 1);
 	array->iterator->array = array;
 	array->iterator->current_block = array->first_block;
 	array->iterator->current_position = array->first_block->p_data;
 	return array;
 }
 
-void
-block_array_push_back (custom_growable_block_array *block_array, gpointer value, LivenessState *state)
+void block_array_push_back(custom_growable_block_array *block_array, gpointer value, LivenessState *state)
 {
 	if (block_array->current_block->next_item == block_array->current_block->p_data + k_array_elements_per_block) {
-		block_array->current_block->next_block = state->reallocateArray (NULL, k_block_size, state->callback_userdata);
+		block_array->current_block->next_block = state->reallocateArray(NULL, k_block_size, state->callback_userdata);
 		block_array->current_block = block_array->current_block->next_block;
 		block_array->current_block->next_block = NULL;
 		block_array->current_block->next_item = block_array->current_block->p_data;
@@ -88,15 +86,13 @@ block_array_push_back (custom_growable_block_array *block_array, gpointer value,
 	*block_array->current_block->next_item++ = value;
 }
 
-void
-block_array_reset_iterator (custom_growable_block_array *array)
+void block_array_reset_iterator(custom_growable_block_array *array)
 {
 	array->iterator->current_block = array->first_block;
 	array->iterator->current_position = array->first_block->p_data;
 }
 
-gpointer
-block_array_next (custom_growable_block_array *block_array)
+gpointer block_array_next(custom_growable_block_array *block_array)
 {
 	custom_block_array_iterator *iterator = block_array->iterator;
 	if (iterator->current_position != iterator->current_block->next_item)
@@ -110,111 +106,86 @@ block_array_next (custom_growable_block_array *block_array)
 	return *iterator->current_position++;
 }
 
-void
-block_array_destroy (custom_growable_block_array *block_array, LivenessState *state)
+void block_array_destroy(custom_growable_block_array *block_array, LivenessState *state)
 {
 	custom_array_block *block = block_array->first_block;
 	while (block != NULL) {
 		void *data_block = block;
 		block = block->next_block;
-		state->reallocateArray (data_block, 0, state->callback_userdata);
+		state->reallocateArray(data_block, 0, state->callback_userdata);
 	}
-	g_free (block_array->iterator);
-	g_free (block_array);
+	g_free(block_array->iterator);
+	g_free(block_array);
 }
-
 
 #define array_at_index(array, index) (array)->pdata[(index)]
 
 #if defined(HAVE_SGEN_GC)
-void
-sgen_stop_world (int generation);
-void
-sgen_restart_world (int generation);
+void sgen_stop_world(int generation);
+void sgen_restart_world(int generation);
 #elif defined(HAVE_BOEHM_GC)
 #ifdef HAVE_BDWGC_GC
-extern void
-GC_stop_world_external ();
-extern void
-GC_start_world_external ();
+extern void GC_stop_world_external();
+extern void GC_start_world_external();
 #else
-void
-GC_stop_world_external ()
+void GC_stop_world_external()
 {
-	g_assert_not_reached ();
+	g_assert_not_reached();
 }
-void
-GC_start_world_external ()
+void GC_start_world_external()
 {
-	g_assert_not_reached ();
+	g_assert_not_reached();
 }
 #endif
 #else
 #error need to implement liveness GC API
 #endif
 
-gboolean
-array_is_full (custom_growable_array *array)
+custom_growable_array * array_create_and_initialize(guint capacity)
 {
-	return array->size == array->len;
-}
-
-custom_growable_array *
-array_create (LivenessState *state, guint reserved_size)
-{
-	custom_growable_array *array = g_new0 (custom_growable_array, 1);
-
-	array->pdata = NULL;
+	custom_growable_array *array = g_ptr_array_sized_new(capacity);
 	array->len = 0;
-	array->size = 0;
-
-	if (reserved_size > 0) {
-		array->pdata = state->reallocateArray (NULL, reserved_size * sizeof (gpointer), state->callback_userdata);
-		array->size = reserved_size;
-	}
-
-	return (custom_growable_array *)array;
+	return array;
 }
 
-void
-array_destroy (custom_growable_array *array, LivenessState *state)
+gboolean array_is_full(custom_growable_array *array)
 {
-	array->pdata = state->reallocateArray (array->pdata, 0, state->callback_userdata);
-	g_free (array);
+	return g_ptr_array_capacity(array) == array->len;
 }
 
-void
-array_push_back (custom_growable_array *array, gpointer value)
+void array_destroy(custom_growable_array *array)
 {
-	g_assert (!array_is_full (array));
+	g_ptr_array_free(array, TRUE);
+	g_free(array);
+}
+
+void array_push_back(custom_growable_array *array, gpointer value)
+{
+	g_assert(!array_is_full(array));
 	array->pdata[array->len] = value;
 	array->len++;
 }
 
-gpointer
-array_pop_back (custom_growable_array *array)
+gpointer array_pop_back(custom_growable_array *array)
 {
 	array->len--;
 	return array->pdata[array->len];
 }
 
-void
-array_clear (custom_growable_array *array)
+void array_clear(custom_growable_array *array)
 {
 	array->len = 0;
 }
 
-void
-array_reserve (LivenessState *state, custom_growable_array *array, guint size)
+void array_reserve(LivenessState *state, custom_growable_array *array, guint size)
 {
-	array->pdata = state->reallocateArray (array->pdata, size * sizeof (gpointer), state->callback_userdata);
+	array->pdata = state->reallocateArray(array->pdata, size * sizeof(gpointer), state->callback_userdata);
 	array->size = size;
 }
 
-void
-array_grow (LivenessState *state, custom_growable_array *array)
+void array_grow(LivenessState *state, custom_growable_array *array)
 {
-	array->pdata = state->reallocateArray (array->pdata, array->size * 2 * sizeof (gpointer), state->callback_userdata);
+	array->pdata = state->reallocateArray(array->pdata, array->size * 2 * sizeof(gpointer), state->callback_userdata);
 	array->size = array->size * 2;
 }
 
@@ -228,21 +199,14 @@ const int kArrayElementsPerChunk = 256;
 const int kMaxTraverseRecursionDepth = 128;
 
 /* Liveness calculation */
-MONO_API LivenessState *
-mono_unity_liveness_allocate_struct (MonoClass *filter, guint max_count, register_object_callback callback, void *callback_userdata, ReallocateArray reallocateArray);
-MONO_API void
-mono_unity_liveness_stop_gc_world ();
-MONO_API void
-mono_unity_liveness_finalize (LivenessState *state);
-MONO_API void
-mono_unity_liveness_start_gc_world ();
-MONO_API void
-mono_unity_liveness_free_struct (LivenessState *state);
+MONO_API LivenessState * mono_unity_liveness_allocate_struct(MonoClass *filter, guint max_count, register_object_callback callback, void *callback_userdata, ReallocateArray reallocateArray);
+MONO_API void mono_unity_liveness_stop_gc_world();
+MONO_API void mono_unity_liveness_finalize(LivenessState *state);
+MONO_API void mono_unity_liveness_start_gc_world();
+MONO_API void mono_unity_liveness_free_struct(LivenessState *state);
 
-MONO_API void
-mono_unity_liveness_calculation_from_root (MonoObject *root, LivenessState *state);
-MONO_API void
-mono_unity_liveness_calculation_from_statics (LivenessState *state);
+MONO_API void mono_unity_liveness_calculation_from_root(MonoObject *root, LivenessState *state);
+MONO_API void mono_unity_liveness_calculation_from_statics(LivenessState *state);
 
 #define MARK_OBJ(obj)                                                       \
 	do {                                                                    \
@@ -260,72 +224,62 @@ mono_unity_liveness_calculation_from_statics (LivenessState *state);
 #define GET_VTABLE(obj) \
 	((MonoVTable *)(((gsize) (obj)->vtable) & ~(gsize)1))
 
-void
-mono_filter_objects (LivenessState *state);
+void mono_filter_objects(LivenessState *state);
 
-void
-mono_reset_state (LivenessState *state)
+void mono_reset_state(LivenessState *state)
 {
-	array_clear (state->process_array);
+	array_clear(state->process_array);
 }
 
-void
-array_safe_grow (LivenessState *state, custom_growable_array *array)
+void array_safe_grow(LivenessState *state, custom_growable_array *array)
 {
-	array_grow (state, array);
+	array_grow(state, array);
 }
 
-static gboolean
-should_process_value (MonoObject *val, MonoClass *filter)
+static gboolean should_process_value(MonoObject *val, MonoClass *filter)
 {
-	MonoClass *val_class = GET_VTABLE (val)->klass;
+	MonoClass *val_class = GET_VTABLE(val)->klass;
 	if (filter &&
-		!mono_class_has_parent (val_class, filter))
+		!mono_class_has_parent(val_class, filter))
 		return FALSE;
 
 	return TRUE;
 }
 
-static void
-mono_traverse_array (MonoArray *array, LivenessState *state);
-static void
-mono_traverse_object (MonoObject *object, LivenessState *state);
-static void
-mono_traverse_gc_desc (MonoObject *object, LivenessState *state);
-static void
-mono_traverse_objects (LivenessState *state);
+static void mono_traverse_array(MonoArray *array, LivenessState *state);
+static void mono_traverse_object(MonoObject *object, LivenessState *state);
+static void mono_traverse_gc_desc(MonoObject *object, LivenessState *state);
+static void mono_traverse_objects(LivenessState *state);
 
-static void
-mono_traverse_generic_object (MonoObject *object, LivenessState *state)
+static void mono_traverse_generic_object(MonoObject *object, LivenessState *state)
 {
 #ifdef HAVE_SGEN_GC
 	gsize gc_desc = 0;
 #else
-	gsize gc_desc = (gsize) (GET_VTABLE (object)->gc_descr);
+	gsize gc_desc = (gsize)(GET_VTABLE(object)->gc_descr);
 #endif
 
 	if (gc_desc & (gsize)1)
-		mono_traverse_gc_desc (object, state);
-	else if (GET_VTABLE (object)->klass->rank)
-		mono_traverse_array ((MonoArray *)object, state);
+		mono_traverse_gc_desc(object, state);
+	else if (GET_VTABLE(object)->klass->rank)
+		mono_traverse_array((MonoArray *)object, state);
 	else
-		mono_traverse_object (object, state);
+		mono_traverse_object(object, state);
 }
 
-static gboolean
-mono_add_process_object (MonoObject *object, LivenessState *state)
+static gboolean mono_add_process_object(MonoObject *object, LivenessState *state)
 {
-	if (object && !IS_MARKED (object)) {
-		gboolean has_references = GET_VTABLE (object)->klass->has_references;
-		if (has_references || should_process_value (object, state->filter)) {
-			block_array_push_back (state->all_objects, object, state);
-			MARK_OBJ (object);
+	if (object && !IS_MARKED(object)) {
+		gboolean has_references = GET_VTABLE(object)->klass->has_references;
+		if (has_references || should_process_value(object, state->filter)) {
+			block_array_push_back(state->all_objects, object, state);
+			MARK_OBJ(object);
 		}
 		// Check if klass has further references - if not skip adding
 		if (has_references) {
-			if (array_is_full (state->process_array))
-				array_safe_grow (state, state->process_array);
-			array_push_back (state->process_array, object);
+			if (array_is_full(state->process_array))
+				array_safe_grow(state, state->process_array);
+			array_push_back(state->process_array, object);
 			return TRUE;
 		}
 	}
@@ -333,27 +287,25 @@ mono_add_process_object (MonoObject *object, LivenessState *state)
 	return FALSE;
 }
 
-static gboolean
-mono_field_can_contain_references (MonoClassField *field)
+static gboolean mono_field_can_contain_references(MonoClassField *field)
 {
-	if (MONO_TYPE_ISSTRUCT (field->type))
+	if (MONO_TYPE_ISSTRUCT(field->type))
 		return TRUE;
 	if (field->type->attrs & FIELD_ATTRIBUTE_LITERAL)
 		return FALSE;
 	if (field->type->type == MONO_TYPE_STRING)
 		return FALSE;
-	return MONO_TYPE_IS_REFERENCE (field->type);
+	return MONO_TYPE_IS_REFERENCE(field->type);
 }
 
-static gboolean
-mono_traverse_object_internal (MonoObject *object, gboolean isStruct, MonoClass *klass, LivenessState *state)
+static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStruct, MonoClass *klass, LivenessState *state)
 {
 	guint32 i;
 	MonoClassField *field;
 	MonoClass *p;
 	gboolean added_objects = FALSE;
 
-	g_assert (object);
+	g_assert(object);
 
 	// subtract the added offset for the vtable. This is added to the offset even though it is a struct
 	if (isStruct)
@@ -362,32 +314,34 @@ mono_traverse_object_internal (MonoObject *object, gboolean isStruct, MonoClass 
 	for (p = klass; p != NULL; p = p->parent) {
 		if (p->size_inited == 0)
 			continue;
-		for (i = 0; i < mono_class_get_field_count (p); i++) {
+		for (i = 0; i < mono_class_get_field_count(p); i++) {
 			field = &p->fields[i];
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 
-			if (!mono_field_can_contain_references (field))
+			if (!mono_field_can_contain_references(field))
 				continue;
 
-			if (MONO_TYPE_ISSTRUCT (field->type)) {
+			if (MONO_TYPE_ISSTRUCT(field->type)) {
 				char *offseted = (char *)object;
 				offseted += field->offset;
 				if (field->type->type == MONO_TYPE_GENERICINST) {
-					g_assert (field->type->data.generic_class->cached_class);
-					added_objects |= mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.generic_class->cached_class, state);
-				} else
-					added_objects |= mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.klass, state);
+					g_assert(field->type->data.generic_class->cached_class);
+					added_objects |= mono_traverse_object_internal((MonoObject *)offseted, TRUE, field->type->data.generic_class->cached_class, state);
+				}
+				else
+					added_objects |= mono_traverse_object_internal((MonoObject *)offseted, TRUE, field->type->data.klass, state);
 				continue;
 			}
 
 			if (field->offset == -1) {
-				g_assert_not_reached ();
-			} else {
+				g_assert_not_reached();
+			}
+			else {
 				MonoObject *val = NULL;
 				MonoVTable *vtable = NULL;
-				mono_field_get_value (object, field, &val);
-				added_objects |= mono_add_process_object (val, state);
+				mono_field_get_value(object, field, &val);
+				added_objects |= mono_add_process_object(val, state);
 			}
 		}
 	}
@@ -395,54 +349,49 @@ mono_traverse_object_internal (MonoObject *object, gboolean isStruct, MonoClass 
 	return added_objects;
 }
 
-static void
-mono_traverse_object (MonoObject *object, LivenessState *state)
+static void mono_traverse_object(MonoObject *object, LivenessState *state)
 {
-	mono_traverse_object_internal (object, FALSE, GET_VTABLE (object)->klass, state);
+	mono_traverse_object_internal(object, FALSE, GET_VTABLE(object)->klass, state);
 }
 
-static void
-mono_traverse_gc_desc (MonoObject *object, LivenessState *state)
+static void mono_traverse_gc_desc(MonoObject *object, LivenessState *state)
 {
 #define WORDSIZE ((int)sizeof (gsize) * 8)
 	int i = 0;
-	gsize mask = (gsize) (GET_VTABLE (object)->gc_descr);
+	gsize mask = (gsize)(GET_VTABLE(object)->gc_descr);
 
-	g_assert (mask & (gsize)1);
+	g_assert(mask & (gsize)1);
 
 	for (i = 0; i < WORDSIZE - 2; i++) {
 		gsize offset = ((gsize)1 << (WORDSIZE - 1 - i));
 		if (mask & offset) {
-			MonoObject *val = *(MonoObject **)(((char *)object) + i * sizeof (void *));
-			mono_add_process_object (val, state);
+			MonoObject *val = *(MonoObject **)(((char *)object) + i * sizeof(void *));
+			mono_add_process_object(val, state);
 		}
 	}
 }
 
-static void
-mono_traverse_objects (LivenessState *state)
+static void mono_traverse_objects(LivenessState *state)
 {
 	int i = 0;
 	MonoObject *object = NULL;
 
 	state->traverse_depth++;
 	while (state->process_array->len > 0) {
-		object = array_pop_back (state->process_array);
-		mono_traverse_generic_object (object, state);
+		object = array_pop_back(state->process_array);
+		mono_traverse_generic_object(object, state);
 	}
 	state->traverse_depth--;
 }
 
-static gboolean
-should_traverse_objects (size_t index, gint32 recursion_depth)
+static gboolean should_traverse_objects(size_t index, gint32 recursion_depth)
 {
 	// Add kArrayElementsPerChunk objects at a time and then traverse
 	return ((index + 1) & (kArrayElementsPerChunk - 1)) == 0 &&
-		   recursion_depth < kMaxTraverseRecursionDepth;
+		recursion_depth < kMaxTraverseRecursionDepth;
 }
 
-static void
-mono_traverse_array (MonoArray *array, LivenessState *state)
+static void mono_traverse_array(MonoArray *array, LivenessState *state)
 {
 	size_t i = 0;
 	gboolean has_references;
@@ -451,64 +400,64 @@ mono_traverse_array (MonoArray *array, LivenessState *state)
 	int32_t elementClassSize;
 	size_t array_length;
 
-	g_assert (object);
+	g_assert(object);
 
-	element_class = GET_VTABLE (object)->klass->element_class;
-	has_references = !mono_class_is_valuetype (element_class);
-	g_assert (element_class->size_inited != 0);
+	element_class = GET_VTABLE(object)->klass->element_class;
+	has_references = !mono_class_is_valuetype(element_class);
+	g_assert(element_class->size_inited != 0);
 
-	for (i = 0; i < mono_class_get_field_count (element_class); i++) {
-		has_references |= mono_field_can_contain_references (&element_class->fields[i]);
+	for (i = 0; i < mono_class_get_field_count(element_class); i++) {
+		has_references |= mono_field_can_contain_references(&element_class->fields[i]);
 	}
 
 	if (!has_references)
 		return;
 
-	array_length = mono_array_length (array);
+	array_length = mono_array_length(array);
 	if (element_class->valuetype) {
 		size_t items_processed = 0;
-		elementClassSize = mono_class_array_element_size (element_class);
+		elementClassSize = mono_class_array_element_size(element_class);
 		for (i = 0; i < array_length; i++) {
-			MonoObject *object = (MonoObject *)mono_array_addr_with_size (array, elementClassSize, i);
-			if (mono_traverse_object_internal (object, 1, element_class, state))
+			MonoObject *object = (MonoObject *)mono_array_addr_with_size(array, elementClassSize, i);
+			if (mono_traverse_object_internal(object, 1, element_class, state))
 				items_processed++;
 
-			if (should_traverse_objects (items_processed, state->traverse_depth))
-				mono_traverse_objects (state);
+			if (should_traverse_objects(items_processed, state->traverse_depth))
+				mono_traverse_objects(state);
 		}
-	} else {
+	}
+	else {
 		size_t items_processed = 0;
 		for (i = 0; i < array_length; i++) {
-			MonoObject *val = mono_array_get (array, MonoObject *, i);
-			if (mono_add_process_object (val, state))
+			MonoObject *val = mono_array_get(array, MonoObject *, i);
+			if (mono_add_process_object(val, state))
 				items_processed++;
 
-			if (should_traverse_objects (items_processed, state->traverse_depth))
-				mono_traverse_objects (state);
+			if (should_traverse_objects(items_processed, state->traverse_depth))
+				mono_traverse_objects(state);
 		}
 	}
 }
 
-void
-mono_filter_objects (LivenessState *state)
+void mono_filter_objects(LivenessState *state)
 {
 	gpointer filtered_objects[64];
 	gint num_objects = 0;
 
-	gpointer value = block_array_next (state->all_objects);
+	gpointer value = block_array_next(state->all_objects);
 	while (value != NULL) {
 		MonoObject *object = value;
-		if (should_process_value (object, state->filter))
+		if (should_process_value(object, state->filter))
 			filtered_objects[num_objects++] = object;
 		if (num_objects == 64) {
-			state->filter_callback (filtered_objects, 64, state->callback_userdata);
+			state->filter_callback(filtered_objects, 64, state->callback_userdata);
 			num_objects = 0;
 		}
-		value = block_array_next (state->all_objects);
+		value = block_array_next(state->all_objects);
 	}
 
 	if (num_objects != 0)
-		state->filter_callback (filtered_objects, num_objects, state->callback_userdata);
+		state->filter_callback(filtered_objects, num_objects, state->callback_userdata);
 }
 
 /**
@@ -517,16 +466,15 @@ mono_filter_objects (LivenessState *state)
  * Returns an array of MonoObject* that are reachable from the static roots
  * in the current domain and derive from @filter (if not NULL).
  */
-void
-mono_unity_liveness_calculation_from_statics (LivenessState *liveness_state)
+void mono_unity_liveness_calculation_from_statics(LivenessState *liveness_state)
 {
 	guint i, j;
-	MonoDomain *domain = mono_domain_get ();
+	MonoDomain *domain = mono_domain_get();
 
-	mono_reset_state (liveness_state);
+	mono_reset_state(liveness_state);
 
 	for (i = 0; i < domain->class_vtable_array->len; ++i) {
-		MonoVTable *vtable = (MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i);
+		MonoVTable *vtable = (MonoVTable *)g_ptr_array_index(domain->class_vtable_array, i);
 		MonoClass *klass = vtable->klass;
 		MonoClassField *field;
 		if (!klass)
@@ -537,45 +485,46 @@ mono_unity_liveness_calculation_from_statics (LivenessState *liveness_state)
 			continue;
 		if (klass->size_inited == 0)
 			continue;
-		for (j = 0; j < mono_class_get_field_count (klass); j++) {
+		for (j = 0; j < mono_class_get_field_count(klass); j++) {
 			field = &klass->fields[j];
 			if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 				continue;
-			if (!mono_field_can_contain_references (field))
+			if (!mono_field_can_contain_references(field))
 				continue;
 			// shortcut check for special statics
 			if (field->offset == -1)
 				continue;
 
-			if (MONO_TYPE_ISSTRUCT (field->type)) {
-				char *offseted = (char *)mono_vtable_get_static_field_data (vtable);
+			if (MONO_TYPE_ISSTRUCT(field->type)) {
+				char *offseted = (char *)mono_vtable_get_static_field_data(vtable);
 				offseted += field->offset;
 				if (field->type->type == MONO_TYPE_GENERICINST) {
-					g_assert (field->type->data.generic_class->cached_class);
-					mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
-				} else {
-					mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.klass, liveness_state);
+					g_assert(field->type->data.generic_class->cached_class);
+					mono_traverse_object_internal((MonoObject *)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
 				}
-			} else {
+				else {
+					mono_traverse_object_internal((MonoObject *)offseted, TRUE, field->type->data.klass, liveness_state);
+				}
+			}
+			else {
 				MonoError error;
 				MonoObject *val = NULL;
 
-				mono_field_static_get_value_checked (mono_class_vtable (domain, klass), field, &val, &error);
+				mono_field_static_get_value_checked(mono_class_vtable(domain, klass), field, &val, &error);
 
-				if (val && mono_error_ok (&error)) {
-					mono_add_process_object (val, liveness_state);
+				if (val && mono_error_ok(&error)) {
+					mono_add_process_object(val, liveness_state);
 				}
-				mono_error_cleanup (&error);
+				mono_error_cleanup(&error);
 			}
 		}
 	}
-	mono_traverse_objects (liveness_state);
+	mono_traverse_objects(liveness_state);
 	//Filter objects and call callback to register found objects
-	mono_filter_objects (liveness_state);
+	mono_filter_objects(liveness_state);
 }
 
-void
-mono_unity_liveness_add_object_callback (gpointer *objs, gint count, void *arr)
+void mono_unity_liveness_add_object_callback(gpointer *objs, gint count, void *arr)
 {
 	int i;
 	custom_growable_array *objects = (custom_growable_array *)arr;
@@ -591,21 +540,19 @@ mono_unity_liveness_add_object_callback (gpointer *objs, gint count, void *arr)
  * Returns an array of MonoObject* that are reachable from @root
  * in the current domain and derive from @filter (if not NULL).
  */
-void
-mono_unity_liveness_calculation_from_root (MonoObject *root, LivenessState *liveness_state)
+void mono_unity_liveness_calculation_from_root(MonoObject *root, LivenessState *liveness_state)
 {
-	mono_reset_state (liveness_state);
+	mono_reset_state(liveness_state);
 
-	array_push_back (liveness_state->process_array, root);
+	array_push_back(liveness_state->process_array, root);
 
-	mono_traverse_objects (liveness_state);
+	mono_traverse_objects(liveness_state);
 
 	//Filter objects and call callback to register found objects
-	mono_filter_objects (liveness_state);
+	mono_filter_objects(liveness_state);
 }
 
-LivenessState *
-mono_unity_liveness_allocate_struct (MonoClass *filter, guint max_count, register_object_callback callback, void *callback_userdata, ReallocateArray reallocateArray)
+LivenessState * mono_unity_liveness_allocate_struct(MonoClass *filter, guint max_count, register_object_callback callback, void *callback_userdata, ReallocateArray reallocateArray)
 {
 	LivenessState *state = NULL;
 
@@ -615,7 +562,7 @@ mono_unity_liveness_allocate_struct (MonoClass *filter, guint max_count, registe
 	// process_array. array that contains the objcets that should be processed. this should run depth first to reduce memory usage
 	// if all_objects run out of space, run through list, add objects that match the filter, clear bit in vtable and then clear the array.
 
-	state = g_new0 (LivenessState, 1);
+	state = g_new0(LivenessState, 1);
 	max_count = max_count < 1000 ? 1000 : max_count;
 
 	state->filter = filter;
@@ -625,52 +572,48 @@ mono_unity_liveness_allocate_struct (MonoClass *filter, guint max_count, registe
 	state->filter_callback = callback;
 	state->reallocateArray = reallocateArray;
 
-	state->all_objects = block_array_create (state);
-	state->process_array = array_create (state, max_count);
+	state->all_objects = block_array_create(state);
+	state->process_array = array_create(state, max_count);
 
 	return state;
 }
 
-void
-mono_unity_liveness_finalize (LivenessState *state)
+void mono_unity_liveness_finalize(LivenessState *state)
 {
-	block_array_reset_iterator (state->all_objects);
-	gpointer it = block_array_next (state->all_objects);
+	block_array_reset_iterator(state->all_objects);
+	gpointer it = block_array_next(state->all_objects);
 	while (it != NULL) {
 		MonoObject *object = it;
-		CLEAR_OBJ (object);
-		it = block_array_next (state->all_objects);
+		CLEAR_OBJ(object);
+		it = block_array_next(state->all_objects);
 	}
 }
 
-void
-mono_unity_liveness_free_struct (LivenessState *state)
+void mono_unity_liveness_free_struct(LivenessState *state)
 {
 	//cleanup the liveness_state
-	block_array_destroy (state->all_objects, state);
-	array_destroy (state->process_array, state);
-	g_free (state);
+	block_array_destroy(state->all_objects, state);
+	array_destroy(state->process_array);
+	g_free(state);
 }
 
-void
-mono_unity_liveness_stop_gc_world ()
+void mono_unity_liveness_stop_gc_world()
 {
 #if defined(HAVE_SGEN_GC)
-	sgen_stop_world (1);
+	sgen_stop_world(1);
 #elif defined(HAVE_BOEHM_GC)
-	GC_stop_world_external ();
+	GC_stop_world_external();
 #else
 #error need to implement liveness GC API
 #endif
 }
 
-void
-mono_unity_liveness_start_gc_world ()
+void mono_unity_liveness_start_gc_world()
 {
 #if defined(HAVE_SGEN_GC)
-	sgen_restart_world (1);
+	sgen_restart_world(1);
 #elif defined(HAVE_BOEHM_GC)
-	GC_start_world_external ();
+	GC_start_world_external();
 #else
 #error need to implement liveness GC API
 #endif

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -1,31 +1,61 @@
 #include <config.h>
 #include <glib.h>
-#include <mono/metadata/object.h>
-#include <mono/metadata/object-internals.h>
-#include <mono/metadata/metadata.h>
-#include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/domain-internals.h>
+#include <mono/metadata/metadata.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/object.h>
+#include <mono/metadata/tabledefs.h>
 #include <mono/utils/mono-error.h>
 
 typedef struct _LivenessState LivenessState;
+typedef struct _custom_growable_array {
+	gpointer *pdata;
+	guint len;  // used
+	guint size; // reserved
+} custom_growable_array;
 
-typedef struct _GPtrArray custom_growable_array;
-#define array_at_index(array,index) (array)->pdata[(index)]
+typedef void (*register_object_callback) (gpointer *arr, int size, void *callback_userdata);
+typedef void (*WorldStateChanged) ();
+typedef void *(*ReallocateArray) (void *ptr, int size, void *callback_userdata);
+
+struct _LivenessState {
+	gint first_index_in_all_objects;
+	custom_growable_array *all_objects;
+
+	MonoClass *filter;
+
+	custom_growable_array *process_array;
+	guint initial_alloc_count;
+
+	void *callback_userdata;
+
+	register_object_callback filter_callback;
+	ReallocateArray reallocateArray;
+	guint traverse_depth; // track recursion. Prevent stack overflow by limiting recurion
+};
+
+#define array_at_index(array, index) (array)->pdata[(index)]
 
 #if defined(HAVE_SGEN_GC)
-void sgen_stop_world (int generation);
-void sgen_restart_world (int generation);
+void
+sgen_stop_world (int generation);
+void
+sgen_restart_world (int generation);
 #elif defined(HAVE_BOEHM_GC)
 #ifdef HAVE_BDWGC_GC
-extern void GC_stop_world_external();
-extern void GC_start_world_external();
+extern void
+GC_stop_world_external ();
+extern void
+GC_start_world_external ();
 #else
-void GC_stop_world_external()
+void
+GC_stop_world_external ()
 {
 	g_assert_not_reached ();
 }
-void GC_start_world_external()
+void
+GC_start_world_external ()
 {
 	g_assert_not_reached ();
 }
@@ -34,67 +64,70 @@ void GC_start_world_external()
 #error need to implement liveness GC API
 #endif
 
-custom_growable_array* array_create_and_initialize (guint capacity)
+gboolean
+array_is_full (custom_growable_array *array)
 {
-	custom_growable_array* array = g_ptr_array_sized_new(capacity);
+	return array->size == array->len;
+}
+
+custom_growable_array *
+array_create (LivenessState *state, guint reserved_size)
+{
+	custom_growable_array *array = g_new0 (custom_growable_array, 1);
+
+	array->pdata = NULL;
 	array->len = 0;
-	return array;
+	array->size = 0;
+
+	if (reserved_size > 0) {
+		array->pdata = state->reallocateArray (NULL, reserved_size * sizeof (gpointer), state->callback_userdata);
+		array->size = reserved_size;
+	}
+
+	return (custom_growable_array *)array;
 }
 
-gboolean array_is_full(custom_growable_array* array)
+void
+array_destroy (LivenessState *state, custom_growable_array *array)
 {
-	return g_ptr_array_capacity(array) == array->len;
+	array->pdata = state->reallocateArray (array->pdata, 0, state->callback_userdata);
+	g_free (array);
 }
 
-void array_destroy (custom_growable_array* array)
+void
+array_push_back (custom_growable_array *array, gpointer value)
 {
-	g_ptr_array_free(array, TRUE);
-}
-
-void array_push_back(custom_growable_array* array, gpointer value)
-{
-	g_assert(!array_is_full(array));
+	g_assert (!array_is_full (array));
 	array->pdata[array->len] = value;
 	array->len++;
 }
 
-gpointer array_pop_back(custom_growable_array* array)
+gpointer
+array_pop_back (custom_growable_array *array)
 {
 	array->len--;
 	return array->pdata[array->len];
 }
 
-void array_clear(custom_growable_array* array)
+void
+array_clear (custom_growable_array *array)
 {
 	array->len = 0;
 }
 
-void array_grow(custom_growable_array* array)
+void
+array_reserve (LivenessState *state, custom_growable_array *array, guint size)
 {
-	int oldlen = array->len;
-	g_ptr_array_set_size(array, g_ptr_array_capacity(array)*2);
-	array->len = oldlen;
+	array->pdata = state->reallocateArray (array->pdata, size * sizeof (gpointer), state->callback_userdata);
+	array->size = size;
 }
 
-typedef void (*register_object_callback)(gpointer* arr, int size, void* callback_userdata);
-typedef void (*WorldStateChanged)();
-struct _LivenessState
+void
+array_grow (LivenessState *state, custom_growable_array *array)
 {
-	gint                first_index_in_all_objects;
-	custom_growable_array* all_objects;
-
-	MonoClass*          filter;
-
-	custom_growable_array* process_array;
-	guint               initial_alloc_count;
-
-	void*               callback_userdata;
-
-	register_object_callback filter_callback;
-	WorldStateChanged        onWorldStartCallback;
-	WorldStateChanged        onWorldStopCallback;
-	guint               traverse_depth; // track recursion. Prevent stack overflow by limiting recurion
-};
+	array->pdata = state->reallocateArray (array->pdata, array->size * 2 * sizeof (gpointer), state->callback_userdata);
+	array->size = array->size * 2;
+}
 
 /* number of sub elements of an array to process before recursing
  * we take a depth first approach to use stack space rather than re-allocating
@@ -106,113 +139,107 @@ const int kArrayElementsPerChunk = 256;
 const int kMaxTraverseRecursionDepth = 128;
 
 /* Liveness calculation */
-MONO_API LivenessState* mono_unity_liveness_allocate_struct (MonoClass* filter, guint max_count, register_object_callback callback, void* callback_userdata, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback);
-MONO_API void           mono_unity_liveness_stop_gc_world (LivenessState* state);
-MONO_API void           mono_unity_liveness_finalize (LivenessState* state);
-MONO_API void           mono_unity_liveness_start_gc_world (LivenessState* state);
-MONO_API void           mono_unity_liveness_free_struct (LivenessState* state);
+MONO_API LivenessState *
+mono_unity_liveness_allocate_struct (MonoClass *filter, guint max_count, register_object_callback callback, void *callback_userdata, ReallocateArray reallocateArray);
+MONO_API void
+mono_unity_liveness_stop_gc_world ();
+MONO_API void
+mono_unity_liveness_finalize (LivenessState *state);
+MONO_API void
+mono_unity_liveness_start_gc_world ();
+MONO_API void
+mono_unity_liveness_free_struct (LivenessState *state);
 
-MONO_API LivenessState* mono_unity_liveness_calculation_begin (MonoClass* filter, guint max_count, register_object_callback callback, void* callback_userdata, WorldStateChanged onStartWorldCallback, WorldStateChanged onStopWorldCallback);
-MONO_API void           mono_unity_liveness_calculation_end (LivenessState* state);
+MONO_API void
+mono_unity_liveness_calculation_from_root (MonoObject *root, LivenessState *state);
+MONO_API void
+mono_unity_liveness_calculation_from_statics (LivenessState *state);
 
-MONO_API void           mono_unity_liveness_calculation_from_root (MonoObject* root, LivenessState* state);
-MONO_API void           mono_unity_liveness_calculation_from_statics (LivenessState* state);
-
-#define MARK_OBJ(obj) \
-	do { \
-		(obj)->vtable = (MonoVTable*)(((gsize)(obj)->vtable) | (gsize)1); \
+#define MARK_OBJ(obj)                                                       \
+	do {                                                                    \
+		(obj)->vtable = (MonoVTable *)(((gsize) (obj)->vtable) | (gsize)1); \
 	} while (0)
 
-#define CLEAR_OBJ(obj) \
-	do { \
-		(obj)->vtable = (MonoVTable*)(((gsize)(obj)->vtable) & ~(gsize)1); \
+#define CLEAR_OBJ(obj)                                                       \
+	do {                                                                     \
+		(obj)->vtable = (MonoVTable *)(((gsize) (obj)->vtable) & ~(gsize)1); \
 	} while (0)
 
 #define IS_MARKED(obj) \
-	(((gsize)(obj)->vtable) & (gsize)1)
+	(((gsize) (obj)->vtable) & (gsize)1)
 
 #define GET_VTABLE(obj) \
-	((MonoVTable*)(((gsize)(obj)->vtable) & ~(gsize)1))
+	((MonoVTable *)(((gsize) (obj)->vtable) & ~(gsize)1))
 
+void
+mono_filter_objects (LivenessState *state);
 
-void mono_filter_objects(LivenessState* state);
-
-void mono_reset_state(LivenessState* state)
+void
+mono_reset_state (LivenessState *state)
 {
 	state->first_index_in_all_objects = state->all_objects->len;
-	array_clear(state->process_array);
+	array_clear (state->process_array);
 }
 
-void array_safe_grow(LivenessState* state, custom_growable_array* array)
+void
+array_safe_grow (LivenessState *state, custom_growable_array *array)
 {
-	// if all_objects run out of space, run through list
-	// clear bit in vtable, start the world, reallocate, stop the world and continue
-	int i;
-	for (i = 0; i < state->all_objects->len; i++)
-	{
-		MonoObject* object = array_at_index(state->all_objects,i);
-		CLEAR_OBJ(object);
-	}
-	mono_unity_liveness_start_gc_world(state);
-	array_grow(array);
-	mono_unity_liveness_stop_gc_world (state);
-	for (i = 0; i < state->all_objects->len; i++)
-	{
-		MonoObject* object = array_at_index(state->all_objects,i);
-		MARK_OBJ(object);
-	}
+	array_grow (state, array);
 }
 
-static gboolean should_process_value (MonoObject* val, MonoClass* filter)
+static gboolean
+should_process_value (MonoObject *val, MonoClass *filter)
 {
-	MonoClass* val_class = GET_VTABLE(val)->klass;
-	if (filter && 
+	MonoClass *val_class = GET_VTABLE (val)->klass;
+	if (filter &&
 		!mono_class_has_parent (val_class, filter))
 		return FALSE;
 
 	return TRUE;
 }
 
-static void mono_traverse_array (MonoArray* array, LivenessState* state);
-static void mono_traverse_object (MonoObject* object, LivenessState* state);
-static void mono_traverse_gc_desc (MonoObject* object, LivenessState* state);
-static void mono_traverse_objects (LivenessState* state);
+static void
+mono_traverse_array (MonoArray *array, LivenessState *state);
+static void
+mono_traverse_object (MonoObject *object, LivenessState *state);
+static void
+mono_traverse_gc_desc (MonoObject *object, LivenessState *state);
+static void
+mono_traverse_objects (LivenessState *state);
 
-static void mono_traverse_generic_object( MonoObject* object, LivenessState* state ) 
+static void
+mono_traverse_generic_object (MonoObject *object, LivenessState *state)
 {
 #ifdef HAVE_SGEN_GC
 	gsize gc_desc = 0;
 #else
-	gsize gc_desc = (gsize)(GET_VTABLE(object)->gc_descr);
+	gsize gc_desc = (gsize) (GET_VTABLE (object)->gc_descr);
 #endif
 
 	if (gc_desc & (gsize)1)
 		mono_traverse_gc_desc (object, state);
-	else if (GET_VTABLE(object)->klass->rank)
-		mono_traverse_array ((MonoArray*)object, state);
+	else if (GET_VTABLE (object)->klass->rank)
+		mono_traverse_array ((MonoArray *)object, state);
 	else
 		mono_traverse_object (object, state);
 }
 
-
-static gboolean mono_add_process_object (MonoObject* object, LivenessState* state)
+static gboolean
+mono_add_process_object (MonoObject *object, LivenessState *state)
 {
-	if (object && !IS_MARKED(object))
-	{
-		gboolean has_references = GET_VTABLE(object)->klass->has_references;
-		if(has_references || should_process_value(object,state->filter))
-		{
-			if (array_is_full(state->all_objects))
-				array_safe_grow(state, state->all_objects);
-			array_push_back(state->all_objects, object);
-			MARK_OBJ(object);
+	if (object && !IS_MARKED (object)) {
+		gboolean has_references = GET_VTABLE (object)->klass->has_references;
+		if (has_references || should_process_value (object, state->filter)) {
+			if (array_is_full (state->all_objects))
+				array_safe_grow (state, state->all_objects);
+			array_push_back (state->all_objects, object);
+			MARK_OBJ (object);
 		}
 		// Check if klass has further references - if not skip adding
-		if (has_references)
-		{
-			if(array_is_full(state->process_array))
-				array_safe_grow(state, state->process_array);
-			array_push_back(state->process_array, object);
+		if (has_references) {
+			if (array_is_full (state->process_array))
+				array_safe_grow (state, state->process_array);
+			array_push_back (state->process_array, object);
 			return TRUE;
 		}
 	}
@@ -220,18 +247,20 @@ static gboolean mono_add_process_object (MonoObject* object, LivenessState* stat
 	return FALSE;
 }
 
-static gboolean mono_field_can_contain_references(MonoClassField* field)
+static gboolean
+mono_field_can_contain_references (MonoClassField *field)
 {
-	if (MONO_TYPE_ISSTRUCT(field->type))
+	if (MONO_TYPE_ISSTRUCT (field->type))
 		return TRUE;
 	if (field->type->attrs & FIELD_ATTRIBUTE_LITERAL)
 		return FALSE;
 	if (field->type->type == MONO_TYPE_STRING)
 		return FALSE;
-	return MONO_TYPE_IS_REFERENCE(field->type);
+	return MONO_TYPE_IS_REFERENCE (field->type);
 }
 
-static gboolean mono_traverse_object_internal (MonoObject* object, gboolean isStruct, MonoClass* klass, LivenessState* state)
+static gboolean
+mono_traverse_object_internal (MonoObject *object, gboolean isStruct, MonoClass *klass, LivenessState *state)
 {
 	int i;
 	MonoClassField *field;
@@ -239,42 +268,37 @@ static gboolean mono_traverse_object_internal (MonoObject* object, gboolean isSt
 	gboolean added_objects = FALSE;
 
 	g_assert (object);
-	
+
 	// subtract the added offset for the vtable. This is added to the offset even though it is a struct
-	if(isStruct)
+	if (isStruct)
 		object--;
 
-	for (p = klass; p != NULL; p = p->parent)
-	{
+	for (p = klass; p != NULL; p = p->parent) {
 		if (p->size_inited == 0)
 			continue;
-		for (i = 0; i < mono_class_get_field_count (p); i++)
-		{
+		for (i = 0; i < mono_class_get_field_count (p); i++) {
 			field = &p->fields[i];
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 
-			if(!mono_field_can_contain_references(field))
+			if (!mono_field_can_contain_references (field))
 				continue;
 
-			if (MONO_TYPE_ISSTRUCT(field->type))
-			{
-				char* offseted = (char*)object;
+			if (MONO_TYPE_ISSTRUCT (field->type)) {
+				char *offseted = (char *)object;
 				offseted += field->offset;
-				if (field->type->type == MONO_TYPE_GENERICINST)
-				{
-					g_assert(field->type->data.generic_class->cached_class);
-					added_objects |= mono_traverse_object_internal((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, state);
-				}
-				else
-					added_objects |= mono_traverse_object_internal((MonoObject*)offseted, TRUE, field->type->data.klass, state);
+				if (field->type->type == MONO_TYPE_GENERICINST) {
+					g_assert (field->type->data.generic_class->cached_class);
+					added_objects |= mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.generic_class->cached_class, state);
+				} else
+					added_objects |= mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.klass, state);
 				continue;
 			}
 
 			if (field->offset == -1) {
 				g_assert_not_reached ();
 			} else {
-				MonoObject* val = NULL;
+				MonoObject *val = NULL;
 				MonoVTable *vtable = NULL;
 				mono_field_get_value (object, field, &val);
 				added_objects |= mono_add_process_object (val, state);
@@ -285,127 +309,119 @@ static gboolean mono_traverse_object_internal (MonoObject* object, gboolean isSt
 	return added_objects;
 }
 
-static void mono_traverse_object (MonoObject* object, LivenessState* state)
+static void
+mono_traverse_object (MonoObject *object, LivenessState *state)
 {
-	mono_traverse_object_internal (object, FALSE, GET_VTABLE(object)->klass, state);
+	mono_traverse_object_internal (object, FALSE, GET_VTABLE (object)->klass, state);
 }
 
-static void mono_traverse_gc_desc (MonoObject* object, LivenessState* state)
+static void
+mono_traverse_gc_desc (MonoObject *object, LivenessState *state)
 {
-#define WORDSIZE ((int)sizeof(gsize)*8)
+#define WORDSIZE ((int)sizeof (gsize) * 8)
 	int i = 0;
-	gsize mask = (gsize)(GET_VTABLE(object)->gc_descr);
+	gsize mask = (gsize) (GET_VTABLE (object)->gc_descr);
 
 	g_assert (mask & (gsize)1);
 
-	for (i = 0; i < WORDSIZE-2; i++)
-	{
+	for (i = 0; i < WORDSIZE - 2; i++) {
 		gsize offset = ((gsize)1 << (WORDSIZE - 1 - i));
-		if (mask & offset)
-		{
-			MonoObject* val = *(MonoObject**)(((char*)object) + i * sizeof(void*));
-			mono_add_process_object(val, state);
+		if (mask & offset) {
+			MonoObject *val = *(MonoObject **)(((char *)object) + i * sizeof (void *));
+			mono_add_process_object (val, state);
 		}
 	}
 }
 
-static void mono_traverse_objects (LivenessState* state)
+static void
+mono_traverse_objects (LivenessState *state)
 {
 	int i = 0;
-	MonoObject* object = NULL;
+	MonoObject *object = NULL;
 
 	state->traverse_depth++;
-	while (state->process_array->len > 0)
-	{
-		object = array_pop_back(state->process_array);
-		mono_traverse_generic_object(object, state);
+	while (state->process_array->len > 0) {
+		object = array_pop_back (state->process_array);
+		mono_traverse_generic_object (object, state);
 	}
 	state->traverse_depth--;
 }
 
-static gboolean should_traverse_objects (size_t index, gint32 recursion_depth)
+static gboolean
+should_traverse_objects (size_t index, gint32 recursion_depth)
 {
 	// Add kArrayElementsPerChunk objects at a time and then traverse
-	return ((index + 1) & (kArrayElementsPerChunk - 1)) == 0 && 
-		recursion_depth < kMaxTraverseRecursionDepth;
+	return ((index + 1) & (kArrayElementsPerChunk - 1)) == 0 &&
+		   recursion_depth < kMaxTraverseRecursionDepth;
 }
 
-static void mono_traverse_array (MonoArray* array, LivenessState* state)
+static void
+mono_traverse_array (MonoArray *array, LivenessState *state)
 {
 	size_t i = 0;
 	gboolean has_references;
-	MonoObject* object = (MonoObject*)array;
-	MonoClass* element_class;
+	MonoObject *object = (MonoObject *)array;
+	MonoClass *element_class;
 	size_t elementClassSize;
 	size_t array_length;
-	
+
 	g_assert (object);
-	
-	
-	
-	element_class = GET_VTABLE(object)->klass->element_class;
-	has_references = !mono_class_is_valuetype(element_class);
-	g_assert(element_class->size_inited != 0);
-	
-	for (i = 0; i < mono_class_get_field_count (element_class); i++)
-	{
-		has_references |= mono_field_can_contain_references(&element_class->fields[i]);
+
+	element_class = GET_VTABLE (object)->klass->element_class;
+	has_references = !mono_class_is_valuetype (element_class);
+	g_assert (element_class->size_inited != 0);
+
+	for (i = 0; i < mono_class_get_field_count (element_class); i++) {
+		has_references |= mono_field_can_contain_references (&element_class->fields[i]);
 	}
-	
+
 	if (!has_references)
 		return;
-	
+
 	array_length = mono_array_length (array);
-	if (element_class->valuetype)
-	{
+	if (element_class->valuetype) {
 		size_t items_processed = 0;
 		elementClassSize = mono_class_array_element_size (element_class);
-		for (i = 0; i < array_length; i++)
-		{
-			MonoObject* object = (MonoObject*)mono_array_addr_with_size (array, elementClassSize, i);
+		for (i = 0; i < array_length; i++) {
+			MonoObject *object = (MonoObject *)mono_array_addr_with_size (array, elementClassSize, i);
 			if (mono_traverse_object_internal (object, 1, element_class, state))
 				items_processed++;
-			
-			if(should_traverse_objects (items_processed, state->traverse_depth))
-				mono_traverse_objects(state);
+
+			if (should_traverse_objects (items_processed, state->traverse_depth))
+				mono_traverse_objects (state);
 		}
-	}
-	else
-	{
+	} else {
 		size_t items_processed = 0;
-		for (i = 0; i < array_length; i++)
-		{
-			MonoObject* val =  mono_array_get(array, MonoObject*, i);
+		for (i = 0; i < array_length; i++) {
+			MonoObject *val = mono_array_get (array, MonoObject *, i);
 			if (mono_add_process_object (val, state))
 				items_processed++;
-			
+
 			if (should_traverse_objects (items_processed, state->traverse_depth))
-				mono_traverse_objects(state);
+				mono_traverse_objects (state);
 		}
 	}
 }
 
-
-void mono_filter_objects(LivenessState* state)
+void
+mono_filter_objects (LivenessState *state)
 {
 	gpointer filtered_objects[64];
 	gint num_objects = 0;
 
 	int i = state->first_index_in_all_objects;
-	for ( ; i < state->all_objects->len; i++)
-	{
-		MonoObject* object = state->all_objects->pdata[i];
+	for (; i < state->all_objects->len; i++) {
+		MonoObject *object = state->all_objects->pdata[i];
 		if (should_process_value (object, state->filter))
 			filtered_objects[num_objects++] = object;
-		if (num_objects == 64)
-		{
-			state->filter_callback(filtered_objects, 64, state->callback_userdata);
+		if (num_objects == 64) {
+			state->filter_callback (filtered_objects, 64, state->callback_userdata);
 			num_objects = 0;
 		}
 	}
 
 	if (num_objects != 0)
-		state->filter_callback(filtered_objects, num_objects, state->callback_userdata);
+		state->filter_callback (filtered_objects, num_objects, state->callback_userdata);
 }
 
 /**
@@ -414,18 +430,17 @@ void mono_filter_objects(LivenessState* state)
  * Returns an array of MonoObject* that are reachable from the static roots
  * in the current domain and derive from @filter (if not NULL).
  */
-void mono_unity_liveness_calculation_from_statics(LivenessState* liveness_state)
+void
+mono_unity_liveness_calculation_from_statics (LivenessState *liveness_state)
 {
 	int i, j;
-	MonoDomain* domain = mono_domain_get();
+	MonoDomain *domain = mono_domain_get ();
 
-	mono_reset_state(liveness_state);
+	mono_reset_state (liveness_state);
 
-
-	for (i = 0; i < domain->class_vtable_array->len; ++i)
-	{
-		MonoVTable* vtable = (MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i);
-		MonoClass* klass = vtable->klass;
+	for (i = 0; i < domain->class_vtable_array->len; ++i) {
+		MonoVTable *vtable = (MonoVTable *)g_ptr_array_index (domain->class_vtable_array, i);
+		MonoClass *klass = vtable->klass;
 		MonoClassField *field;
 		if (!klass)
 			continue;
@@ -435,41 +450,33 @@ void mono_unity_liveness_calculation_from_statics(LivenessState* liveness_state)
 			continue;
 		if (klass->size_inited == 0)
 			continue;
-		for (j = 0; j < mono_class_get_field_count (klass); j++)
-		{
+		for (j = 0; j < mono_class_get_field_count (klass); j++) {
 			field = &klass->fields[j];
 			if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 				continue;
-			if(!mono_field_can_contain_references(field))
+			if (!mono_field_can_contain_references (field))
 				continue;
 			// shortcut check for special statics
 			if (field->offset == -1)
 				continue;
 
-			if (MONO_TYPE_ISSTRUCT(field->type))
-			{
-				char* offseted = (char*)mono_vtable_get_static_field_data (vtable);
+			if (MONO_TYPE_ISSTRUCT (field->type)) {
+				char *offseted = (char *)mono_vtable_get_static_field_data (vtable);
 				offseted += field->offset;
-				if (field->type->type == MONO_TYPE_GENERICINST)
-				{
-					g_assert(field->type->data.generic_class->cached_class);
-					mono_traverse_object_internal((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
+				if (field->type->type == MONO_TYPE_GENERICINST) {
+					g_assert (field->type->data.generic_class->cached_class);
+					mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
+				} else {
+					mono_traverse_object_internal ((MonoObject *)offseted, TRUE, field->type->data.klass, liveness_state);
 				}
-				else
-				{
-					mono_traverse_object_internal((MonoObject*)offseted, TRUE, field->type->data.klass, liveness_state);
-				}
-			}
-			else
-			{
+			} else {
 				MonoError error;
-				MonoObject* val = NULL;
+				MonoObject *val = NULL;
 
 				mono_field_static_get_value_checked (mono_class_vtable (domain, klass), field, &val, &error);
 
-				if (val && mono_error_ok (&error))
-				{
-					mono_add_process_object(val, liveness_state);
+				if (val && mono_error_ok (&error)) {
+					mono_add_process_object (val, liveness_state);
 				}
 				mono_error_cleanup (&error);
 			}
@@ -477,58 +484,18 @@ void mono_unity_liveness_calculation_from_statics(LivenessState* liveness_state)
 	}
 	mono_traverse_objects (liveness_state);
 	//Filter objects and call callback to register found objects
-	mono_filter_objects(liveness_state);
+	mono_filter_objects (liveness_state);
 }
 
-void mono_unity_liveness_add_object_callback(gpointer* objs, gint count, void* arr)
+void
+mono_unity_liveness_add_object_callback (gpointer *objs, gint count, void *arr)
 {
 	int i;
-	GPtrArray* objects = (GPtrArray*)arr;
-	for (i = 0; i < count; i++)
-	{
-		if (g_ptr_array_capacity(objects) > objects->len)
+	custom_growable_array *objects = (custom_growable_array *)arr;
+	for (i = 0; i < count; i++) {
+		if (objects->size > objects->len)
 			objects->pdata[objects->len++] = objs[i];
 	}
-}
-
-/**
- * mono_unity_liveness_calculation_from_statics_managed:
- *
- * Returns a gchandle to an array of MonoObject* that are reachable from the static roots
- * in the current domain and derive from type retrieved from @filter_handle (if not NULL).
- */
-gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_handle, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback)
-{
-	int i = 0;
-	MonoArray *res = NULL;
-	MonoReflectionType* filter_type = (MonoReflectionType*)mono_gchandle_get_target (GPOINTER_TO_UINT(filter_handle));
-	MonoClass* filter = NULL;
-	GPtrArray* objects = NULL;
-	LivenessState* liveness_state = NULL;
-	MonoError* error = NULL;
-
-	if (filter_type)
-		filter = mono_class_from_mono_type (filter_type->type);
-
-	objects = g_ptr_array_sized_new(1000);
-	objects->len = 0;
-
-	liveness_state = mono_unity_liveness_calculation_begin (filter, 1000, mono_unity_liveness_add_object_callback, (void*)objects, onWorldStartCallback, onWorldStopCallback);
-
-	mono_unity_liveness_calculation_from_statics (liveness_state);
-
-	mono_unity_liveness_calculation_end (liveness_state);
-
-	res = mono_array_new_checked (mono_domain_get (), filter ? filter: mono_defaults.object_class, objects->len, error);
-	for (i = 0; i < objects->len; ++i) {
-		MonoObject* o = g_ptr_array_index (objects, i);
-		mono_array_setref (res, i, o);
-	}
-	g_ptr_array_free (objects, TRUE);
-
-	
-	return (gpointer)mono_gchandle_new ((MonoObject*)res, FALSE);
-
 }
 
 /**
@@ -537,11 +504,12 @@ gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_ha
  * Returns an array of MonoObject* that are reachable from @root
  * in the current domain and derive from @filter (if not NULL).
  */
-void mono_unity_liveness_calculation_from_root (MonoObject* root, LivenessState* liveness_state)
+void
+mono_unity_liveness_calculation_from_root (MonoObject *root, LivenessState *liveness_state)
 {
 	mono_reset_state (liveness_state);
 
-	array_push_back (liveness_state->process_array,root);
+	array_push_back (liveness_state->process_array, root);
 
 	mono_traverse_objects (liveness_state);
 
@@ -549,49 +517,10 @@ void mono_unity_liveness_calculation_from_root (MonoObject* root, LivenessState*
 	mono_filter_objects (liveness_state);
 }
 
-/**
- * mono_unity_liveness_calculation_from_root_managed:
- *
- * Returns a gchandle to an array of MonoObject* that are reachable from the static roots
- * in the current domain and derive from type retrieved from @filter_handle (if not NULL).
- */
-gpointer mono_unity_liveness_calculation_from_root_managed(gpointer root_handle, gpointer filter_handle, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback)
+LivenessState *
+mono_unity_liveness_allocate_struct (MonoClass *filter, guint max_count, register_object_callback callback, void *callback_userdata, ReallocateArray reallocateArray)
 {
-	int i = 0;
-	MonoArray *res = NULL;
-	MonoReflectionType* filter_type = (MonoReflectionType*)mono_gchandle_get_target (GPOINTER_TO_UINT(filter_handle));
-	MonoObject* root = mono_gchandle_get_target (GPOINTER_TO_UINT(root_handle));
-	MonoClass* filter = NULL;
-	GPtrArray* objects = NULL;
-	LivenessState* liveness_state = NULL;
-	MonoError* error = NULL;
-
-	objects = g_ptr_array_sized_new(1000);
-	objects->len = 0;
-
-	if (filter_type)
-		filter = mono_class_from_mono_type (filter_type->type);
-
-	liveness_state = mono_unity_liveness_calculation_begin (filter, 1000, mono_unity_liveness_add_object_callback, (void*)objects, onWorldStartCallback, onWorldStopCallback);
-
-	mono_unity_liveness_calculation_from_root (root, liveness_state);
-
-	mono_unity_liveness_calculation_end (liveness_state);
-
-	res = mono_array_new_checked (mono_domain_get (), filter ? filter: mono_defaults.object_class, objects->len, error);
-	for (i = 0; i < objects->len; ++i) {
-		MonoObject* o = g_ptr_array_index (objects, i);
-		mono_array_setref (res, i, o);
-	}
-
-	g_ptr_array_free (objects, TRUE);
-
-	return (gpointer)mono_gchandle_new ((MonoObject*)res, FALSE);
-}
-
-LivenessState* mono_unity_liveness_allocate_struct (MonoClass* filter, guint max_count, register_object_callback callback, void* callback_userdata, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback)
-{
-	LivenessState* state = NULL;
+	LivenessState *state = NULL;
 
 	// construct liveness_state;
 	// allocate memory for the following structs
@@ -599,44 +528,45 @@ LivenessState* mono_unity_liveness_allocate_struct (MonoClass* filter, guint max
 	// process_array. array that contains the objcets that should be processed. this should run depth first to reduce memory usage
 	// if all_objects run out of space, run through list, add objects that match the filter, clear bit in vtable and then clear the array.
 
-	state = g_new0(LivenessState, 1);
+	state = g_new0 (LivenessState, 1);
 	max_count = max_count < 1000 ? 1000 : max_count;
-	state->all_objects = array_create_and_initialize(max_count*4);
-	state->process_array = array_create_and_initialize (max_count);
 
-	state->first_index_in_all_objects = 0; 
+	state->first_index_in_all_objects = 0;
 	state->filter = filter;
 	state->traverse_depth = 0;
 
 	state->callback_userdata = callback_userdata;
 	state->filter_callback = callback;
-	state->onWorldStartCallback = onWorldStartCallback;
-	state->onWorldStopCallback = onWorldStopCallback;
+	state->reallocateArray = reallocateArray;
+
+	state->all_objects = array_create (state, max_count * 4);
+	state->process_array = array_create (state, max_count);
 
 	return state;
 }
 
-void mono_unity_liveness_finalize (LivenessState* state)
+void
+mono_unity_liveness_finalize (LivenessState *state)
 {
 	int i;
-	for (i = 0; i < state->all_objects->len; i++)
-	{
-		MonoObject* object = g_ptr_array_index(state->all_objects,i);
-		CLEAR_OBJ(object);
+	for (i = 0; i < state->all_objects->len; i++) {
+		MonoObject *object = g_ptr_array_index (state->all_objects, i);
+		CLEAR_OBJ (object);
 	}
 }
 
-void mono_unity_liveness_free_struct (LivenessState* state)
+void
+mono_unity_liveness_free_struct (LivenessState *state)
 {
 	//cleanup the liveness_state
-	array_destroy(state->all_objects);
-	array_destroy(state->process_array);
-	g_free(state);
+	array_destroy (state, state->all_objects);
+	array_destroy (state, state->process_array);
+	g_free (state);
 }
 
-void mono_unity_liveness_stop_gc_world (LivenessState* state)
+void
+mono_unity_liveness_stop_gc_world ()
 {
-	state->onWorldStopCallback();
 #if defined(HAVE_SGEN_GC)
 	sgen_stop_world (1);
 #elif defined(HAVE_BOEHM_GC)
@@ -646,7 +576,8 @@ void mono_unity_liveness_stop_gc_world (LivenessState* state)
 #endif
 }
 
-void mono_unity_liveness_start_gc_world (LivenessState* state)
+void
+mono_unity_liveness_start_gc_world ()
 {
 #if defined(HAVE_SGEN_GC)
 	sgen_restart_world (1);
@@ -655,20 +586,4 @@ void mono_unity_liveness_start_gc_world (LivenessState* state)
 #else
 #error need to implement liveness GC API
 #endif
-	state->onWorldStartCallback();
-}
-
-LivenessState* mono_unity_liveness_calculation_begin (MonoClass* filter, guint max_count, register_object_callback callback, void* callback_userdata, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback)
-{
-	LivenessState* state = mono_unity_liveness_allocate_struct (filter, max_count, callback, callback_userdata, onWorldStartCallback, onWorldStopCallback);
-	mono_unity_liveness_stop_gc_world (state);
-	// no allocations can happen beyond this point
-	return state;
-}
-
-void mono_unity_liveness_calculation_end (LivenessState* state)
-{
-	mono_unity_liveness_finalize(state);
-	mono_unity_liveness_start_gc_world(state);
-	mono_unity_liveness_free_struct(state);
 }


### PR DESCRIPTION
This branch introduces support for multithreaded liveness checking, and uses a new block container type, that will allocate new blocks when needed, instead of reallocating a continuous array like the old implementation did. This also removes the need for starting and stopping the world, and removing the marks that has been set in the walked objects.

Release notes:
Improved:
Scripting: Asset garbage collection has been multithreaded and sped up by up to 2.5x

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
