### PR TITLE
Fix crash on android because on image load we were taking a codepath …

### DIFF
--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -3354,7 +3354,7 @@ mono_w32process_get_fileversion_info (const gunichar2 *filename, gpointer *data)
 	gpointer file_map;
 	gpointer versioninfo;
 	void *map_handle;
-	gint32 map_size;
+	guint32 map_size;
 	gsize datasize;
 
 	g_assert (data);

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -982,7 +982,7 @@ gboolean
 mono_pe_file_time_date_stamp (const gunichar2 *filename, guint32 *out)
 {
 	void *map_handle;
-	gint32 map_size;
+	guint32 map_size;
 	gpointer file_map = mono_pe_file_map (filename, &map_size, &map_handle);
 	if (!file_map)
 		return FALSE;
@@ -1011,12 +1011,11 @@ mono_pe_file_time_date_stamp (const gunichar2 *filename, guint32 *out)
 }
 
 gpointer
-mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle)
+mono_pe_file_map (const gunichar2 *filename, guint32 *map_size, void **handle)
 {
 	gchar *filename_ext = NULL;
 	gchar *located_filename = NULL;
-	int fd = -1;
-	struct stat statbuf;
+	guint64 fsize = 0;
 	gpointer file_map = NULL;
 	ERROR_DECL (error);
 
@@ -1041,8 +1040,8 @@ mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle)
 		goto exit;
 	}
 
-	fd = open (filename_ext, O_RDONLY, 0);
-	if (fd == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
+	MonoFileMap *filed = NULL;
+	if ((filed = mono_file_map_open (filename_ext)) == NULL && IS_PORTABILITY_SET) {
 		gint saved_errno = errno;
 
 		located_filename = mono_portability_find_file (filename_ext, TRUE);
@@ -1053,38 +1052,39 @@ mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle)
 			goto exit;
 		}
 
-		fd = open (located_filename, O_RDONLY, 0);
-		if (fd == -1) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
+		if ((filed = mono_file_map_open (located_filename)) == NULL) {
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, located_filename, strerror (errno));
 			goto exit;
 		}
 	}
-	else if (fd == -1) {
+	else if (filed == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
 		goto exit;
 	}
 
-	if (fstat (fd, &statbuf) == -1) {
+	fsize = mono_file_map_size (filed);
+	if (fsize == 0) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error stat()ing file %s: %s", __func__, filename_ext, strerror (errno));
 		goto exit;
 	}
-	*map_size = statbuf.st_size;
+	g_assert (fsize <= G_MAXUINT32);
+	*map_size = fsize;
 
 	/* Check basic file size */
-	if (statbuf.st_size < sizeof(IMAGE_DOS_HEADER)) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: File %s is too small: %" PRId64, __func__, filename_ext, (gint64) statbuf.st_size);
+	if (fsize < sizeof(IMAGE_DOS_HEADER)) {
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: File %s is too small: %" PRId64, __func__, filename_ext, fsize);
 
 		goto exit;
 	}
 
-	file_map = mono_file_map (statbuf.st_size, MONO_MMAP_READ | MONO_MMAP_PRIVATE, fd, 0, handle);
+	file_map = mono_file_map (fsize, MONO_MMAP_READ | MONO_MMAP_PRIVATE, mono_file_map_fd (filed), 0, handle);
 	if (file_map == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error mmap()int file %s: %s", __func__, filename_ext, strerror (errno));
 		goto exit;
 	}
 exit:
-	if (fd != -1)
-		close (fd);
+	if (filed)
+		mono_file_map_close (filed);
 	g_free (located_filename);
 	g_free (filename_ext);
 	return file_map;

--- a/mono/utils/mono-proclib.h
+++ b/mono/utils/mono-proclib.h
@@ -328,7 +328,7 @@ gboolean
 mono_pe_file_time_date_stamp (const gunichar2 *filename, guint32 *out);
 
 gpointer
-mono_pe_file_map (const gunichar2 *filename, gint32 *map_size, void **handle);
+mono_pe_file_map (const gunichar2 *filename, guint32 *map_size, void **handle);
 
 void
 mono_pe_file_unmap (gpointer file_map, void *handle);


### PR DESCRIPTION
…that did not respect the mmap file function wrappers which would cause a crash in the Unity runtime.

Fixes android integration test failures.