### PR TITLE
Return 0 size from mono_class_value_size when class has error (case 1339503)

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -6992,6 +6992,12 @@ mono_class_value_size (MonoClass *klass, guint32 *align)
 
 	size = mono_class_instance_size (klass) - sizeof (MonoObject);
 
+	if (mono_class_has_failure (klass)) {
+		if (align)
+			*align = 1;
+		return 0;
+	}
+
 	if (align)
 		*align = klass->min_align;
 


### PR DESCRIPTION

Returning 0 gives the runtime a better chance to recover and report the
error in the editor.

Fix case 1339503:
Scripting: Fix editor crash when a script has a never ending recursion

