### PR TITLE
Add missing facades for Unity profiles (Case 1367105)

### DIFF
--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -73,7 +73,7 @@ testing_winaot_interp_SUBDIRS = $(common_DEPS_SUBDIRS) System.Drawing.Common
 testing_winaot_interp_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS)
 
 unityjit_SUBDIRS = $(common_DEPS_SUBDIRS)
-unityjit_PARALLEL_SUBDIRS = $(common_SUBDIRS) System.Net.Http.Rtc
+unityjit_PARALLEL_SUBDIRS = $(common_SUBDIRS) System.Net.Http.Rtc $(mobile_only_SUBDIRS)
 
 unityaot_SUBDIRS = $(common_DEPS_SUBDIRS) System.Drawing.Common
 unityaot_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS)


### PR DESCRIPTION
Adding to the JIT profiles
 - System.Threading.Tasks.Extensions 
 - System.Xml.XPath.XmlDocument 
 - System.Reflection.DispatchProxy 
 - System.Memory
 - System.Buffers



Used the .Net Standard compat dll list to drive this change.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Release notes**

Fixed case 1367105@bholmes :
Mono: Add missing facade dlls for Unity profiles


**Backports**

 - 2021.2

