### PR TITLE
Adding null check to avoid invalid il abort [case 1353003]

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7456,7 +7456,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			sp -= n;
 
-			if (virtual_ && cmethod && sp [0]->opcode == OP_TYPED_OBJREF) {
+			if (virtual_ && cmethod && sp[0] && sp [0]->opcode == OP_TYPED_OBJREF) {
 				ERROR_DECL (error);
 
 				MonoMethod *new_cmethod = mono_class_get_virtual_method (sp [0]->klass, cmethod, FALSE, error);


### PR DESCRIPTION
Adding null check to avoid abort when invalid IL is encountered

When a callvirt instruction is encountered on a static method, there is
a hard abort/crash. This commit avoids the problem.


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No

**Release notes**

Fixed case 1353003 @bholmes:
Mono: Avoid runtime abort when JIT encounters a callvirt on a static method.


**Backports**
 - 2021.2

