### PR TITLE
Initial ephemeron support for Boehm.

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/ConditionalWeakTableTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/ConditionalWeakTableTest.cs
@@ -195,8 +195,6 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Test]
 	[Category ("MultiThreaded")]
 	public void Reachability () {
-		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			Assert.Ignore ("Not working on Boehm.");
 		var cwt = new ConditionalWeakTable <object,object> ();
 		List<object> keepAlive = null;
 		List<WeakReference> keys = null;
@@ -245,8 +243,6 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Test]
 	[Category ("MultiThreaded")]
 	public void InsertStress () {
-		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			Assert.Ignore ("Not working on Boehm.");
 		var cwt = new ConditionalWeakTable <object,object> ();
 
 		var a = new object ();
@@ -295,8 +291,6 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Category ("MultiThreaded")]
 	[Category ("NotWorkingRuntimeInterpreter")] // Flaky due to false pinning
 	public void OldGenStress () {
-		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			Assert.Ignore ("Not working on Boehm.");
 		var cwt = new ConditionalWeakTable <object,object>[1];
 		List<object> k = null;
 		List<WeakReference> res, res2;
@@ -439,8 +433,6 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Category ("MultiThreaded")]
 	public void FinalizableObjectsThatRetainDeadKeys ()
 	{
-		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			Assert.Ignore ("Not working on Boehm.");
 		lock (_lock1) { 
 			var cwt = new ConditionalWeakTable <object,object> ();
 			FinalizerHelpers.PerformNoPinAction (() => { FillWithFinalizable (cwt); });
@@ -461,8 +453,6 @@ namespace MonoTests.System.Runtime.CompilerServices {
 	[Category("WASM")] //This test takes forever under WASM due to over allocating
 	public void OldGenKeysMakeNewGenObjectsReachable ()
 	{
-		if (GC.MaxGeneration == 0) /*Boehm doesn't handle ephemerons */
-			Assert.Ignore ("Not working on Boehm.");
 		ConditionalWeakTable<object, Val> table = new ConditionalWeakTable<object, Val>();
 		List<Key> keys = new List<Key>();
 

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2256,7 +2256,13 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		klass->instance_size = instance_size;
 	}
 	klass->blittable = blittable;
-	klass->has_references = has_references;
+	/* An Ephemeron cannot be marked by Boehm */
+	/* See SGen equivalent code in compute_class_bitmap */
+	if (!mono_gc_is_moving() && m_class_get_image (klass) == mono_defaults.corlib && !strcmp ("Ephemeron", m_class_get_name (klass))) {
+		klass->has_references = FALSE;
+	} else {
+		klass->has_references = has_references;
+	}
 	klass->packing_size = packing_size;
 	klass->min_align = min_align;
 	for (i = 0; i < top; ++i) {


### PR DESCRIPTION
This will also require similar changes in IL2CPP.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1338754 @joncham:
Mono: Implement support for ConditionalWeakTable which fixes memory a leak.

**Backports**
2019.4, 2020.3, 2021.1, 2021.2
