### PR TITLE
[2020.3] For macOS arm64 setting the default to jit write protect

### DIFF
--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -216,10 +216,10 @@ static void mono_arm_restore_jit_protect_mode(jit_protect_mode* previous_jit_pro
     switch (*previous_jit_protect_mode)
     {
     case JPM_ENABLED:
+    case JPM_NONE:
         mono_arm_jit_write_protect_enable();
         break;
     case JPM_DISABLED:
-    case JPM_NONE:
     default:
         mono_arm_jit_write_protect_disable();
     }


### PR DESCRIPTION
Fixes native-to-managed callback fails with Apple Silicon (case 1305211)

When Mono is embedded and we leave a runtime method invoke we leave the thread
in a default state. Prior to this commit the default was to set the thread to jit
write mode which disables jit exec for the thread. If the thread calls a
native-to-managed callback we abort beacause of the exec protection.

This change sets the default to write disabled and execute enabled. The
thread will now be in a executable state for any potential callbacks coming
from native.