### PR TITLE
Removing Mono.Cecil and dependencies from unityjit profile. We did no…

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -440,7 +440,7 @@ xbuild_14_SUBDIRS := $(xbuild_4_0_dirs) Microsoft.NuGet.Build.Tasks
 
 unityjit_SUBDIRS := $(net_4_x_dirs)
 # TODO: Probably don't want ALL the net_4_x stuff here. Revisit.
-unityjit_PARALLEL_SUBDIRS := $(net_4_x_parallel_dirs)
+unityjit_PARALLEL_SUBDIRS := $(filter-out Mono.Cecil Mono.Cecil.Mdb Mono.Debugger.Soft Mono.CodeContracts,$(net_4_x_parallel_dirs))
 unityaot_SUBDIRS := $(mobile_common_dirs)
 unityaot_PARALLEL_SUBDIRS := $(unityaot_dirs_parallel)
 


### PR DESCRIPTION
…t include these libraries prior to the mono upgrade and should not be needed in a unity runtime context. case 1342390



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1342390 @alexthibodeau:
Mono: Fixed issue where the C# runtime profile that the Editor ran with incorrectly included Mono.Cecil and other unneeded libraries causing conflicts with user projects.


**Backports**
* 2021.2


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->