### PR TITLE
Exposing mono_unity_class_has_failure externally so Unity can use it …

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1970,3 +1970,9 @@ mono_unity_class_is_open_constructed_type (MonoClass *klass)
 {
 	return mono_class_is_open_constructed_type (m_class_get_byval_arg(klass));
 }
+
+MONO_API gboolean
+mono_unity_class_has_failure(const MonoClass* klass)
+{
+	return mono_class_has_failure(klass);
+}

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -223,4 +223,6 @@ mono_unity_get_enable_handler_block_guards (void);
 
 MONO_API gboolean mono_unity_class_is_open_constructed_type (MonoClass *klass);
 
+MONO_API gboolean mono_unity_class_has_failure (const MonoClass* klass);
+
 #endif


### PR DESCRIPTION
…to avoid loading errored classes.

The upstream fix for case 1248911 (https://github.com/mono/mono/issues/20650) introduced a way for instantiated classes to be flagged with an error. Unity's serialization system would still attempt to use these errored classes leading to a crash. Exposing this API allows Unity to check the class for the error flag before attempting to use it natively.

No release notes needed.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
