### PR TITLE
Ignore inherit param for ParameterInfo.GetCustomAttributes

### DIFF
--- a/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
@@ -192,14 +192,20 @@ namespace System.Reflection
 		override
 		object[] GetCustomAttributes (bool inherit)
 		{
-			return MonoCustomAttrs.GetCustomAttributes (this, inherit);
+			// It is documented that the inherit flag is ignored.
+			// Attribute.GetCustomAttributes is to be used to search
+			// inheritance chain.
+			return MonoCustomAttrs.GetCustomAttributes (this, false);
 		}
 
 		public
 		override
 		object[] GetCustomAttributes (Type attributeType, bool inherit)
 		{
-			return MonoCustomAttrs.GetCustomAttributes (this, attributeType, inherit);
+			// It is documented that the inherit flag is ignored.
+			// Attribute.GetCustomAttributes is to be used to search
+			// inheritance chain.
+			return MonoCustomAttrs.GetCustomAttributes (this, attributeType, false);
 		}
 
 		internal object GetDefaultValueImpl (ParameterInfo pinfo)

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -183,9 +183,6 @@ namespace System
 			if (inherit && GetBase (obj) == null)
 				inherit = false;
 
-			if (obj is RuntimeParameterInfo)
-				inherit = false;
-
 			// if AttributeType is sealed, and Inherited is set to false, then 
 			// there's no use in scanning base types 
 			if ((attributeType != null && attributeType.IsSealed) && inherit) {


### PR DESCRIPTION
Adjust the recent change in the Unity version of Mono to address the inherit bug
uncovered with the mono upgrade. This commit matches that patch that was applied
to upstream dotnet and mono.


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No


**Release notes**

Internal @bholmes:
Mono: Ignore inherit param for ParameterInfo.GetCustomAttributes.

**Backports**

 - 2021.2

**Upstream Changes**

 - [dotnet](https://github.com/dotnet/runtime/pull/57769)
 - [mono](https://github.com/mono/mono/pull/21200)