### PR TITLE
Fix IsComObject check for unityjit profile.

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -856,7 +856,7 @@ namespace System.Runtime.InteropServices
 			throw new PlatformNotSupportedException ();
 		}
 
-#if !MOBILE || UNITY_AOT
+#if (!MOBILE && !UNITY) || UNITY_AOT
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		public extern static bool IsComObject (object o);
 #else


### PR DESCRIPTION
Use correct preprocessor check to cover unityjit profile for Marshal.IsComObject.

Fixes issue in IL2CPP introduced by https://github.com/Unity-Technologies/mono/pull/1469

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No

Backports
2021.2 same as original fix.