### PR TITLE
Adding a missed ConfigureAwait(false) within MyGetResponseAsync (case 1338465)

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -1010,7 +1010,7 @@ namespace System.Net
 
 					WebConnection.Debug ($"HWR GET RESPONSE LOOP: Req={ID} Op={operation?.ID} {auth_state.NtlmAuthState}");
 
-					writeStream = await operation.GetRequestStreamInternal ();
+					writeStream = await operation.GetRequestStreamInternal ().ConfigureAwait (false);
 					await writeStream.WriteRequestAsync (cancellationToken).ConfigureAwait (false);
 
 					stream = await operation.GetResponseStream ();


### PR DESCRIPTION
Without this the async call invokes the UnitySynchronizationContext which is not needed and also causes incorrect behavior as it then requires the main unity thread to execute pending tasks.

Release notes:
Fixed issue in the mono web request stack where it would incorrectly wait on the Unity synchronization context for an asynchronous call to complete leading to the request being aborted on timeout.


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
