### PR TITLE
Use IsComObject icall under UNITY_AOT.

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -856,7 +856,7 @@ namespace System.Runtime.InteropServices
 			throw new PlatformNotSupportedException ();
 		}
 
-#if !MOBILE && !UNITY
+#if !MOBILE || UNITY_AOT
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		public extern static bool IsComObject (object o);
 #else


### PR DESCRIPTION
IL2CPP supports COM interop and needs a chance to handle this call.

Fixes issue in IL2CPP introduced by https://github.com/Unity-Technologies/mono/pull/1457

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Backports**
2021.2 same as original fix.

cc @UnityAlex 