### PR TITLE
Stub the implementation profiles to match .NET FW 4.8

### DIFF
--- a/external/buildscripts/manifest.stevedore
+++ b/external/buildscripts/manifest.stevedore
@@ -10,7 +10,7 @@ unity-internal: android-ndk-win/r19-unity_799f451638695b9da797fcd509f9f2a8e59e35
 # macOS
 unity-internal: android-ndk-mac/r19-unity_8b169ff2a8234c85e0c5ba3c776aa94273cd3c15fdc96d213154970d87938589.7z
 unity-internal: mac-toolchain-11_0/12.2-12B5018i_351c773fb8a192039fe0f0e962314b888102b0718c734ad54f3906c0caeed1c9.zip
-unity-internal: mono-build-tools-extra/9de3c42ef81ec4f79b53e7db32d390227d8c43c4_fa9931c37b7a4ca636eb9e0e48252c4cb591caaa9b77c41b75795037868c1256.7z
+unity-internal: mono-build-tools-extra/f2f8c2c6e2674cdcac8950643c93915e2631d92e_42ec904e3fc5b604db5fc7430f4a1a3c018a4261e0362dbf3229b7a48589b691.7z
 unity-internal: cmake-linux-x64/3.20.0_a47b24f0bb16dca4fbd6974c03d5eb82e081318f5c9de75e1416db0020508579.7z
 
 # Linux

--- a/external/buildscripts/stub_classlibs.pl
+++ b/external/buildscripts/stub_classlibs.pl
@@ -15,7 +15,7 @@ my $monoroot = abs_path($monoroot);
 my $extraBuildTools = "$monoroot/external/buildscripts/artifacts/Stevedore/mono-build-tools-extra";
 
 my $profileRoot = "tmp/lib/mono";
-my $referenceProfile = "$profileRoot/4.7.1-api";
+my $referenceProfile = "$profileRoot/4.8-api";
 
 my @hostPlatforms = ("win32", "macos", "linux");
 my @compilationVariants = ("unityjit", "unityaot");
@@ -26,7 +26,7 @@ foreach my $hostPlatform(@hostPlatforms)
 	{
 		my $profileName = "$compilationVariant-$hostPlatform";
 
-		print ">>> Modifying the $profileName profile to match the .NET 4.7.1 API\n";
+		print ">>> Modifying the $profileName profile to match the .NET 4.8 API\n";
 
 		my $result = system("mono",
 							"$extraBuildTools/ProfileStubber.exe",


### PR DESCRIPTION
This includes changes to update the mono-build-tools-extra Stevedore
package so that we can pick up a new profile stubber to allow this to
work.