### PR TITLE
ARM64 JIT fixes for macOS

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5010,12 +5010,13 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 		}
 	}
 
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	if (fail_tramp)
 		buf = mono_method_alloc_generic_virtual_trampoline (domain, buf_len);
 	else
 		buf = mono_domain_code_reserve (domain, buf_len);
 	code = buf;
-	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/*
 	 * We are called by JITted code, which passes in the IMT argument in

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2293,8 +2293,11 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	 */
 	mono_jit_info_table_remove (domain, ji->ji);
 
-	if (destroy)
+	if (destroy) {
+		MONO_SCOPE_ENABLE_JIT_WRITE();
 		mono_code_manager_destroy (ji->code_mp);
+	}
+
 	g_free (ji);
 }
 

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -355,8 +355,8 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	guint32 size = 32;
 	MonoDomain *domain = mono_domain_get ();
 
-	start = code = mono_domain_code_reserve (domain, size);
 	MONO_SCOPE_ENABLE_JIT_WRITE();
+	start = code = mono_domain_code_reserve (domain, size);
 
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_addx_imm (code, ARMREG_R0, ARMREG_R0, sizeof (MonoObject));
@@ -374,8 +374,8 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	guint32 buf_len = 32;
 	MonoDomain *domain = mono_domain_get ();
 
-	start = code = mono_domain_code_reserve (domain, buf_len);
 	MONO_SCOPE_ENABLE_JIT_WRITE();
+	start = code = mono_domain_code_reserve (domain, buf_len);
 
 	code = mono_arm_emit_imm64 (code, MONO_ARCH_RGCTX_REG, (guint64)arg);
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);


### PR DESCRIPTION
When I finally got Apple silicon editor building, I ran into crashes in Mono. There were places that were missed in the initial port where we need to switch to writable executable memory before modifying. Generally, there were 2 patterns that weren't accounted for:

1. Allocating executable memory. It seems that when run in the editor, Mono tries to memset it to zero but it doesn't do it in the player. Perhaps it's hitting a different codeman path;
2. When freeing/finalizing executable memory it also seems to try to modify it.

I went through all the places that end up calling `mono_code_manager_reserve`/`mono_code_manager_destroy` (that I could find) and made sure that we switched to writable executable memory before calling them.

These changes allow the editor to work on Apple silicon.