### PR TITLE
Adding Brotli compression for Windows

### DIFF
--- a/mcs/class/System.IO.Compression/corefx/Interop.Libraries.cs
+++ b/mcs/class/System.IO.Compression/corefx/Interop.Libraries.cs
@@ -6,6 +6,10 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
+#if WIN_PLATFORM
+        internal const string CompressionNative = "__Internal";
+#else
         internal const string CompressionNative = "System.Native";
+#endif
     }
 }

--- a/msvc/clrcompression.targets
+++ b/msvc/clrcompression.targets
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="clrcompression">
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\dictionary.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\bit_reader.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\decode.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\huffman.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\state.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references_hq.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\bit_cost.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_splitter.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\brotli_bit_stream.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\cluster.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment_two_pass.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\dictionary_hash.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\encode.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\entropy_encode.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\histogram.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\literal_cost.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\memory.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\metablock.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\static_dict.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\utf8_util.c">
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DLLEXPORT=__declspec(dllexport);BROTLI_SHARED_COMPILATION</PreprocessorDefinitions>
+    </ClCompile>
+
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\constants.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\dictionary.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\version.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\bit_reader.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\context.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\huffman.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\port.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\prefix.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\state.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\transform.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references_hq.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\bit_cost.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\bit_cost_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_encoder_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_splitter.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_splitter_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\brotli_bit_stream.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\cluster.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\cluster_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\command.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment_two_pass.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\context.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\dictionary_hash.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\entropy_encode.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\entropy_encode_static.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\fast_log.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\find_match_length.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_forgetful_chain_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_longest_match64_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_longest_match_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_longest_match_quickly_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_to_binary_tree_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\histogram.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\histogram_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\literal_cost.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\memory.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\metablock.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\metablock_inc.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\port.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\prefix.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\quality.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\ringbuffer.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\static_dict.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\static_dict_lut.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\utf8_util.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\write_bits.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\decode.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\encode.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\port.h"/>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\types.h"/>
+
+  </ItemGroup>
+</Project>

--- a/msvc/clrcompression.targets.filters
+++ b/msvc/clrcompression.targets.filters
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="clrcompression">
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\dictionary.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\bit_reader.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\decode.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\huffman.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\state.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references_hq.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\bit_cost.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_splitter.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\brotli_bit_stream.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\cluster.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment_two_pass.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\dictionary_hash.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\encode.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\entropy_encode.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\histogram.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\literal_cost.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\memory.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\metablock.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\static_dict.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\utf8_util.c">
+      <Filter>Source Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClCompile>
+
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\constants.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\dictionary.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\common\version.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\bit_reader.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\context.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\huffman.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\port.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\prefix.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\state.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\dec\transform.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references_hq.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\backward_references_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\bit_cost.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\bit_cost_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_encoder_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_splitter.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\block_splitter_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\brotli_bit_stream.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\cluster.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\cluster_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\command.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\compress_fragment_two_pass.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\context.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\dictionary_hash.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\entropy_encode.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\entropy_encode_static.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\fast_log.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\find_match_length.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_forgetful_chain_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_longest_match64_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_longest_match_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_longest_match_quickly_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\hash_to_binary_tree_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\histogram.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\histogram_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\literal_cost.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\memory.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\metablock.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\metablock_inc.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\port.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\prefix.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\quality.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\ringbuffer.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\static_dict.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\static_dict_lut.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\utf8_util.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\enc\write_bits.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\decode.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\encode.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\port.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\external\corefx\src\Native\AnyOS\brotli\include\brotli\types.h">
+      <Filter>Header Files$(ClrCompressionFilterSubFolder)</Filter>
+    </ClInclude>
+
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Header Files$(ClrCompressionFilterSubFolder)">
+      <UniqueIdentifier>{073fa345-f2f5-4e48-9db5-b15cf0898229}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files$(ClrCompressionFilterSubFolder)">
+      <UniqueIdentifier>{68FFDDD6-2E04-4EE2-BA8C-9798618A6CC9}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/msvc/libmono-dynamic.vcxproj
+++ b/msvc/libmono-dynamic.vcxproj
@@ -217,6 +217,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-windows-dllmain.c" />
     <ClCompile Include="..\mono\metadata\oop.c" />
   </ItemGroup>
+  <Import Project="clrcompression.targets" />
   <Import Project="eglib.targets" />
   <Import Project="libmonoutils.targets" />
   <Import Project="libmonoruntime.targets" />

--- a/msvc/libmono-dynamic.vcxproj.filters
+++ b/msvc/libmono-dynamic.vcxproj.filters
@@ -6,7 +6,9 @@
     <MonoMiniFilterSubFolder>\libmini</MonoMiniFilterSubFolder>
     <MonoGCsgenFilterSubFolder>\libgcmonosgen</MonoGCsgenFilterSubFolder>
     <EGLibFilterSubFolder>\eglib</EGLibFilterSubFolder>
+    <ClrCompressionFilterSubFolder>\clrcompression</ClrCompressionFilterSubFolder>
   </PropertyGroup>
+  <Import Project="clrcompression.targets.filters" />
   <Import Project="eglib.targets.filters" />
   <Import Project="libmonoutils.targets.filters" />
   <Import Project="libmonoruntime.targets.filters" />


### PR DESCRIPTION
The required native methods will be compiled into the mono-bdwgc and
mono-sgen dlls.

Changing the dll name for PInvokes targeting Brotli on Windows to __Internal so the
calls will get picked up by the mono.dll.


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Feature @bholmes:
Mono: Enable Brotli compression for Windows with the Mono runtime.


**Backports**

 - 2021.2
