### PR TITLE
Don't include ArrayGet/SetGenericValue_icall in UNITY_AOT

### DIFF
--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -211,6 +211,22 @@ namespace System
 			// Do not change this to call SetGenericValue_icall directly, due to special casing in the runtime.
 			SetGenericValueImpl (index, ref item);
 		}
+		
+		#if UNITY_AOT
+		
+		// This is a replaced by an intrinsic.
+		internal void GetGenericValueImpl<T> (int pos, out T value)
+		{
+            throw new NotImplementedException("GetGenericValueImpl should be remapped to an intrinsic");
+		}
+
+		// This is a replaced by an intrinsic.
+		internal void SetGenericValueImpl<T> (int pos, ref T value)
+		{
+            throw new NotImplementedException("SetGenericValueImpl should be remapped to an intrinsic");
+		}
+		
+		#else
 
 		// CAUTION! No bounds checking!
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
@@ -233,6 +249,7 @@ namespace System
 			var self = this;
 			SetGenericValue_icall (ref self, pos, ref value);
 		}
+		#endif
 
 		internal struct InternalEnumerator<T> : IEnumerator<T>
 		{


### PR DESCRIPTION
PR https://github.com/Unity-Technologies/mono/pull/1433 to `unity-master`

GetGenericValueImpl/SetGenericValueImpl will be replaced with
intrinsics and will never be called.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
