### PR TITLE
[TermInfo] support new file format terminfo2 introduced with ncurses6.1

### DIFF
--- a/mcs/class/corlib/System/TermInfoReader.cs
+++ b/mcs/class/corlib/System/TermInfoReader.cs
@@ -32,7 +32,8 @@ using System.IO;
 using System.Text;
 namespace System {
 	// This class reads data from a byte array or file containing the terminfo capabilities
-	// information for any given terminal. The maximum allowed size is 4096 bytes.
+	// information for any given terminal. The maximum allowed size is 4096 (or
+	// 32768 for terminfo2) bytes.
 	//
 	// Terminfo database files are divided in the following sections:
 	//
@@ -45,7 +46,7 @@ namespace System {
 	//
 	// The header is as follows:
 	//
-	//	Magic number (0x1 and 0x1A)
+	//	Magic number (0x11A/0432 or 0x21e/01036 for terminfo2)
 	//	Terminal names size
 	//	Boolean section size
 	//	Numeric section size
@@ -58,8 +59,9 @@ namespace System {
 	// The boolean capabilities section has bytes that are set to 1 if the capability is supported
 	// and 0 otherwise. If the index of a capability is greater than the section size, 0 is assumed.
 	//
-	// The numeric capabilities section holds 2-byte integers in little endian format. No negative
-	// values are allowed and the absence of a capability is marked as two 0xFF.
+	// The numeric capabilities section holds 2-byte integers (4-byte integers for terminfo2) in
+	// little endian format. No negative values are allowed and the absence of a capability is marked
+	// as two 0xFF (four 0xFF for terminfo2).
 	//
 	// The string offsets section contains 2-byte integer offsets into the string capabilies section.
 	// If the capability is not supported, the index will be two 0xFF bytes.
@@ -72,16 +74,16 @@ namespace System {
 	//
 
 	class TermInfoReader {
-		//short nameSize;
-		short boolSize;
-		short numSize;
-		short strOffsets;
-		//short strSize;
+		int boolSize;
+		int numSize;
+		int strOffsets;
 
 		//string [] names; // Last one is the description
 		byte [] buffer;
 		int booleansOffset;
 		//string term;
+
+		int intOffset;
 
 		public TermInfoReader (string term, string filename)
 		{
@@ -114,12 +116,21 @@ namespace System {
 //			get { return term; }
 //		}
 
+		void DetermineVersion (short magic)
+		{
+			if (magic == 0x11a)
+				intOffset = 2;
+			else if (magic == 0x21e)
+				intOffset = 4;
+			else
+				throw new Exception (String.Format ("Magic number is wrong: {0}", magic));
+		}
+
 		void ReadHeader (byte [] buffer, ref int position)
 		{
 			short magic = GetInt16 (buffer, position);
 			position += 2;
-			if (magic != 282)
-				throw new Exception (String.Format ("Magic number is wrong: {0}", magic));
+			DetermineVersion (magic);
 			
 			/*nameSize =*/ GetInt16 (buffer, position);
 			position += 2;
@@ -161,8 +172,8 @@ namespace System {
 			if ((offset % 2) == 1)
 				offset++;
 
-			offset += ((int) number) * 2;
-			return GetInt16 (buffer, offset);
+			offset += ((int) number) * intOffset;
+			return GetInteger (buffer, offset);
 		}
 
 		public string Get (TermInfoStrings tstr)
@@ -175,7 +186,7 @@ namespace System {
 			if ((offset % 2) == 1)
 				offset++;
 
-			offset += numSize * 2;
+			offset += numSize * intOffset;
 			int off2 = GetInt16 (buffer, offset + (int) tstr * 2);
 			if (off2 == -1)
 				return null;
@@ -193,7 +204,7 @@ namespace System {
 			if ((offset % 2) == 1)
 				offset++;
 
-			offset += numSize * 2;
+			offset += numSize * intOffset;
 			int off2 = GetInt16 (buffer, offset + (int) tstr * 2);
 			if (off2 == -1)
 				return null;
@@ -209,6 +220,27 @@ namespace System {
 				return -1;
 
 			return (short) (uno + dos * 256);
+		}
+
+		int GetInt32 (byte [] buffer, int offset)
+		{
+			int b1 = (int) buffer [offset];
+			int b2 = (int) buffer [offset + 1];
+			int b3 = (int) buffer [offset + 2];
+			int b4 = (int) buffer [offset + 3];
+			if (b1 == 255 && b2 == 255 && b3 == 255 && b4 == 255)
+				return -1;
+
+			return b1 + b2 << 8 + b3 << 16 + b4 << 24;
+		}
+
+		int GetInteger (byte [] buffer, int offset)
+		{
+			if (intOffset == 2)
+				return GetInt16 (buffer, offset);
+			else
+				// intOffset == 4
+				return GetInt32 (buffer, offset);
 		}
 
 		string GetString (byte [] buffer, int offset)
@@ -250,4 +282,3 @@ namespace System {
 	}
 }
 #endif
-


### PR DESCRIPTION
These changes are applied from upstream Mono at https://github.com/mono/mono/pull/7308/commits/e25f5c321573b677ab9edcb88833ef40d267026c.

They correct an exception that happens on Linux like this:

```
System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.TypeInitializationException: The type initializer for 'System.ConsoleDriver' threw an exception. ---> System.Exception: Magic number is wrong: 542
  at System.TermInfoReader.ReadHeader (System.Byte[] buffer, System.Int32& position) [0x0008d] in /Users/bokken/build/output/Unity-Technologies/mono/mcs/class/corlib/System/TermInfoReader.cs:134
  at System.TermInfoReader..ctor (System.String term, System.String filename) [0x0005f] in /Users/bokken/build/output/Unity-Technologies/mono/mcs/class/corlib/System/TermInfoReader.cs:97
  at System.TermInfoDriver..ctor (System.String term) [0x00055] in /Users/bokken/build/output/Unity-Technologies/mono/mcs/class/corlib/System/TermInfoDriver.cs:164
  at System.ConsoleDriver.CreateTermInfoDriver (System.String term) [0x00000] in /Users/bokken/build/output/Unity-Technologies/mono/mcs/class/corlib/System/ConsoleDriver.cs:73
  at System.ConsoleDriver..cctor () [0x0004d] in /Users/bokken/build/output/Unity-Technologies/mono/mcs/class/corlib/System/ConsoleDriver.cs:57
```