### PR TITLE
2021.1 : Implementing a slightly different variation of upstream's: https://gi…

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -269,6 +269,9 @@ namespace System.Net.Http
 			using (var lcts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken)) {
 				lcts.CancelAfter (timeout);
 
+				if (handler is HttpClientHandler clientHandler)
+					clientHandler.Timeout = timeout;
+
 				var task = base.SendAsync (request, lcts.Token);
 				if (task == null)
 					throw new InvalidOperationException ("Handler failed to return a value");

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -57,6 +57,7 @@ namespace System.Net.Http
 		bool sentRequest;
 		string connectionGroupName;
 		bool disposed;
+		internal TimeSpan? Timeout;
 
 		public HttpClientHandler ()
 		{
@@ -278,6 +279,9 @@ namespace System.Net.Http
 			}
 
 			wr.ServicePoint.Expect100Continue = request.Headers.ExpectContinue == true;
+
+			if (Timeout != null)
+				wr.Timeout = (int)Timeout.Value.TotalMilliseconds;
 
 			// Add request headers
 			var headers = wr.Headers;

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 {
 	public class HttpMessageInvoker : IDisposable
 	{
-		HttpMessageHandler handler;
+		protected private HttpMessageHandler handler;
 		readonly bool disposeHandler;
 		
 		public HttpMessageInvoker (HttpMessageHandler handler)


### PR DESCRIPTION
Upstream fix: a44db72

Fixes case 1313205

Release note:
Setting Timeout property on a HttpClient object will now correctly propagate the timeout value to any HttpWebRequest objects created by it for async messaging.