### PR TITLE
Work around UWP Windows SDK limitations

### DIFF
--- a/external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.Uap.cs
+++ b/external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.Uap.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        // Rename this method so that it does not conflict with the method of the
+        // same name for Windows Desktop. In the unityjit profile, this source
+        // file is not included in the build.
+#if UNITY_AOT && WIN_PLATFORM
+        internal static int CopyFileUWP(string src, string dst, bool failIfExists)
+#else
+        internal static int CopyFile(string src, string dst, bool failIfExists)
+#endif
+        {
+            uint copyFlags = failIfExists ? (uint)Interop.Kernel32.FileOperations.COPY_FILE_FAIL_IF_EXISTS : 0;
+            Interop.Kernel32.COPYFILE2_EXTENDED_PARAMETERS parameters = new Interop.Kernel32.COPYFILE2_EXTENDED_PARAMETERS()
+            {
+                dwSize = (uint)Marshal.SizeOf<Interop.Kernel32.COPYFILE2_EXTENDED_PARAMETERS>(),
+                dwCopyFlags = copyFlags
+            };
+
+            int hr = Interop.Kernel32.CopyFile2(src, dst, ref parameters);
+
+            return Win32Marshal.TryMakeWin32ErrorCodeFromHR(hr);
+        }
+    }
+}

--- a/external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.cs
+++ b/external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+#if UNITY_AOT && WIN_PLATFORM
+		static bool useUWPFallback = false;
+#endif
+        internal static int CopyFile(string src, string dst, bool failIfExists)
+        {
+            int copyFlags = failIfExists ? Interop.Kernel32.FileOperations.COPY_FILE_FAIL_IF_EXISTS : 0;
+            int cancel = 0;
+            // The CopyFileExW method does not exist on Windows SDK versions
+            // before 16299. This is manifested at runtime in IL2CPP as a DllNotFoundException
+            // for kernel32.dll. If this happens, fall back to a copy file implementation
+            // that does work on UWP with that SDK.
+#if UNITY_AOT && WIN_PLATFORM
+			if (useUWPFallback)
+				return CopyFileUWP(src, dst, failIfExists);
+
+            try
+            {
+#endif
+                if (!Interop.Kernel32.CopyFileEx(src, dst, IntPtr.Zero, IntPtr.Zero, ref cancel, copyFlags))
+                {
+                    return Marshal.GetLastWin32Error();
+                }
+#if UNITY_AOT && WIN_PLATFORM
+            }
+            catch(DllNotFoundException)
+            {
+				useUWPFallback = true;
+                return CopyFileUWP(src, dst, failIfExists);
+            }
+#endif
+            return Interop.Errors.ERROR_SUCCESS;
+        }
+    }
+}

--- a/external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.DeleteVolumeMountPoint.cs
+++ b/external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.DeleteVolumeMountPoint.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        /// <summary>
+        /// WARNING: This method does not implicitly handle long paths. Use DeleteVolumeMountPoint.
+        /// </summary>
+        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        internal static extern bool DeleteVolumeMountPointPrivate(string mountPoint);
+
+
+        internal static bool DeleteVolumeMountPoint(string mountPoint)
+        {
+            mountPoint = PathInternal.EnsureExtendedPrefixIfNeeded(mountPoint);
+            // The DeleteVolumeMountPointW method does not exist on Windows SDK versions
+            // before 16299. This is manifested at runtime in IL2CPP as a DllNotFoundException
+            // for kernel32.dll. If this happens, throw a proper exception, as this should not
+            // be possible for UWP apps.
+#if UNITY_AOT && WIN_PLATFORM
+            try
+            {
+#endif
+                return DeleteVolumeMountPointPrivate(mountPoint);
+#if UNITY_AOT && WIN_PLATFORM
+            }
+            catch (System.DllNotFoundException)
+            {
+                throw new System.UnauthorizedAccessException(); 
+            }
+#endif
+        }
+    }
+}

--- a/external/corefx-bugfix/src/Common/src/System/IO/DriveInfoInternal.Win32.cs
+++ b/external/corefx-bugfix/src/Common/src/System/IO/DriveInfoInternal.Win32.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text;
+
+namespace System.IO
+{
+    /// <summary>Contains internal volume helpers that are shared between many projects.</summary>
+    internal static partial class DriveInfoInternal
+    {
+        public static string[] GetLogicalDrives()
+        {
+            int drives = 0;
+            // The GetLogicalDrives method does not exist on Windows SDK versions
+            // before 16299. This is manifested at runtime in IL2CPP as a DllNotFoundException
+            // for kernel32.dll. If this happens, throw an exception.
+#if UNITY_AOT && WIN_PLATFORM
+            try
+            {
+#endif
+                drives = Interop.Kernel32.GetLogicalDrives();
+#if UNITY_AOT && WIN_PLATFORM
+            }
+            catch (System.DllNotFoundException)
+            {
+                throw new InvalidOperationException("GetLogicalDrives is not supported using this version of the Windows SDK. Use SDK versions greater than 16299.");
+            }
+#endif
+            if (drives == 0)
+                throw Win32Marshal.GetExceptionForLastWin32Error();
+
+            // GetLogicalDrives returns a bitmask starting from 
+            // position 0 "A" indicating whether a drive is present.
+            // Loop over each bit, creating a string for each one
+            // that is set.
+
+            uint d = (uint)drives;
+            int count = 0;
+            while (d != 0)
+            {
+                if (((int)d & 1) != 0) count++;
+                d >>= 1;
+            }
+
+            string[] result = new string[count];
+            char[] root = new char[] { 'A', ':', '\\' };
+            d = (uint)drives;
+            count = 0;
+            while (d != 0)
+            {
+                if (((int)d & 1) != 0)
+                {
+                    result[count++] = new string(root);
+                }
+                d >>= 1;
+                root[0]++;
+            }
+            return result;
+        }
+    }
+}

--- a/external/corefx-bugfix/src/System.IO.FileSystem/src/System/IO/DisableMediaInsertionPrompt.cs
+++ b/external/corefx-bugfix/src/System.IO.FileSystem/src/System/IO/DisableMediaInsertionPrompt.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    /// <summary>
+    /// Simple wrapper to safely disable the normal media insertion prompt for
+    /// removable media (floppies, cds, memory cards, etc.)
+    /// </summary>
+    /// <remarks>
+    /// Note that removable media file systems lazily load. After starting the OS
+    /// they won't be loaded until you have media in the drive- and as such the
+    /// prompt won't happen. You have to have had media in at least once to get
+    /// the file system to load and then have removed it.
+    /// </remarks>
+    internal struct DisableMediaInsertionPrompt : IDisposable
+    {
+        private bool _disableSuccess;
+        private uint _oldMode;
+
+#if UNITY_AOT && WIN_PLATFORM
+		static bool useUWPFallback = false;
+#endif
+
+        public static DisableMediaInsertionPrompt Create()
+        {
+            DisableMediaInsertionPrompt prompt = new DisableMediaInsertionPrompt();
+            // The SetThreadErrorMode method does not exist on Windows SDK versions
+            // before 16299. This is manifested at runtime in IL2CPP as a DllNotFoundException
+            // for kernel32.dll. If this happens, assume that there is no media insertion
+            // prompt and continue.
+#if UNITY_AOT && WIN_PLATFORM
+			if (useUWPFallback)
+			{
+				prompt._disableSuccess = false;
+				return prompt;
+			}
+
+            try
+            {
+#endif
+                prompt._disableSuccess = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out prompt._oldMode);
+#if UNITY_AOT && WIN_PLATFORM
+            }
+            catch (DllNotFoundException)
+            {
+				useUWPFallback = true;
+                prompt._disableSuccess = false;
+            }
+#endif
+            return prompt;
+        }
+
+        public void Dispose()
+        {
+            uint ignore;
+            if (_disableSuccess)
+                Interop.Kernel32.SetThreadErrorMode(_oldMode, out ignore);
+        }
+    }
+}

--- a/mcs/class/corlib/win32_build_corlib.dll.sources
+++ b/mcs/class/corlib/win32_build_corlib.dll.sources
@@ -17,7 +17,7 @@
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.FILE_TIME.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.FileAttributes.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.CreateFile.cs
-../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.cs
+../../../external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.CopyFileEx.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.DeleteFile.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.GetFileAttributesEx.cs
@@ -36,7 +36,7 @@
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.FILE_INFO_BY_HANDLE_CLASS.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.CloseHandle.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.SetFileInformationByHandle.cs
-../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.DeleteVolumeMountPoint.cs
+../../../external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.DeleteVolumeMountPoint.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.SetThreadErrorMode.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.GetLogicalDrive.cs
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.FormatMessage.cs
@@ -57,13 +57,13 @@
 ../../../external/corefx/src/Common/src/CoreLib/System/IO/Win32Marshal.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
 ../../../external/corefx/src/Common/src/CoreLib/Internal/IO/File.Windows.cs
-../../../external/corefx/src/Common/src/System/IO/DriveInfoInternal.Win32.cs
+../../../external/corefx-bugfix/src/Common/src/System/IO/DriveInfoInternal.Win32.cs
 ../../../external/corefx/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
 ../../../external/corefx/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Windows.cs
 ../../../external/corefx/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
 ../../../external/corefx/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
 ../../../external/corefx/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEntry.Windows.cs
-../../../external/corefx/src/System.IO.FileSystem/src/System/IO/DisableMediaInsertionPrompt.cs
+../../../external/corefx-bugfix/src/System.IO.FileSystem/src/System/IO/DisableMediaInsertionPrompt.cs
 
 ../../../external/corefx/src/Common/src/System/Memory/FixedBufferExtensions.cs
 

--- a/mcs/class/corlib/win32_unityaot_corlib.dll.sources
+++ b/mcs/class/corlib/win32_unityaot_corlib.dll.sources
@@ -2,3 +2,6 @@
 
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.GetFileInformationByHandleEx.cs
 ../../../external/corefx/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
+../../../external/corefx-bugfix/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile.Uap.cs
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.CopyFile2.cs
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.COPYFILE2_EXTENDED_PARAMETERS.cs


### PR DESCRIPTION
Four functions used via p/invoke in the class library code for Windows
are not present in Windows SDK versions before 16299:

* SetThreadErrorMode
* CopyFileExW
* DeleteVolumeMountPointW
* GetLogicalDrives

In IL2CPP on UWP with older Windows SDK versions, calls to these
functions will cause a `DllNotFoundException` to occur. Work around
these exceptions with alternative implementations or useful error
messages.