### PR TITLE
After adding the concept of a pending threads join list boehm was not…

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -567,8 +567,7 @@ mono_gc_thread_detach_with_lock (MonoThreadInfo *p)
 
 	tid = mono_thread_info_get_tid (p);
 
-	if (p->runtime_thread)
-		mono_threads_add_joinable_thread ((gpointer)tid);
+	mono_threads_add_joinable_runtime_thread(p);
 
 	mono_handle_stack_free (p->handle_stack);
 	p->handle_stack = NULL;


### PR DESCRIPTION
… removing the threads from that list on detach as sgen was in sgen_client_thread_detach_with_lock. This change brings boehm in line with sgen to remove threads from the pending join list on detach to avoid waiting the full 2 seconds on runtime shutdown. (case 1295072)