### PR TITLE
Fixing memory leak that occurred when crash reporter v2 was introduce…

### DIFF
--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -671,13 +671,16 @@ find_method (MonoMethod *method, MonoDomain *domain, MonoDebugMethodJitInfo *jit
 MonoDebugMethodJitInfo *
 mono_debug_find_method (MonoMethod *method, MonoDomain *domain)
 {
-	MonoDebugMethodJitInfo *res = g_new0 (MonoDebugMethodJitInfo, 1);
-
 	if (mono_debug_format == MONO_DEBUG_FORMAT_NONE)
 		return NULL;
 
+	MonoDebugMethodJitInfo* res = g_new0(MonoDebugMethodJitInfo, 1);
 	mono_debugger_lock ();
-	find_method (method, domain, res);
+	if (!find_method(method, domain, res))
+	{
+		g_free(res);
+		res = NULL;
+	}
 	mono_debugger_unlock ();
 	return res;
 }


### PR DESCRIPTION
…d. (case 1358413)



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal case 1358413 @alexthibodeau:
Mono: Fixed memory leak on usages of mono_debug_find_method where it was unable to find the method requested.

Other options: Internal, Changed, Improved, Feature. 


**Backports**
2021.2

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->