### PR TITLE
Heap validation second attempt

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -883,36 +883,39 @@ mono_gc_free_fixed (void* addr)
 	GC_FREE (addr);
 }
 
-// static int counter = 0;
-// static int validate_frequency = 0;
-// static UnityHeapVerifierCallback unity_heap_validation_callback;
+#ifdef HEAP_VALIDATION_FREQUENCY
+static int counter = 0;
+static int validate_frequency = 0;
+static UnityHeapVerifierCallback unity_heap_validation_callback;
 
-// void
-// mono_gc_set_heap_validate_frequency (int freq)
-// {
-// 	if (freq >= 0 && freq != validate_frequency)
-// 		validate_frequency = freq;
-// }
+void
+mono_gc_set_heap_validate_frequency (int freq)
+{
+	if (freq >= 0 && freq != validate_frequency)
+		validate_frequency = freq;
+}
 
-// void
-// mono_gc_set_heap_verifier_callback (UnityHeapVerifierCallback callback)
-// {
-// 	unity_heap_validation_callback = callback;
-// }
+void
+mono_gc_set_heap_verifier_callback (UnityHeapVerifierCallback callback)
+{
+	unity_heap_validation_callback = callback;
+}
+#endif
 
 MonoObject*
 mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj;
 
-	// INTERNAL DEV NOTE: As this is a hotpath function we only want this to exist when we know we need it.
-	// if (unity_heap_validation_callback && validate_frequency > 0 && (++counter % validate_frequency) == 0)
-	// {
-	// 	mono_gc_handle_lock();
-	// 	unity_heap_validation_callback();
-	// 	mono_gc_handle_unlock();
-	// 	counter = 0;
-	// }
+#ifdef HEAP_VALIDATION_FREQUENCY
+	if (unity_heap_validation_callback && validate_frequency > 0 && (++counter % validate_frequency) == 0)
+	{
+		mono_gc_handle_lock();
+		unity_heap_validation_callback();
+		mono_gc_handle_unlock();
+		counter = 0;
+	}
+#endif
 
 	if (!m_class_has_references (vtable->klass)) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -883,38 +883,36 @@ mono_gc_free_fixed (void* addr)
 	GC_FREE (addr);
 }
 
-static int validate_heap = 0;
-static int counter = 0;
-static int validate_frequency = 100;
-static UnityHeapVerifierCallback unity_heap_validation_callback;
+// static int counter = 0;
+// static int validate_frequency = 0;
+// static UnityHeapVerifierCallback unity_heap_validation_callback;
 
-void
-mono_gc_set_heap_verifier (gboolean enabled)
-{
-	g_message("heap verifier is now: %d", enabled);
-	validate_heap = enabled;
-}
+// void
+// mono_gc_set_heap_validate_frequency (int freq)
+// {
+// 	if (freq >= 0 && freq != validate_frequency)
+// 		validate_frequency = freq;
+// }
 
-void
-mono_gc_set_heap_verifier_callback(UnityHeapVerifierCallback callback)
-{
-	unity_heap_validation_callback = callback;
-}
+// void
+// mono_gc_set_heap_verifier_callback (UnityHeapVerifierCallback callback)
+// {
+// 	unity_heap_validation_callback = callback;
+// }
 
 MonoObject*
 mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj;
 
-	if (unity_heap_validation_callback && validate_heap && (counter++ % validate_frequency) == 0)
-	{
-		ves_icall_System_GC_WaitForPendingFinalizers();
-		mono_gc_handle_lock();
-		GC_stop_world_external();
-		unity_heap_validation_callback();
-		GC_start_world_external();
-		mono_gc_handle_unlock();
-	}
+	// INTERNAL DEV NOTE: As this is a hotpath function we only want this to exist when we know we need it.
+	// if (unity_heap_validation_callback && validate_frequency > 0 && (++counter % validate_frequency) == 0)
+	// {
+	// 	mono_gc_handle_lock();
+	// 	unity_heap_validation_callback();
+	// 	mono_gc_handle_unlock();
+	// 	counter = 0;
+	// }
 
 	if (!m_class_has_references (vtable->klass)) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -887,6 +887,13 @@ static int validate_heap = 0;
 static int counter = 0;
 static int validate_frequency = 100;
 
+void
+mono_gc_set_heap_verifier (gboolean enabled)
+{
+	g_message("heap verifier is now: %d", enabled);
+	validate_heap = enabled;
+}
+
 extern void mono_unity_heap_validation ();
 
 MonoObject*

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -891,7 +891,7 @@ static UnityHeapVerifierCallback unity_heap_validation_callback;
 void
 mono_gc_set_heap_validate_frequency (int freq)
 {
-	if (freq >= 0 && freq != validate_frequency)
+	if (freq >= 0)
 		validate_frequency = freq;
 }
 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -188,9 +188,9 @@ void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);
 /* Signal early termination of finalizer processing inside the gc */
 void  mono_gc_suspend_finalizers (void);
-MONO_API void  mono_gc_set_heap_verifier (gboolean enabled);
-typedef void (*UnityHeapVerifierCallback)();
-MONO_API void mono_gc_set_heap_verifier_callback(UnityHeapVerifierCallback callback);
+// typedef void (*UnityHeapVerifierCallback)();
+// MONO_API void mono_gc_set_heap_verifier_callback(UnityHeapVerifierCallback callback);
+// MONO_API void mono_gc_set_heap_validate_frequency(int freq);
 
 
 /* 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -188,6 +188,7 @@ void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);
 /* Signal early termination of finalizer processing inside the gc */
 void  mono_gc_suspend_finalizers (void);
+MONO_API void  mono_gc_set_heap_verifier (gboolean enabled);
 
 
 /* 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -188,9 +188,11 @@ void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);
 /* Signal early termination of finalizer processing inside the gc */
 void  mono_gc_suspend_finalizers (void);
-// typedef void (*UnityHeapVerifierCallback)();
-// MONO_API void mono_gc_set_heap_verifier_callback(UnityHeapVerifierCallback callback);
-// MONO_API void mono_gc_set_heap_validate_frequency(int freq);
+#ifdef HEAP_VALIDATION_FREQUENCY
+typedef void (*UnityHeapVerifierCallback)();
+MONO_API void mono_gc_set_heap_verifier_callback(UnityHeapVerifierCallback callback);
+MONO_API void mono_gc_set_heap_validate_frequency(int freq);
+#endif
 
 
 /* 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -189,6 +189,8 @@ void  mono_gc_clear_domain (MonoDomain * domain);
 /* Signal early termination of finalizer processing inside the gc */
 void  mono_gc_suspend_finalizers (void);
 MONO_API void  mono_gc_set_heap_verifier (gboolean enabled);
+typedef void (*UnityHeapVerifierCallback)();
+MONO_API void mono_gc_set_heap_verifier_callback(UnityHeapVerifierCallback callback);
 
 
 /* 

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -692,8 +692,10 @@ void gchandle_process(void *data, void *user_data)
 	mono_add_and_validate_object(target, liveness_state);
 }
 
+#if HAVE_BOEHM_GC
 extern void
 mono_gc_strong_handle_foreach(GFunc func, gpointer user_data);
+#endif
 
 static void
 foreach_thread_static_field (gpointer key, gpointer value, gpointer user_data)
@@ -730,7 +732,11 @@ void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
 
 	mono_reset_state(liveness_state);
 
+#if HAVE_BOEHM_GC
 	mono_gc_strong_handle_foreach(gchandle_process, liveness_state);
+#else
+	g_assert_not_reached();
+#endif
 
 	g_hash_table_foreach(domain->special_static_fields, foreach_thread_static_field, liveness_state);
 

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -282,8 +282,7 @@ static gboolean mono_add_process_object(MonoObject *object, LivenessState *state
 static gboolean mono_add_and_validate_object(MonoObject *object, LivenessState *state)
 {
 	// TODO: validate object is good first...
-	if (object)
-	{
+	if (object) {
 		void* vtable = NULL;
 		__try {
 			vtable = *(void**)(object);
@@ -293,8 +292,7 @@ static gboolean mono_add_and_validate_object(MonoObject *object, LivenessState *
 			vtable = NULL;
 		}
 
-		if (vtable == NULL)
-		{
+		if (vtable == NULL) {
 			DebugBreak();
 		}
 
@@ -303,19 +301,16 @@ static gboolean mono_add_and_validate_object(MonoObject *object, LivenessState *
 		//	DebugBreak();
 		//}
 
-		if (!IS_MARKED(object))
-		{
+		if (!IS_MARKED(object)) {
 			gboolean has_references = GET_VTABLE(object)->klass->has_references;
-			if (has_references || should_process_value(object, state->filter))
-			{
+			if (has_references || should_process_value(object, state->filter)) {
 				if (array_is_full(state->all_objects))
 					array_safe_grow(state, state->all_objects);
 				array_push_back(state->all_objects, object);
 				MARK_OBJ(object);
 			}
 			// Check if klass has further references - if not skip adding
-			if (has_references)
-			{
+			if (has_references) {
 				if (array_is_full(state->process_array))
 					array_safe_grow(state, state->process_array);
 				array_push_back(state->process_array, object);
@@ -351,10 +346,12 @@ static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStr
 	if (isStruct)
 		object--;
 
-	for (p = klass; p != NULL; p = p->parent) {
+	for (p = klass; p != NULL; p = p->parent)
+	{
 		if (p->size_inited == 0)
 			continue;
-		for (i = 0; i < mono_class_get_field_count(p); i++) {
+		for (i = 0; i < mono_class_get_field_count(p); i++)
+		{
 			field = &p->fields[i];
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
@@ -479,7 +476,8 @@ static void mono_traverse_gc_desc(MonoObject *object, LivenessState *state)
 
 	g_assert(mask & (gsize)1);
 
-	for (i = 0; i < WORDSIZE - 2; i++) {
+	for (i = 0; i < WORDSIZE - 2; i++)
+	{
 		gsize offset = ((gsize)1 << (WORDSIZE - 1 - i));
 		if (mask & offset) {
 			MonoObject *val = *(MonoObject **)(((char *)object) + i * sizeof(void *));
@@ -494,7 +492,8 @@ static void mono_traverse_objects(LivenessState *state)
 	MonoObject *object = NULL;
 
 	state->traverse_depth++;
-	while (!block_array_is_empty(state->process_array)) {
+	while (!block_array_is_empty(state->process_array))
+	{
 		object = block_array_pop_back(state->process_array);
 		mono_traverse_generic_object(object, state);
 	}
@@ -537,7 +536,8 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 	has_references = !m_class_is_valuetype(element_class);
 	g_assert(element_class->size_inited != 0);
 
-	for (i = 0; i < mono_class_get_field_count(element_class); i++) {
+	for (i = 0; i < mono_class_get_field_count(element_class); i++)
+	{
 		has_references |= mono_field_can_contain_references(&element_class->fields[i]);
 	}
 
@@ -548,7 +548,8 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 	if (element_class->valuetype) {
 		size_t items_processed = 0;
 		elementClassSize = mono_class_array_element_size(element_class);
-		for (i = 0; i < array_length; i++) {
+		for (i = 0; i < array_length; i++)
+		{
 			MonoObject *object = (MonoObject *)mono_array_addr_with_size_internal(array, elementClassSize, i);
 			if (mono_traverse_object_internal(object, 1, element_class, state))
 				items_processed++;
@@ -559,7 +560,8 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 	}
 	else {
 		size_t items_processed = 0;
-		for (i = 0; i < array_length; i++) {
+		for (i = 0; i < array_length; i++)
+		{
 			MonoObject *val = mono_array_get(array, MonoObject *, i);
 			if (mono_add_process_object(val, state))
 				items_processed++;
@@ -596,12 +598,10 @@ static void mono_validate_array(MonoArray *array, LivenessState *state)
 		return;
 
 	array_length = mono_array_length(array);
-	if (element_class->valuetype)
-	{
+	if (element_class->valuetype) {
 		size_t items_processed = 0;
 		elementClassSize = mono_class_array_element_size(element_class);
-		for (i = 0; i < array_length; i++)
-		{
+		for (i = 0; i < array_length; i++) {
 			MonoObject *object = (MonoObject*)mono_array_addr_with_size(array, elementClassSize, i);
 			if (mono_validate_object_internal(object, 1, element_class, state))
 				items_processed++;
@@ -610,8 +610,7 @@ static void mono_validate_array(MonoArray *array, LivenessState *state)
 				mono_traverse_and_validate_objects(state);
 		}
 	}
-	else
-	{
+	else {
 		size_t items_processed = 0;
 		for (i = 0; i < array_length; i++)
 		{
@@ -633,7 +632,8 @@ void mono_filter_objects(LivenessState *state)
 	gint num_objects = 0;
 
 	gpointer value = block_array_next(state->all_objects);
-	while (value != NULL) {
+	while (value != NULL)
+	{
 		MonoObject *object = value;
 		if (should_process_value(object, state->filter))
 			filtered_objects[num_objects++] = object;
@@ -662,7 +662,8 @@ void mono_unity_liveness_calculation_from_statics(LivenessState *liveness_state)
 
 	mono_reset_state(liveness_state);
 
-	for (i = 0; i < memory_manager->class_vtable_array->len; ++i) {
+	for (i = 0; i < memory_manager->class_vtable_array->len; ++i)
+	{
 		MonoVTable *vtable = (MonoVTable *)g_ptr_array_index(memory_manager->class_vtable_array, i);
 		MonoClass *klass = vtable->klass;
 		MonoClassField *field;
@@ -748,6 +749,33 @@ void gchandle_process(void *data, void *user_data)
 extern void
 mono_gc_strong_handle_foreach(GFunc func, gpointer user_data);
 
+static void
+foreach_thread_static_field (gpointer key, gpointer value, gpointer user_data)
+{
+	MonoClassField *field = key;
+	guint32 offset = GPOINTER_TO_UINT(value);
+	LivenessState *liveness_state = user_data;
+
+	if (!mono_field_can_contain_references(field))
+		return;
+	// TODO
+	if (MONO_TYPE_ISSTRUCT(field->type))
+		return;
+
+	MonoInternalThread *thread;
+
+	thread = mono_thread_internal_current();
+
+	gpointer data = mono_get_special_static_data_for_thread(thread, offset);
+
+	MonoObject *val = *(MonoObject**)data;
+
+	if (val) {
+		mono_add_and_validate_object(val, liveness_state);
+		validate_object_value(val, field->type);
+	}
+}
+
 void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
 {
 	int i, j;
@@ -756,6 +784,8 @@ void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
 	mono_reset_state(liveness_state);
 
 	mono_gc_strong_handle_foreach(gchandle_process, liveness_state);
+
+	g_hash_table_foreach(domain->special_static_fields, foreach_thread_static_field, liveness_state);
 
 	for (i = 0; i < domain->class_vtable_array->len; ++i)
 	{
@@ -781,31 +811,26 @@ void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
 			if (field->offset == -1)
 				continue;
 
-			if (MONO_TYPE_ISSTRUCT(field->type))
-			{
+			if (MONO_TYPE_ISSTRUCT(field->type)) {
 				char* offseted = (char*)mono_vtable_get_static_field_data(vtable);
 				offseted += field->offset;
-				if (field->type->type == MONO_TYPE_GENERICINST)
-				{
+				if (field->type->type == MONO_TYPE_GENERICINST) {
 					g_assert(field->type->data.generic_class->cached_class);
 					mono_validate_object_internal((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
 				}
-				else
-				{
+				else {
 					mono_validate_object_internal((MonoObject*)offseted, TRUE, field->type->data.klass, liveness_state);
 				}
 			}
-			else
-			{
+			else {
 				MonoError error;
 				MonoObject* val = NULL;
 
 				mono_field_static_get_value_checked(mono_class_vtable(domain, klass), field, &val, &error);
 
 				if (val && mono_error_ok(&error))
-				{
 					mono_add_and_validate_object(val, liveness_state);
-				}
+
 				mono_error_cleanup(&error);
 			}
 		}
@@ -862,7 +887,8 @@ void mono_unity_liveness_finalize(LivenessState *state)
 {
 	block_array_reset_iterator(state->all_objects);
 	gpointer it = block_array_next(state->all_objects);
-	while (it != NULL) {
+	while (it != NULL)
+	{
 		MonoObject *object = it;
 		CLEAR_OBJ(object);
 		it = block_array_next(state->all_objects);

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -200,6 +200,8 @@ static gboolean should_process_value(MonoObject *val, MonoClass *filter)
 
 static void mono_traverse_array(MonoArray *array, LivenessState *state);
 static void mono_traverse_object(MonoObject *object, LivenessState *state);
+static void mono_validate_array(MonoArray *array, LivenessState *state);
+static void mono_validate_object(MonoObject *object, LivenessState *state);
 static void mono_traverse_gc_desc(MonoObject *object, LivenessState *state);
 static void mono_traverse_objects(LivenessState *state);
 
@@ -219,6 +221,22 @@ static void mono_traverse_generic_object(MonoObject *object, LivenessState *stat
 		mono_traverse_object(object, state);
 }
 
+static void mono_traverse_and_validate_generic_object(MonoObject *object, LivenessState *state)
+{
+#ifdef HAVE_SGEN_GC
+	gsize gc_desc = 0;
+#else
+	gsize gc_desc = (gsize)(GET_VTABLE(object)->gc_descr);
+#endif
+
+	/*if (gc_desc & (gsize)1)
+		mono_traverse_gc_desc(object, state);
+	else */if (GET_VTABLE(object)->klass->rank)
+		mono_validate_array((MonoArray*)object, state);
+	else
+		mono_validate_object(object, state);
+}
+
 static gboolean mono_add_process_object(MonoObject *object, LivenessState *state)
 {
 	if (object && !IS_MARKED(object)) {
@@ -231,6 +249,54 @@ static gboolean mono_add_process_object(MonoObject *object, LivenessState *state
 		if (has_references) {
 			block_array_push_back(state->process_array, object, state);
 			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+static gboolean mono_add_and_validate_object(MonoObject *object, LivenessState *state)
+{
+	// TODO: validate object is good first...
+	if (object)
+	{
+		void* vtable = NULL;
+		__try {
+			vtable = *(void**)(object);
+		}
+		__except(1) {
+
+			vtable = NULL;
+		}
+
+		if (vtable == NULL)
+		{
+			DebugBreak();
+		}
+
+		//if (!GC_is_marked(object))
+		//{
+		//	DebugBreak();
+		//}
+
+		if (!IS_MARKED(object))
+		{
+			gboolean has_references = GET_VTABLE(object)->klass->has_references;
+			if (has_references || should_process_value(object, state->filter))
+			{
+				if (array_is_full(state->all_objects))
+					array_safe_grow(state, state->all_objects);
+				array_push_back(state->all_objects, object);
+				MARK_OBJ(object);
+			}
+			// Check if klass has further references - if not skip adding
+			if (has_references)
+			{
+				if (array_is_full(state->process_array))
+					array_safe_grow(state, state->process_array);
+				array_push_back(state->process_array, object);
+				return TRUE;
+			}
 		}
 	}
 
@@ -299,9 +365,69 @@ static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStr
 	return added_objects;
 }
 
+static gboolean mono_validate_object_internal(MonoObject *object, gboolean isStruct, MonoClass *klass, LivenessState *state)
+{
+	int i;
+	MonoClassField* field;
+	MonoClass* p;
+	gboolean added_objects = FALSE;
+
+	g_assert (object);
+
+	// subtract the added offset for the vtable. This is added to the offset even though it is a struct
+	if (isStruct)
+		object--;
+
+	for (p = klass; p != NULL; p = p->parent)
+	{
+		if (p->size_inited == 0)
+			continue;
+		for (i = 0; i < mono_class_get_field_count(p); i++)
+		{
+			field = &p->fields[i];
+			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
+				continue;
+
+			if (!mono_field_can_contain_references(field))
+				continue;
+
+			if (MONO_TYPE_ISSTRUCT(field->type))
+			{
+				char* offseted = (char*)object;
+				offseted += field->offset;
+				if (field->type->type == MONO_TYPE_GENERICINST)
+				{
+					g_assert (field->type->data.generic_class->cached_class);
+					added_objects |= mono_validate_object_internal((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, state);
+				}
+				else
+					added_objects |= mono_validate_object_internal((MonoObject*)offseted, TRUE, field->type->data.klass, state);
+				continue;
+			}
+
+			if (field->offset == -1) {
+				g_assert_not_reached();
+			}
+			else {
+				MonoObject* val = NULL;
+				MonoVTable* vtable = NULL;
+				mono_field_get_value(object, field, &val);
+				added_objects |= mono_add_and_validate_object(val, state);
+			}
+		}
+	}
+
+	return added_objects;
+}
+
 static void mono_traverse_object(MonoObject *object, LivenessState *state)
 {
 	mono_traverse_object_internal(object, FALSE, GET_VTABLE(object)->klass, state);
+}
+
+static void mono_validate_object(MonoObject *object, LivenessState *state)
+{
+	mono_validate_object_internal(object, FALSE, GET_VTABLE(object)->klass, state);
 }
 
 static void mono_traverse_gc_desc(MonoObject *object, LivenessState *state)
@@ -330,6 +456,20 @@ static void mono_traverse_objects(LivenessState *state)
 	while (!block_array_is_empty(state->process_array)) {
 		object = block_array_pop_back(state->process_array);
 		mono_traverse_generic_object(object, state);
+	}
+	state->traverse_depth--;
+}
+
+static void mono_traverse_and_validate_objects(LivenessState *state)
+{
+	int i = 0;
+	MonoObject* object = NULL;
+
+	state->traverse_depth++;
+	while (state->process_array->len > 0)
+	{
+		object = array_pop_back(state->process_array);
+		mono_traverse_and_validate_generic_object(object, state);
 	}
 	state->traverse_depth--;
 }
@@ -385,6 +525,61 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 
 			if (should_traverse_objects(items_processed, state->traverse_depth))
 				mono_traverse_objects(state);
+		}
+	}
+}
+
+static void mono_validate_array(MonoArray *array, LivenessState *state)
+{
+	size_t i = 0;
+	gboolean has_references;
+	MonoObject *object = (MonoObject*)array;
+	MonoClass *element_class;
+	size_t elementClassSize;
+	size_t array_length;
+
+	g_assert(object);
+
+
+
+	element_class = GET_VTABLE(object)->klass->element_class;
+	has_references = !mono_class_is_valuetype(element_class);
+	g_assert(element_class->size_inited != 0);
+
+	for (i = 0; i < mono_class_get_field_count(element_class); i++)
+	{
+		has_references |= mono_field_can_contain_references(&element_class->fields[i]);
+	}
+
+	if (!has_references)
+		return;
+
+	array_length = mono_array_length(array);
+	if (element_class->valuetype)
+	{
+		size_t items_processed = 0;
+		elementClassSize = mono_class_array_element_size(element_class);
+		for (i = 0; i < array_length; i++)
+		{
+			MonoObject *object = (MonoObject*)mono_array_addr_with_size(array, elementClassSize, i);
+			if (mono_validate_object_internal(object, 1, element_class, state))
+				items_processed++;
+
+			if (should_traverse_objects(items_processed, state->traverse_depth))
+				mono_traverse_and_validate_objects(state);
+		}
+	}
+	else
+	{
+		size_t items_processed = 0;
+		for (i = 0; i < array_length; i++)
+		{
+			MonoObject *val = mono_array_get(array, MonoObject*, i);
+			if (mono_add_and_validate_object(val, state))
+				items_processed++;
+
+			if (should_traverse_objects (items_processed, state->traverse_depth))
+				mono_traverse_and_validate_objects(state);
 		}
 	}
 }
@@ -469,6 +664,114 @@ void mono_unity_liveness_calculation_from_statics(LivenessState *liveness_state)
 	mono_filter_objects(liveness_state);
 }
 
+void mono_unity_heap_validation_from_statics(LivenessState *liveness_state);
+extern void mono_gc_handle_lock();
+extern void mono_gc_handle_unlock();
+MONO_API void mono_unity_heap_validation()
+{
+
+	// int i = 0;
+	// MonoArray* res = NULL;
+	// GPtrArray* objects = NULL;
+	// LivenessState* liveness_state = NULL;
+	// MonoError* error = NULL;
+
+	// objects = g_ptr_array_sized_new (100000);
+	// objects->len = 0;
+
+	// mono_gc_handle_lock ();
+
+	// //liveness_state = mono_unity_liveness_calculation_begin (NULL, 100000, mono_unity_liveness_add_object_callback, (void*)objects, NULL, NULL);
+
+	// mono_unity_heap_validation_from_statics (liveness_state);
+
+	// //mono_unity_liveness_calculation_end (liveness_state);
+
+	// mono_gc_handle_unlock ();
+
+	// g_ptr_array_free (objects, TRUE);
+
+	/// I DON'T KNOW HOW TO DO THIS YET FIXMEEEEEE
+}
+
+void gchandle_process(void *data, void *user_data)
+{
+	MonoObject *target = data;
+	LivenessState *liveness_state = user_data;
+
+	mono_add_and_validate_object(target, liveness_state);
+}
+
+extern void
+mono_gc_strong_handle_foreach(GFunc func, gpointer user_data);
+
+void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
+{
+	int i, j;
+	MonoDomain *domain = mono_domain_get();
+
+	mono_reset_state(liveness_state);
+
+	mono_gc_strong_handle_foreach(gchandle_process, liveness_state);
+
+	for (i = 0; i < domain->class_vtable_array->len; ++i)
+	{
+		MonoVTable *vtable = (MonoVTable*)g_ptr_array_index(domain->class_vtable_array, i);
+		MonoClass *klass = vtable->klass;
+		MonoClassField *field;
+		if (!klass)
+			continue;
+		if (!klass->has_static_refs)
+			continue;
+		if (klass->image == mono_defaults.corlib)
+			continue;
+		if (klass->size_inited == 0)
+			continue;
+		for (j = 0; j < mono_class_get_field_count(klass); j++)
+		{
+			field = &klass->fields[j];
+			if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+				continue;
+			if (!mono_field_can_contain_references(field))
+				continue;
+			// shortcut check for special statics
+			if (field->offset == -1)
+				continue;
+
+			if (MONO_TYPE_ISSTRUCT(field->type))
+			{
+				char* offseted = (char*)mono_vtable_get_static_field_data(vtable);
+				offseted += field->offset;
+				if (field->type->type == MONO_TYPE_GENERICINST)
+				{
+					g_assert(field->type->data.generic_class->cached_class);
+					mono_validate_object_internal((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
+				}
+				else
+				{
+					mono_validate_object_internal((MonoObject*)offseted, TRUE, field->type->data.klass, liveness_state);
+				}
+			}
+			else
+			{
+				MonoError error;
+				MonoObject* val = NULL;
+
+				mono_field_static_get_value_checked(mono_class_vtable(domain, klass), field, &val, &error);
+
+				if (val && mono_error_ok(&error))
+				{
+					mono_add_and_validate_object(val, liveness_state);
+				}
+				mono_error_cleanup(&error);
+			}
+		}
+	}
+	mono_traverse_and_validate_objects(liveness_state);
+	//Filter objects and call callback to register found objects
+	//mono_filter_objects (liveness_state);
+}
+
 /**
  * mono_unity_liveness_calculation_from_root:
  *
@@ -530,3 +833,4 @@ void mono_unity_liveness_free_struct(LivenessState *state)
 	block_array_destroy(state->process_array, state);
 	g_free(state);
 }
+

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -230,9 +230,7 @@ static void mono_traverse_and_validate_generic_object(MonoObject *object, Livene
 	gsize gc_desc = (gsize)(GET_VTABLE(object)->gc_descr);
 #endif
 
-	/*if (gc_desc & (gsize)1)
-		mono_traverse_gc_desc(object, state);
-	else */if (GET_VTABLE(object)->klass->rank)
+	if (GET_VTABLE(object)->klass->rank)
 		mono_validate_array((MonoArray*)object, state);
 	else
 		mono_validate_object(object, state);
@@ -245,10 +243,8 @@ static void validate_object_value(MonoObject *val, MonoType *storageType)
 		MonoClass *valClass = GET_VTABLE(val)->klass;
 		if (mono_class_is_interface(storageClass)) {
 			int found = 0;
-			for (int i = 0; i < valClass->interface_offsets_count; ++i)
-			{
-				if (valClass->interfaces_packed[i] == storageClass)
-				{
+			for (int i = 0; i < valClass->interface_offsets_count; ++i) {
+				if (valClass->interfaces_packed[i] == storageClass) {
 					found = TRUE;
 					break;
 				}
@@ -357,12 +353,10 @@ static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStr
 	if (isStruct)
 		object--;
 
-	for (p = klass; p != NULL; p = p->parent)
-	{
+	for (p = klass; p != NULL; p = p->parent) {
 		if (p->size_inited == 0)
 			continue;
-		for (i = 0; i < mono_class_get_field_count(p); i++)
-		{
+		for (i = 0; i < mono_class_get_field_count(p); i++) {
 			field = &p->fields[i];
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
@@ -390,7 +384,6 @@ static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStr
 				MonoVTable *vtable = NULL;
 				mono_field_get_value_internal(object, field, &val);
 				added_objects |= mono_add_process_object(val, state);
-				validate_object_value(val, field->type);
 			}
 		}
 	}
@@ -411,12 +404,10 @@ static gboolean mono_validate_object_internal(MonoObject *object, gboolean isStr
 	if (isStruct)
 		object--;
 
-	for (p = klass; p != NULL; p = p->parent)
-	{
+	for (p = klass; p != NULL; p = p->parent) {
 		if (p->size_inited == 0)
 			continue;
-		for (i = 0; i < mono_class_get_field_count(p); i++)
-		{
+		for (i = 0; i < mono_class_get_field_count(p); i++) {
 			field = &p->fields[i];
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
@@ -424,8 +415,7 @@ static gboolean mono_validate_object_internal(MonoObject *object, gboolean isStr
 			if (!mono_field_can_contain_references(field))
 				continue;
 
-			if (MONO_TYPE_ISSTRUCT(field->type))
-			{
+			if (MONO_TYPE_ISSTRUCT(field->type)) {
 				char* offseted = (char*)object;
 				offseted += field->offset;
 				if (field->type->type == MONO_TYPE_GENERICINST)
@@ -482,8 +472,7 @@ static void mono_traverse_gc_desc(MonoObject *object, LivenessState *state)
 
 	g_assert(mask & (gsize)1);
 
-	for (i = 0; i < WORDSIZE - 2; i++)
-	{
+	for (i = 0; i < WORDSIZE - 2; i++) {
 		gsize offset = ((gsize)1 << (WORDSIZE - 1 - i));
 		if (mask & offset) {
 			MonoObject *val = *(MonoObject **)(((char *)object) + i * sizeof(void *));
@@ -498,8 +487,7 @@ static void mono_traverse_objects(LivenessState *state)
 	MonoObject *object = NULL;
 
 	state->traverse_depth++;
-	while (!block_array_is_empty(state->process_array))
-	{
+	while (!block_array_is_empty(state->process_array)) {
 		object = block_array_pop_back(state->process_array);
 		mono_traverse_generic_object(object, state);
 	}
@@ -541,8 +529,7 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 	has_references = !m_class_is_valuetype(element_class);
 	g_assert(element_class->size_inited != 0);
 
-	for (i = 0; i < mono_class_get_field_count(element_class); i++)
-	{
+	for (i = 0; i < mono_class_get_field_count(element_class); i++)	{
 		has_references |= mono_field_can_contain_references(&element_class->fields[i]);
 	}
 
@@ -553,8 +540,7 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 	if (element_class->valuetype) {
 		size_t items_processed = 0;
 		elementClassSize = mono_class_array_element_size(element_class);
-		for (i = 0; i < array_length; i++)
-		{
+		for (i = 0; i < array_length; i++) {
 			MonoObject *object = (MonoObject *)mono_array_addr_with_size_internal(array, elementClassSize, i);
 			if (mono_traverse_object_internal(object, 1, element_class, state))
 				items_processed++;
@@ -565,8 +551,7 @@ static void mono_traverse_array(MonoArray *array, LivenessState *state)
 	}
 	else {
 		size_t items_processed = 0;
-		for (i = 0; i < array_length; i++)
-		{
+		for (i = 0; i < array_length; i++) {
 			MonoObject *val = mono_array_get(array, MonoObject *, i);
 			if (mono_add_process_object(val, state))
 				items_processed++;
@@ -594,8 +579,7 @@ static void mono_validate_array(MonoArray *array, LivenessState *state)
 	has_references = !m_class_is_valuetype(element_class);
 	g_assert(element_class->size_inited != 0);
 
-	for (i = 0; i < mono_class_get_field_count(element_class); i++)
-	{
+	for (i = 0; i < mono_class_get_field_count(element_class); i++)	{
 		has_references |= mono_field_can_contain_references(&element_class->fields[i]);
 	}
 
@@ -617,8 +601,7 @@ static void mono_validate_array(MonoArray *array, LivenessState *state)
 	}
 	else {
 		size_t items_processed = 0;
-		for (i = 0; i < array_length; i++)
-		{
+		for (i = 0; i < array_length; i++) {
 			MonoObject *val = mono_array_get(array, MonoObject*, i);
 			if (mono_add_and_validate_object(val, state))
 				items_processed++;
@@ -637,8 +620,7 @@ void mono_filter_objects(LivenessState *state)
 	gint num_objects = 0;
 
 	gpointer value = block_array_next(state->all_objects);
-	while (value != NULL)
-	{
+	while (value != NULL) {
 		MonoObject *object = value;
 		if (should_process_value(object, state->filter))
 			filtered_objects[num_objects++] = object;
@@ -667,8 +649,7 @@ void mono_unity_liveness_calculation_from_statics(LivenessState *liveness_state)
 
 	mono_reset_state(liveness_state);
 
-	for (i = 0; i < memory_manager->class_vtable_array->len; ++i)
-	{
+	for (i = 0; i < memory_manager->class_vtable_array->len; ++i) {
 		MonoVTable *vtable = (MonoVTable *)g_ptr_array_index(memory_manager->class_vtable_array, i);
 		MonoClass *klass = vtable->klass;
 		MonoClassField *field;
@@ -763,8 +744,7 @@ void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
 
 	g_hash_table_foreach(domain->special_static_fields, foreach_thread_static_field, liveness_state);
 
-	for (i = 0; i < memory_manager->class_vtable_array->len; ++i)
-	{
+	for (i = 0; i < memory_manager->class_vtable_array->len; ++i) {
 		MonoVTable *vtable = (MonoVTable*)g_ptr_array_index(memory_manager->class_vtable_array, i);
 		MonoClass *klass = vtable->klass;
 		MonoClassField *field;
@@ -776,8 +756,7 @@ void mono_unity_heap_validation_from_statics(LivenessState *liveness_state)
 			continue;
 		if (klass->size_inited == 0)
 			continue;
-		for (j = 0; j < mono_class_get_field_count(klass); j++)
-		{
+		for (j = 0; j < mono_class_get_field_count(klass); j++)	{
 			field = &klass->fields[j];
 			if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 				continue;
@@ -864,8 +843,7 @@ void mono_unity_liveness_finalize(LivenessState *state)
 {
 	block_array_reset_iterator(state->all_objects);
 	gpointer it = block_array_next(state->all_objects);
-	while (it != NULL)
-	{
+	while (it != NULL) {
 		MonoObject *object = it;
 		CLEAR_OBJ(object);
 		it = block_array_next(state->all_objects);
@@ -879,4 +857,3 @@ void mono_unity_liveness_free_struct(LivenessState *state)
 	block_array_destroy(state->process_array, state);
 	g_free(state);
 }
-

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -164,6 +164,7 @@ MONO_API void mono_unity_liveness_free_struct(LivenessState *state);
 
 MONO_API void mono_unity_liveness_calculation_from_root(MonoObject *root, LivenessState *state);
 MONO_API void mono_unity_liveness_calculation_from_statics(LivenessState *state);
+MONO_API void mono_unity_heap_validation_from_statics(LivenessState* state);
 
 #define MARK_OBJ(obj)                                                       \
 	do {                                                                    \
@@ -465,7 +466,8 @@ static gboolean mono_validate_object_internal(MonoObject *object, gboolean isStr
 						valClass->_byval_arg.type == MONO_TYPE_GENERICINST ||
 						valClass->_byval_arg.type == MONO_TYPE_SZARRAY ||
 						valClass->_byval_arg.type == MONO_TYPE_STRING ||
-						valClass->_byval_arg.type == MONO_TYPE_OBJECT);
+						valClass->_byval_arg.type == MONO_TYPE_OBJECT ||
+						valClass->_byval_arg.type == MONO_TYPE_VALUETYPE); // TODO: Not sure if this is correct
 					if (mono_class_is_interface(fieldClass)) {
 						/* TODO */
 					}
@@ -728,36 +730,6 @@ void mono_unity_liveness_calculation_from_statics(LivenessState *liveness_state)
 	mono_traverse_objects(liveness_state);
 	//Filter objects and call callback to register found objects
 	mono_filter_objects(liveness_state);
-}
-
-void mono_unity_heap_validation_from_statics(LivenessState *liveness_state);
-extern void mono_gc_handle_lock();
-extern void mono_gc_handle_unlock();
-MONO_API void mono_unity_heap_validation()
-{
-
-	// int i = 0;
-	// MonoArray* res = NULL;
-	// GPtrArray* objects = NULL;
-	// LivenessState* liveness_state = NULL;
-	// MonoError* error = NULL;
-
-	// objects = g_ptr_array_sized_new (100000);
-	// objects->len = 0;
-
-	// mono_gc_handle_lock ();
-
-	// //liveness_state = mono_unity_liveness_calculation_begin (NULL, 100000, mono_unity_liveness_add_object_callback, (void*)objects, NULL, NULL);
-
-	// mono_unity_heap_validation_from_statics (liveness_state);
-
-	// //mono_unity_liveness_calculation_end (liveness_state);
-
-	// mono_gc_handle_unlock ();
-
-	// g_ptr_array_free (objects, TRUE);
-
-	/// I DON'T KNOW HOW TO DO THIS YET FIXMEEEEEE
 }
 
 void gchandle_process(void *data, void *user_data)

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -279,6 +279,33 @@ static gboolean mono_add_process_object(MonoObject *object, LivenessState *state
 	return FALSE;
 }
 
+MONO_API void mono_validate_object_pointer (MonoObject *object)
+{
+	if (object) {
+		void *vtable = NULL;
+		MonoClass *klass = NULL;
+		char *name = NULL;
+		__try {
+			vtable = *(void**)(object);
+			klass = object->vtable->klass;
+			name = klass->name;
+		}
+		__except(1) {
+
+			vtable = NULL;
+			klass = NULL;
+		}
+
+		if (vtable == NULL || klass == NULL || name == NULL)
+			DebugBreak();
+	}
+}
+
+MONO_API void mono_validate_string_pointer(MonoString *string)
+{
+	mono_validate_object_pointer(&string->object);
+}
+
 static gboolean mono_add_and_validate_object(MonoObject *object, LivenessState *state)
 {
 	// TODO: validate object is good first...

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3646,18 +3646,16 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 #else
 
 	if (!ji) {
-		//if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
-		//	return;
+		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
+			return;
 
-		// if (mono_dump_start ())
-		// 	mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
+		if (mono_dump_start ())
+			mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
 
-		//if (mono_do_crash_chaining) {
-		//	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
-		//	return;
-		//}
-		info->handled = FALSE;
-		return;
+		if (mono_do_crash_chaining) {
+			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+			return;
+		}
 	}
 
 	if (mono_is_addr_implicit_null_check (fault_addr)) {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3646,16 +3646,18 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 #else
 
 	if (!ji) {
-		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
-			return;
+		//if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
+		//	return;
 
-		if (mono_dump_start ())
-			mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
+		// if (mono_dump_start ())
+		// 	mono_handle_native_crash (mono_get_signame (SIGSEGV), &mctx, (MONO_SIG_HANDLER_INFO_TYPE*)info);
 
-		if (mono_do_crash_chaining) {
-			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
-			return;
-		}
+		//if (mono_do_crash_chaining) {
+		//	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+		//	return;
+		//}
+		info->handled = FALSE;
+		return;
 	}
 
 	if (mono_is_addr_implicit_null_check (fault_addr)) {


### PR DESCRIPTION
Mono side support for the heap validator. The use case is primarily for us but could also be very useful for other Unity support staff that want to assist in chasing memory corruption. The entry point for the heap validation will be through the Unity side as the block array functionality lives over there. If corruption is detected we will crash immediately rather than crashing at some point later when non-validation code eventually stumbles across the corruption. This will provide a hopefully slightly closer point to the source of the corruption.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

**Backports**
2021.2, 2020.x

Backport won't be clean I'll have to do this myself separately.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->