### PR TITLE
Fixing padding issue around explicit sized structs

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -924,7 +924,7 @@ void
 mono_classes_cleanup (void);
 
 void
-mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, gboolean sre);
+mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, int real_size, gboolean sre);
 
 void
 mono_class_setup_interface_offsets (MonoClass *klass);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2059,11 +2059,9 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 
 			instance_size = MAX (real_size, instance_size);
        
-			if (!((layout == TYPE_ATTRIBUTE_EXPLICIT_LAYOUT) && explicit_size)) {
-				if (instance_size & (min_align - 1)) {
-					instance_size += min_align - 1;
-					instance_size &= ~(min_align - 1);
-				}
+			if (instance_size & (min_align - 1)) {
+				instance_size += min_align - 1;
+				instance_size &= ~(min_align - 1);
 			}
 		}
 		break;
@@ -2150,9 +2148,11 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		}
 
 		instance_size = MAX (real_size, instance_size);
-		if (instance_size & (min_align - 1)) {
-			instance_size += min_align - 1;
-			instance_size &= ~(min_align - 1);
+		if (!((layout == TYPE_ATTRIBUTE_EXPLICIT_LAYOUT) && explicit_size)) {
+			if (instance_size & (min_align - 1)) {
+				instance_size += min_align - 1;
+				instance_size &= ~(min_align - 1);
+			}
 		}
 		break;
 	}

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1657,7 +1657,7 @@ mono_class_setup_fields (MonoClass *klass)
 
 	if (!mono_class_has_failure (klass)) {
 		mono_loader_lock ();
-		mono_class_layout_fields (klass, instance_size, packing_size, FALSE);
+		mono_class_layout_fields (klass, instance_size, packing_size, real_size, FALSE);
 		mono_loader_unlock ();
 	}
 
@@ -1828,7 +1828,7 @@ mono_class_is_gparam_with_nonblittable_parent (MonoClass *klass)
  * LOCKING: Acquires the loader lock
  */
 void
-mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, gboolean sre)
+mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, int explicit_size, gboolean sre)
 {
 	int i;
 	const int top = mono_class_get_field_count (klass);
@@ -2059,9 +2059,11 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 
 			instance_size = MAX (real_size, instance_size);
        
-			if (instance_size & (min_align - 1)) {
-				instance_size += min_align - 1;
-				instance_size &= ~(min_align - 1);
+			if (!((layout == TYPE_ATTRIBUTE_EXPLICIT_LAYOUT) && explicit_size)) {
+				if (instance_size & (min_align - 1)) {
+					instance_size += min_align - 1;
+					instance_size &= ~(min_align - 1);
+				}
 			}
 		}
 		break;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3495,7 +3495,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 	}
 
 	if (!mono_class_has_failure (klass)) {
-		mono_class_layout_fields (klass, instance_size, packing_size, TRUE);
+		mono_class_layout_fields (klass, instance_size, packing_size, tb->class_size, TRUE);
 	}
 }
 


### PR DESCRIPTION
This PR brings in some changes that fixes a pretty nasty bug we were seeing in Unity Transport and this pattern is used in many places within unity. 

https://github.com/mono/mono/commit/6b58f1317732b9cbf6ec61921e76d7d48e362104
https://bugzilla.xamarin.com/60/60298/bug.html

Example of issue: 

```
  [StructLayout(LayoutKind.Explicit, Size = Length)]
  public unsafe struct UdpCHeader
  {
      [Flags]
      public enum HeaderFlags : byte
      {
          HasConnectToken = 0x1,
          HasPipeline = 0x2
      }

      public const int Length = 10;
      [FieldOffset(0)] public fixed byte Data[Length];
      [FieldOffset(0)] public ulong SessionToken;
      [FieldOffset(8)] public byte Type;
      [FieldOffset(9)] public HeaderFlags Flags;
  }
```

This code reports back when printing out sizeof (UdpCHeader) 16 instead of 10 on 2020.3 because of this bug. This is already fixed in 2021/2022

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Improved: @andrews-unity :
Mono: Avoid padding classes/structs with an explicit size
