### PR TITLE
Adjust Unity TLS minimum and maximum versions (case 1338432)

### DIFF
--- a/mcs/class/System/Mono.UnityTls/UnityTlsConversions.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsConversions.cs
@@ -23,7 +23,7 @@ namespace Mono.Unity
 				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_1;
 			if (protocols.HasFlag (SslProtocols.Tls12))
 				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;
-			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;	// Behavior as in AppleTlsContext
+			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_0;	// Use mbed tls min default
 		}
 
 		public static UnityTls.unitytls_protocol GetMaxProtocol (SslProtocols protocols)
@@ -34,7 +34,7 @@ namespace Mono.Unity
 				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_1;
 			if (protocols.HasFlag (SslProtocols.Tls))
 				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_0;
-			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_0;	// Behavior as in AppleTlsContext
+			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;	// Use mbed tls max default
 		}
 
 		public static TlsProtocols ConvertProtocolVersion(UnityTls.unitytls_protocol protocol)


### PR DESCRIPTION
With the new Mono version, corefx class libs do not use TLS default
enum any longer. By default TLS None is used. With the original code the
min would be greater than the max. That is an invalid scenario.

This change defaults the min and max to the documented mbed tls
defaults.
