### PR TITLE
Unity master include system store certificates in callback

### DIFF
--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -48,6 +48,13 @@ namespace Mono.Unity
 			return new UnityTlsStream (innerStream, leaveInnerStreamOpen, sslStream, settings, this);
 		}
 
+		static UnityTls.unitytls_x509verify_result x509verify_callback(void* userData, UnityTls.unitytls_x509_ref cert, UnityTls.unitytls_x509verify_result result, UnityTls.unitytls_errorstate* errorState)
+		{
+			if (userData != null)
+				UnityTls.NativeInterface.unitytls_x509list_append ((UnityTls.unitytls_x509list*)userData, cert, errorState);
+			return result;
+		}
+
 		internal override bool ValidateCertificate (
 			ICertificateValidator2 validator, string targetHost, bool serverMode,
 			X509CertificateCollection certificates, bool wantsChain, ref X509Chain chain,
@@ -85,6 +92,8 @@ namespace Mono.Unity
 			// convert cert to native or extract from unityTlsChainImpl.
 			var result = UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE;
 			UnityTls.unitytls_x509list* certificatesNative = null;
+			UnityTls.unitytls_x509list* finalCertificateChainNative = 
+				chain == null ? null : UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
 			try
 			{
 				// Things the validator provides that we might want to make use of here:
@@ -114,7 +123,8 @@ namespace Mono.Unity
 						var trustCAnativeRef = UnityTls.NativeInterface.unitytls_x509list_get_ref (trustCAnative, &errorState);
 
 						fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
-							result = UnityTls.NativeInterface.unitytls_x509verify_explicit_ca (certificatesNativeRef, trustCAnativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
+							result = UnityTls.NativeInterface.unitytls_x509verify_explicit_ca (
+								certificatesNativeRef, trustCAnativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, x509verify_callback, finalCertificateChainNative, &errorState);
 						}
 					}
 					finally {
@@ -122,12 +132,25 @@ namespace Mono.Unity
 					}
 				} else {
 					fixed (byte* targetHostUtf8Ptr = targetHostUtf8) {
-						result = UnityTls.NativeInterface.unitytls_x509verify_default_ca (certificatesNativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, null, null, &errorState);
+						result = UnityTls.NativeInterface.unitytls_x509verify_default_ca (
+							certificatesNativeRef, targetHostUtf8Ptr, (size_t)targetHostUtf8.Length, x509verify_callback, finalCertificateChainNative, &errorState);
 					}
 				}
 			}
+			catch {
+				UnityTls.NativeInterface.unitytls_x509list_free (finalCertificateChainNative);
+				throw;
+			}
 			finally	{
 				UnityTls.NativeInterface.unitytls_x509list_free (certificatesNative);
+			}
+
+			if (finalCertificateChainNative != null) {
+				chain?.Dispose();
+				chain = new X509Chain(new X509ChainImplUnityTls(
+					UnityTls.NativeInterface.unitytls_x509list_get_ref (finalCertificateChainNative, &errorState),
+					reverseOrder: true // the verify callback starts with the root and ends with the leaf. That's the opposite of chain ordering.
+				));
 			}
 
 			errors = UnityTlsConversions.VerifyResultToPolicyErrror(result);

--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -69,9 +69,6 @@ namespace Mono.Unity
 					errors |= MonoSslPolicyErrors.RemoteCertificateNotAvailable;
 					return false;
 				}
-
-				if (wantsChain)
-					chain = MNS.SystemCertificateValidator.CreateX509Chain (certificates);
 			}
 			else
 			{
@@ -92,8 +89,7 @@ namespace Mono.Unity
 			// convert cert to native or extract from unityTlsChainImpl.
 			var result = UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_NOT_DONE;
 			UnityTls.unitytls_x509list* certificatesNative = null;
-			UnityTls.unitytls_x509list* finalCertificateChainNative = 
-				chain == null ? null : UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
+			UnityTls.unitytls_x509list* finalCertificateChainNative = UnityTls.NativeInterface.unitytls_x509list_create (&errorState);
 			try
 			{
 				// Things the validator provides that we might want to make use of here:
@@ -145,13 +141,12 @@ namespace Mono.Unity
 				UnityTls.NativeInterface.unitytls_x509list_free (certificatesNative);
 			}
 
-			if (finalCertificateChainNative != null) {
-				chain?.Dispose();
-				chain = new X509Chain(new X509ChainImplUnityTls(
-					UnityTls.NativeInterface.unitytls_x509list_get_ref (finalCertificateChainNative, &errorState),
-					reverseOrder: true // the verify callback starts with the root and ends with the leaf. That's the opposite of chain ordering.
-				));
-			}
+			chain?.Dispose();
+			var chainImpl = new X509ChainImplUnityTls(
+				UnityTls.NativeInterface.unitytls_x509list_get_ref (finalCertificateChainNative, &errorState),
+				reverseOrder: true // the verify callback starts with the root and ends with the leaf. That's the opposite of chain ordering.
+			);
+			chain = new X509Chain(chainImpl);
 
 			errors = UnityTlsConversions.VerifyResultToPolicyErrror(result);
 			// There should be a status per certificate, but once again we're following closely the BTLS implementation
@@ -159,7 +154,7 @@ namespace Mono.Unity
 			// which also provides only a single status for the entire chain.
 			// It is notoriously tricky to implement in OpenSSL to get a status for all invididual certificates without finishing the handshake in the process.
 			// This is partially the reason why unitytls_x509verify_X doesn't expose it (TODO!) and likely the reason Mono's BTLS impl ignores this.
-			unityTlsChainImpl?.AddStatus(UnityTlsConversions.VerifyResultToChainStatus(result));
+			chainImpl.AddStatus(UnityTlsConversions.VerifyResultToChainStatus(result));
 			return result == UnityTls.unitytls_x509verify_result.UNITYTLS_X509VERIFY_SUCCESS && 
 					errorState.code == UnityTls.unitytls_error_code.UNITYTLS_SUCCESS;
 		}

--- a/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
@@ -47,7 +47,7 @@ namespace Mono.Unity
 					elements = new X509ChainElementCollection ();
 					UnityTls.unitytls_errorstate errorState = UnityTls.NativeInterface.unitytls_errorstate_create ();
 					var cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)0, &errorState);
-					for (int i = 0; cert.handle != UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE; ++i) {
+					for (int i = 1; cert.handle != UnityTls.NativeInterface.UNITYTLS_INVALID_HANDLE; ++i) {
 						size_t certBufferSize = UnityTls.NativeInterface.unitytls_x509_export_der (cert, null, (size_t)0, &errorState);
 						var certBuffer = new byte[(int)certBufferSize];	// Need to reallocate every time since X509Certificate constructor takes no length but only a byte array.
 						fixed(byte* certBufferPtr = certBuffer) {

--- a/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/X509ChainImplUnityTls.cs
@@ -17,11 +17,13 @@ namespace Mono.Unity
 		private UnityTls.unitytls_x509list_ref nativeCertificateChain;
 		private X509ChainPolicy policy = new X509ChainPolicy ();
 		private List<X509ChainStatus> chainStatusList;
+		private bool reverseOrder;
 
-		internal X509ChainImplUnityTls (UnityTls.unitytls_x509list_ref nativeCertificateChain)
+		internal X509ChainImplUnityTls (UnityTls.unitytls_x509list_ref nativeCertificateChain, bool reverseOrder = false)
 		{
 			this.elements = null;
 			this.nativeCertificateChain = nativeCertificateChain;
+			this.reverseOrder = reverseOrder;
 		}
 
 		public override bool IsValid {
@@ -55,6 +57,13 @@ namespace Mono.Unity
 
 						cert = UnityTls.NativeInterface.unitytls_x509list_get_x509 (nativeCertificateChain, (size_t)i, &errorState);
 					}
+				}
+
+				if (reverseOrder) {
+					var reversed = new X509ChainElementCollection ();
+					for (int i=elements.Count - 1; i>=0; --i)
+						reversed.Add(elements[i].Certificate);
+					elements = reversed;
 				}
 
 				return elements;


### PR DESCRIPTION
Fixes a long standing bug (https://fogbugz.unity3d.com/f/cases/1191987/) where we don't send the full certificate chain along the user facing certificate callbacks. Previously, we send only the certificates that we got from a server, now we also show what we found in the system certificate store to complete the chain (if any).

Also, it turned out we previously duplicated the first certificate in any callback we gave out
(see change 
https://github.com/Unity-Technologies/mono/compare/unity-master...Unity-Technologies:unity-master-include-system-store-certificates-in-callback#diff-2e1838cb4ae31f132a31ca9d9c545008cde926323e998a1f282ac9967e70f2daR50)

I have a Unity sided fix in this branch
https://github.cds.internal.unity3d.com/unity/unity/compare/trunk...tls/expand-servicecertificatevalidationcallback-test
that should land with the next mono update

Note on potential backports:
This fix https://ono.unity3d.com/unity/unity/pull-request/102527/_/tls/consistent-verify-callback is required first

Release notes

Improved:
Scripting: Certificate validation callbacks from .Net libraries pass now also previously identified root certificates along (i.e. the full validated chain if any)