### PR TITLE
Fix CultureInfo implementation when running as UWP application.

### DIFF
--- a/mcs/class/corlib/Mono.Interop/MonoPInvokeCallbackAttribute.cs
+++ b/mcs/class/corlib/Mono.Interop/MonoPInvokeCallbackAttribute.cs
@@ -1,0 +1,33 @@
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+
+namespace Mono.Interop
+{
+	// Internal in order to not conflict with other definitions
+	[AttributeUsage (AttributeTargets.Method)]
+	internal sealed class MonoPInvokeCallbackAttribute : Attribute
+	{
+		public MonoPInvokeCallbackAttribute (Type t)
+		{
+		}
+	}
+}

--- a/mcs/class/corlib/System.Globalization/CultureInfo.cs
+++ b/mcs/class/corlib/System.Globalization/CultureInfo.cs
@@ -30,6 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Mono.Interop;
 using System.Collections.Generic;
 using System.Threading;
 using System.Runtime.CompilerServices;
@@ -1123,6 +1124,39 @@ namespace System.Globalization
 			}
 		}
 
+		static CultureInfo s_UserPreferredCultureInfoInAppX;
+
+		delegate void OnCultureInfoChangedDelegate ([MarshalAs(UnmanagedType.LPWStr)] string language);
+
+		[DllImport("__Internal")]
+		static extern void InitializeUserPreferredCultureInfoInAppX (OnCultureInfoChangedDelegate onCultureInfoChangedInAppX);
+
+		[DllImport("__Internal")]
+		static extern void SetUserPreferredCultureInfoInAppX ([MarshalAs(UnmanagedType.LPWStr)] string name);
+
+		[MonoPInvokeCallback (typeof(OnCultureInfoChangedDelegate))]
+		static void OnCultureInfoChangedInAppX ([MarshalAs(UnmanagedType.LPWStr)] string language)
+		{
+			if (language != null) {
+				s_UserPreferredCultureInfoInAppX = new CultureInfo(language);
+			} else {
+				s_UserPreferredCultureInfoInAppX = null;
+			}
+		}
+
+		internal static CultureInfo GetCultureInfoForUserPreferredLanguageInAppX ()
+		{
+			if (s_UserPreferredCultureInfoInAppX == null)
+				InitializeUserPreferredCultureInfoInAppX (OnCultureInfoChangedInAppX);
+
+			return s_UserPreferredCultureInfoInAppX;
+		}
+
+		internal static void SetCultureInfoForUserPreferredLanguageInAppX (CultureInfo cultureInfo)
+		{
+			SetUserPreferredCultureInfoInAppX (cultureInfo.Name);
+			s_UserPreferredCultureInfoInAppX = cultureInfo;
+		}
 
 #region reference sources
 		// TODO:

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -41,6 +41,7 @@ Mono/DataConverter.cs
 Mono.Interop/ComInteropProxy.cs
 Mono.Interop/IDispatch.cs
 Mono.Interop/IUnknown.cs
+Mono.Interop/MonoPInvokeCallbackAttribute.cs
 ../Mono.Security/Mono.Math/BigInteger.cs
 ../Mono.Security/Mono.Math.Prime/ConfidenceFactor.cs
 ../Mono.Security/Mono.Math.Prime/PrimalityTests.cs

--- a/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs
@@ -18,6 +18,8 @@ namespace System.Threading
 {    
 #if !MONO
     using Microsoft.Win32.SafeHandles;
+#else
+    using Mono.Interop;
 #endif
     using System.Security.Permissions;
     using System.Runtime.InteropServices;
@@ -436,14 +438,6 @@ namespace System.Threading
 				Exception.ReportUnhandledException(e);
 			}
         }
-
-		[AttributeUsage (AttributeTargets.Method)]
-		sealed class MonoPInvokeCallbackAttribute : Attribute
-		{
-			public MonoPInvokeCallbackAttribute(Type t)
-            {
-			}
-		}
 
         class InvocationContext
         {

--- a/mcs/class/referencesource/mscorlib/system/threading/thread.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/thread.cs
@@ -1209,12 +1209,11 @@ namespace System.Threading {
         public CultureInfo CurrentUICulture {
             get {
                 Contract.Ensures(Contract.Result<CultureInfo>() != null);
-#if FEATURE_APPX
+
                 if(AppDomain.IsAppXModel()) {
                     return CultureInfo.GetCultureInfoForUserPreferredLanguageInAppX() ?? GetCurrentUICultureNoAppX();
                 } 
                 else 
-#endif
                 {
                     return GetCurrentUICultureNoAppX();
                 }
@@ -1236,6 +1235,12 @@ namespace System.Threading {
 
                 // If you add more pre-conditions to this method, check to see if you also need to 
                 // add them to CultureInfo.DefaultThreadCurrentUICulture.set.
+
+                if (AppDomain.IsAppXModel ())
+                {
+                    CultureInfo.SetCultureInfoForUserPreferredLanguageInAppX (value);
+                    return;
+                }
 
 #if FEATURE_LEAK_CULTURE_INFO
                 if (nativeSetThreadUILocale(value.SortName) == false)
@@ -1335,12 +1340,10 @@ namespace System.Threading {
             get {
                 Contract.Ensures(Contract.Result<CultureInfo>() != null);
 
-#if FEATURE_APPX
                 if(AppDomain.IsAppXModel()) {
                     return CultureInfo.GetCultureInfoForUserPreferredLanguageInAppX() ?? GetCurrentCultureNoAppX();
                 } 
                 else 
-#endif
                 {
                     return GetCurrentCultureNoAppX();
                 }
@@ -1358,6 +1361,12 @@ namespace System.Threading {
 
                 // If you add more pre-conditions to this method, check to see if you also need to 
                 // add them to CultureInfo.DefaultThreadCurrentCulture.set.
+
+                if (AppDomain.IsAppXModel ())
+                {
+                    CultureInfo.SetCultureInfoForUserPreferredLanguageInAppX (value);
+                    return;
+                }
 
 #if FEATURE_LEAK_CULTURE_INFO
                 //If we can't set the nativeThreadLocale, we'll just let it stay


### PR DESCRIPTION
This PR implements proper CultureInfo.CurrentCulture and CultureInfo.CurrentUICulture handling on UWP. It should be reviewed in tandem with the IL2CPP PR 3224.