### PR TITLE
[mini] Fix delegate trampoline virtual call via delgate Invoke (#18073)

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1203,7 +1203,15 @@ mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tr
 			}
 		}
 
-		if (delegate->target && 
+		if (tramp_info->method == NULL && delegate->target != NULL && method->flags & METHOD_ATTRIBUTE_VIRTUAL) {
+			/* tramp_info->method == NULL happens when someone asks us to JIT some delegate's
+			 * Invoke method (see compile_special).  In that case if method is virtual, the target
+			 * could be some derived class, so we need to find the correct override.
+			 */
+			/* FIXME: does it make sense that we get called with tramp_info for the Invoke? */
+			method = mono_object_get_virtual_method (delegate->target, method);
+			enable_caching = FALSE;
+		} else if (delegate->target &&
 			method->flags & METHOD_ATTRIBUTE_VIRTUAL && 
 			method->flags & METHOD_ATTRIBUTE_ABSTRACT &&
 			mono_class_is_abstract (method->klass)) {

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -252,6 +252,8 @@ TESTS_CS_SRC=		\
 	delegate13.cs		\
 	delegate14.cs		\
 	delegate15.cs		\
+	delegate17.cs		\
+	delegate18.cs		\
 	largeexp.cs		\
 	largeexp2.cs		\
 	marshalbyref1.cs	\

--- a/mono/tests/delegate17.cs
+++ b/mono/tests/delegate17.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+
+internal class Program
+{
+	public static int Main (string[] args)
+	{
+		// newobj Derived
+		Derived d = new Derived ();
+		// ldvirtftn Base::Foo
+		// newobj Del1::.ctor
+		Del1 b = new Del1 (d.Foo);
+		// ldftn Del1::Invoke
+		// newobj Del2::.ctor
+		Del2 f = new Del2 (b.Invoke);
+		// should call Derived.Foo not Base.Foo
+		var r = f ("abcd");
+		return r;
+	}
+}
+
+
+public delegate int Del1 (string s);
+public delegate int Del2 (string s);
+
+public class Base
+{
+	public virtual int Foo (string s)
+	{
+		Console.WriteLine ("Base.Foo called. Bad");
+		return 1;
+	}
+}
+
+public class Derived : Base
+{
+	public override int Foo (string s)
+	{
+		Console.WriteLine ("Derived.Foo called. Good");
+		return 0;
+	}
+}

--- a/mono/tests/delegate18.cs
+++ b/mono/tests/delegate18.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+
+internal class Program
+{
+	public static int Main (string[] args)
+	{
+		// newobj Derived
+		Derived d = new Derived ();
+		// ldvirtftn Base::Foo
+		// newobj Del1::.ctor
+		Del1 b = new Del1 (d.Foo);
+		var mi = typeof (Del1).GetMethod ("Invoke");
+		if (mi is null)
+			return 2;
+		// should call Derived.Foo not Base.Foo
+		var r = (int) mi.Invoke (b, new object[] {"abcd"});
+		return r;
+	}
+}
+
+
+public delegate int Del1 (string s);
+public delegate int Del2 (string s);
+
+public class Base
+{
+	public virtual int Foo (string s)
+	{
+		Console.WriteLine ("Base.Foo called. Bad");
+		return 1;
+	}
+}
+
+public class Derived : Base
+{
+	public override int Foo (string s)
+	{
+		Console.WriteLine ("Derived.Foo called. Good");
+		return 0;
+	}
+}


### PR DESCRIPTION
Upstream fix: https://github.com/mono/mono/commit/7704bd1b9260d0f6434ca02a2e7341f7c94113d8

Fixes case 1188422 (and duplicate 1317629)

Release notes:
Ensure virtual call is made when delegate target is another delegate targeting a virtual method.