### PR TITLE
Removing call to automake's bootstrap script that used to be required…

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -412,12 +412,6 @@ if ($build)
 			my $automakeMakeFlags = "";
 			print(">>> Installing automake from $automakeDir\n");
 			chdir("$automakeDir") eq 1 or die ("failed to chdir to automake directory\n");
-			if($windowsSubsystemForLinux)
-			{
-				#Windows subsystem needs to run bootstrap, and make needs to be run with -i due to one doc failing to build
-				system("./bootstrap") eq 0 or die ("failed to bootstrap automake\n");
-				$automakeMakeFlags = "-i";
-			}
 			system("./configure --prefix=$builtToolsDir") eq 0 or die ("failed to configure automake\n");
 			system("make $automakeMakeFlags") eq 0 or die ("failed to make automake\n");
 			system("make install");


### PR DESCRIPTION
… when building on wsl1. In wsl2 this causes a permission error to be thrown.

It is possible that this will cause building the classlibs on wsl1 will no longer work with this change.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->