### PR TITLE
pick upstream mono path for GetInterfaceMap 

### DIFF
--- a/mono/metadata/class-inlines.h
+++ b/mono/metadata/class-inlines.h
@@ -201,6 +201,29 @@ m_class_is_private (MonoClass *klass)
 }
 
 static inline gboolean
+m_method_is_static (MonoMethod *method)
+{
+	return (method->flags & METHOD_ATTRIBUTE_STATIC) != 0;
+}
+static inline gboolean
+m_method_is_virtual (MonoMethod *method)
+{
+	return (method->flags & METHOD_ATTRIBUTE_VIRTUAL) != 0;
+}
+
+static inline gboolean
+m_method_is_abstract (MonoMethod *method)
+{
+        return (method->flags & METHOD_ATTRIBUTE_ABSTRACT) != 0;
+}
+
+static inline gboolean
+m_method_is_final (MonoMethod *method)
+{
+        return (method->flags & METHOD_ATTRIBUTE_FINAL) != 0;
+}
+
+static inline gboolean
 m_method_is_icall (MonoMethod *method)
 {
 	return (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) != 0;


### PR DESCRIPTION
Don't return null target methods in GetInterfaceMap for abstract classes, or classes using DIMs (#21112)

* Don't return null target methods in GetInterfaceMap for abstract classes, or classes using DIMs

If the interface method is reabstracted, and either the found implementation
method is abstract, or the found implementation method is from another
DIM (meaning neither klass nor any of its ancestor classes implemented the
method), then say the target method is null. Otherwise return the found
implementation method, even if it is abstract.

Corresponding dotnet/runtime PR is https://github.com/dotnet/runtime/pull/53972

Fixes https://github.com/dotnet/runtime/issues/53933

* Add method flags accessors; cleanup interface map code

Ported from https://github.com/dotnet/runtime/pull/54271




