### PR TITLE
Use the FileSystemEnumerator implementation from WinRT

### DIFF
--- a/mcs/class/corlib/win32_unityaot_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/win32_unityaot_corlib.dll.exclude.sources
@@ -1,1 +1,3 @@
 #include win32_build_corlib.dll.exclude.sources
+
+../../../external/corefx/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs

--- a/mcs/class/corlib/win32_unityaot_corlib.dll.sources
+++ b/mcs/class/corlib/win32_unityaot_corlib.dll.sources
@@ -1,1 +1,4 @@
 #include win32_build_corlib.dll.sources
+
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.GetFileInformationByHandleEx.cs
+../../../external/corefx/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs


### PR DESCRIPTION
This implementation will work on Windows, Xbox, and WinRT, since it does
not depend on ntdll.dll, which is not available on Xbox and WinRT.

So explicitly exclude the Windows implementation and include the WinRT
implementation when the unityaot-win32 profile is built.