### PR TITLE
2020.3 arm64 jit fixes

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5010,12 +5010,13 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 		}
 	}
 
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	if (fail_tramp)
 		buf = mono_method_alloc_generic_virtual_trampoline (domain, buf_len);
 	else
 		buf = mono_domain_code_reserve (domain, buf_len);
 	code = buf;
-	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/*
 	 * We are called by JITted code, which passes in the IMT argument in

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2293,8 +2293,11 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	 */
 	mono_jit_info_table_remove (domain, ji->ji);
 
-	if (destroy)
+	if (destroy) {
+		MONO_SCOPE_ENABLE_JIT_WRITE();
 		mono_code_manager_destroy (ji->code_mp);
+	}
+
 	g_free (ji);
 }
 

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -355,8 +355,8 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	guint32 size = 32;
 	MonoDomain *domain = mono_domain_get ();
 
-	start = code = mono_domain_code_reserve (domain, size);
 	MONO_SCOPE_ENABLE_JIT_WRITE();
+	start = code = mono_domain_code_reserve (domain, size);
 
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_addx_imm (code, ARMREG_R0, ARMREG_R0, sizeof (MonoObject));
@@ -374,8 +374,8 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	guint32 buf_len = 32;
 	MonoDomain *domain = mono_domain_get ();
 
-	start = code = mono_domain_code_reserve (domain, buf_len);
 	MONO_SCOPE_ENABLE_JIT_WRITE();
+	start = code = mono_domain_code_reserve (domain, buf_len);
 
 	code = mono_arm_emit_imm64 (code, MONO_ARCH_RGCTX_REG, (guint64)arg);
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/mono/pull/1411 to 2020.3 branch

People have been complaining about building source code locally on Apple silicon machine crashes Mono: https://unity.slack.com/archives/C016JSJMFUG/p1620849277335100?thread_ts=1620844419.331800&cid=C016JSJMFUG

Backporting this PR so people who use Apple silicon machines for daily work could backport fixes to 2020.3.