### PR TITLE
Fix WebResponseStream CopyTo bug (case 1337986)

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -492,9 +492,10 @@ namespace System.Net
 						remaining -= r;
 						readSize += r;
 					}
+
+					readBuffer = new BufferOffsetSize (b, 0, new_size, false);
 				}
 
-				readBuffer = new BufferOffsetSize (b, 0, new_size, false);
 				totalRead = 0;
 				nextReadCalled = true;
 				completion.TrySetCompleted ();


### PR DESCRIPTION
Setting readBuffer outside of the else condition can case the internal
buffer to be set to null. This is the cause of the bug.

Fix case 1337986:
Scripting: Fix "GetResponseStream() errors when using CopyTo() method"


