### PR TITLE
Fixes for HttpUtility.UrlEncode for Unity aot and jit profiles

### DIFF
--- a/mcs/class/Facades/netstandard/Makefile
+++ b/mcs/class/Facades/netstandard/Makefile
@@ -23,9 +23,7 @@ LIB_MCS_FLAGS = $(SIGN_FLAGS) $(EXTRA_LIB_MCS_FLAGS)
 ifeq ($(PROFILE),xammac_net_4_5)
 LIB_REFS += System.Web.Services
 else ifeq (2.1, $(FRAMEWORK_VERSION))
-ifeq ($(PROFILE),unityaot)
-LIB_REFS += System.Web
-else
+ifneq ($(PROFILE),unityaot)
 LIB_REFS += System.Web.Services
 endif
 else

--- a/mcs/class/System.Web/Assembly/AssemblyInfo.cs
+++ b/mcs/class/System.Web/Assembly/AssemblyInfo.cs
@@ -139,3 +139,8 @@ using System.Web.UI;
 [assembly: WebResource ("webform.js", "text/javascript")]
 [assembly: WebResource ("WebUIValidation_2.0.js", "text/javascript")]
 #endif
+
+#if UNITY_AOT && FULL_AOT_RUNTIME
+[assembly: TypeForwardedTo (typeof (System.Web.HttpUtility))]
+[assembly: TypeForwardedTo (typeof (System.Web.Util.HttpEncoder))]
+#endif

--- a/mcs/class/System.Web/unityaot_System.Web.dll.sources
+++ b/mcs/class/System.Web/unityaot_System.Web.dll.sources
@@ -3,7 +3,3 @@ Assembly/AssemblyInfo.cs
 ../../build/common/Locale.cs
 ../../build/common/MonoTODOAttribute.cs
 ../System/System/MonoToolsLocator.cs
-
-System.Web/HttpUtility.cs
-System.Web.Util/Helpers.cs
-System.Web.Util/HttpEncoder.cs

--- a/mcs/class/System/unityaot_System.dll.sources
+++ b/mcs/class/System/unityaot_System.dll.sources
@@ -1,4 +1,7 @@
 #include mobile_System.dll.sources
+../System.Web/System.Web/HttpUtility.cs	
+../System.Web/System.Web.Util/Helpers.cs	
+../System.Web/System.Web.Util/HttpEncoder.cs
 System.CodeDom/CodeCompileUnit.cs
 System.CodeDom/CodeTypeDeclaration.cs
 


### PR DESCRIPTION
Reverting HttpUtility.UrlEncode back to the System.dll to keep
netstandard profiles smaller, especially on Android. In Unity
integration testing we found that adding System.Web to netstandard
profile brings in 4 dlls to Android APKs that were not there before.

This attempt is to leave HttpUtility in System.dll and use a type
forward in System.Web to satisfy .net 4 profile references.