### PR TITLE
Remove System.Runtime.CompilerServices.Unsafe.dll from unity profiles 

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -439,10 +439,9 @@ xbuild_12_SUBDIRS := $(xbuild_4_0_dirs)
 xbuild_14_SUBDIRS := $(xbuild_4_0_dirs) Microsoft.NuGet.Build.Tasks
 
 unityjit_SUBDIRS := $(net_4_x_dirs)
-# TODO: Probably don't want ALL the net_4_x stuff here. Revisit.
-unityjit_PARALLEL_SUBDIRS := $(filter-out Mono.Cecil Mono.Cecil.Mdb Mono.Debugger.Soft Mono.CodeContracts,$(net_4_x_parallel_dirs))
+unityjit_PARALLEL_SUBDIRS := $(filter-out Mono.Cecil Mono.Cecil.Mdb Mono.Debugger.Soft Mono.CodeContracts System.Runtime.CompilerServices.Unsafe,$(net_4_x_parallel_dirs))
 unityaot_SUBDIRS := $(mobile_common_dirs)
-unityaot_PARALLEL_SUBDIRS := $(unityaot_dirs_parallel)
+unityaot_PARALLEL_SUBDIRS := $(filter-out System.Runtime.CompilerServices.Unsafe,$(unityaot_dirs_parallel))
 
 winaot_SUBDIRS := $(mobile_common_dirs)
 winaot_PARALLEL_SUBDIRS := $(winaot_dirs_parallel)


### PR DESCRIPTION
To avoid potential conflicts with user provided versions of this
dll we are removing it from the jit and aot profiles.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1360423 @bholmes:
Mono: Remove System.Runtime.CompilerServices.Unsafe.dll from unity profiles.


**Backports**
 - 2021.2
