### PR TITLE
Increase the buffer size for ping reply (case 1329962)

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/Ping.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Ping.cs
@@ -249,11 +249,11 @@ namespace System.Net.NetworkInformation {
 				var sw = Stopwatch.StartNew ();
 
 				// receive
-				bytes = new byte [100];
+				bytes = new byte [bytes.Length + 40];
 				do {
 					EndPoint endpoint = target;
 					SocketError error = 0;
-					int rc = s.ReceiveFrom (bytes, 0, 100, SocketFlags.None,
+					int rc = s.ReceiveFrom (bytes, 0, bytes.Length, SocketFlags.None,
 							ref endpoint, out error);
 
 					if (error != SocketError.Success) {


### PR DESCRIPTION

Avoid Windows socket error code WSAEMSGSIZE when receiving the ping
reply for larger sent payloads.

Fix case 1329962:
Scripting: Fix ".Net Ping.Send() throws NotSupportedException"
