### PR TITLE
Unity 2020.3 heap validation

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -947,6 +947,7 @@ mono_gc_free_fixed (void* addr)
 	GC_FREE (addr);
 }
 
+#ifdef HEAP_VALIDATION_FREQUENCY
 static int validate_heap = 0;
 static int counter = 0;
 static int validate_frequency = 100;
@@ -957,6 +958,7 @@ mono_gc_set_heap_verifier (gboolean enabled)
 	g_message("heap verifier is now: %d", enabled);
 	validate_heap = enabled;
 }
+#endif
 
 extern void mono_unity_heap_validation ();
 void *
@@ -964,10 +966,13 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj;
 
-	if (validate_heap && (counter++ % validate_frequency) == 0)
+#ifdef HEAP_VALIDATION_FREQUENCY
+	if (validate_heap && (++counter % validate_frequency) == 0)
 	{
 		mono_unity_heap_validation ();
+		counter = 0;
 	}
+#endif
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -951,6 +951,13 @@ static int validate_heap = 0;
 static int counter = 0;
 static int validate_frequency = 100;
 
+void
+mono_gc_set_heap_verifier (gboolean enabled)
+{
+	g_message("heap verifier is now: %d", enabled);
+	validate_heap = enabled;
+}
+
 extern void mono_unity_heap_validation ();
 void *
 mono_gc_alloc_obj (MonoVTable *vtable, size_t size)

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -82,7 +82,9 @@ static MonoGCFinalizerCallbacks fin_callbacks;
 
 static mono_mutex_t handle_section;
 #define lock_handles(handles) mono_os_mutex_lock (&handle_section)
+void mono_gc_handle_lock () { lock_handles (NULL);}
 #define unlock_handles(handles) mono_os_mutex_unlock (&handle_section)
+void mono_gc_handle_unlock () { unlock_handles (NULL); }
 
 typedef struct {
 	guint32  *bitmap;
@@ -945,10 +947,20 @@ mono_gc_free_fixed (void* addr)
 	GC_FREE (addr);
 }
 
+static int validate_heap = 0;
+static int counter = 0;
+static int validate_frequency = 100;
+
+extern void mono_unity_heap_validation ();
 void *
 mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj;
+
+	if (validate_heap && (counter++ % validate_frequency) == 0)
+	{
+		mono_unity_heap_validation ();
+	}
 
 	if (!vtable->klass->has_references) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -151,6 +151,7 @@ void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);
 /* Signal early termination of finalizer processing inside the gc */
 void  mono_gc_suspend_finalizers (void);
+MONO_API void  mono_gc_set_heap_verifier (gboolean enabled);
 
 
 /* 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -151,7 +151,9 @@ void  mono_gc_run_finalize (void *obj, void *data);
 void  mono_gc_clear_domain (MonoDomain * domain);
 /* Signal early termination of finalizer processing inside the gc */
 void  mono_gc_suspend_finalizers (void);
+#ifdef HEAP_VALIDATION_FREQUENCY
 MONO_API void  mono_gc_set_heap_verifier (gboolean enabled);
+#endif
 
 
 /* 

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -262,6 +262,36 @@ static gboolean mono_add_process_object (MonoObject* object, LivenessState* stat
 	return FALSE;
 }
 
+MONO_API void mono_validate_object_pointer (MonoObject* object)
+{
+	if (object)
+	{
+		void* vtable = NULL;
+		MonoClass* klass = NULL;
+		char* name = NULL;
+		__try {
+			vtable = *(void**)(object);
+			klass = object->vtable->klass;
+			name = klass->name;
+		}
+		__except (1) {
+
+			vtable = NULL;
+			klass = NULL;
+		}
+
+		if (vtable == NULL || klass == NULL || name == NULL)
+		{
+			DebugBreak ();
+		}
+	}
+}
+
+MONO_API void mono_validate_string_pointer(MonoString* string)
+{
+	mono_validate_object_pointer(&string->object);
+}
+
 static gboolean mono_add_and_validate_object (MonoObject* object, LivenessState* state)
 {
 	// TODO: validate object is good first...

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -840,6 +840,9 @@ void mono_unity_heap_validation_from_statics (LivenessState* liveness_state)
 	int i, j;
 	MonoDomain* domain = mono_domain_get ();
 
+	if (!domain)
+		return;
+
 	mono_reset_state (liveness_state);
 
 	mono_gc_strong_handle_foreach (gchandle_process, liveness_state);

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -175,6 +175,8 @@ static gboolean should_process_value (MonoObject* val, MonoClass* filter)
 
 static void mono_traverse_array (MonoArray* array, LivenessState* state);
 static void mono_traverse_object (MonoObject* object, LivenessState* state);
+static void mono_validate_array (MonoArray* array, LivenessState* state);
+static void mono_validate_object (MonoObject* object, LivenessState* state);
 static void mono_traverse_gc_desc (MonoObject* object, LivenessState* state);
 static void mono_traverse_objects (LivenessState* state);
 
@@ -192,6 +194,22 @@ static void mono_traverse_generic_object( MonoObject* object, LivenessState* sta
 		mono_traverse_array ((MonoArray*)object, state);
 	else
 		mono_traverse_object (object, state);
+}
+
+static void mono_traverse_and_validate_generic_object (MonoObject* object, LivenessState* state)
+{
+#ifdef HAVE_SGEN_GC
+	gsize gc_desc = 0;
+#else
+	gsize gc_desc = (gsize)(GET_VTABLE (object)->gc_descr);
+#endif
+
+	/*if (gc_desc & (gsize)1)
+		mono_traverse_gc_desc (object, state);
+	else */if (GET_VTABLE (object)->klass->rank)
+		mono_validate_array ((MonoArray*)object, state);
+	else
+		mono_validate_object (object, state);
 }
 
 
@@ -214,6 +232,54 @@ static gboolean mono_add_process_object (MonoObject* object, LivenessState* stat
 				array_safe_grow(state, state->process_array);
 			array_push_back(state->process_array, object);
 			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+static gboolean mono_add_and_validate_object (MonoObject* object, LivenessState* state)
+{
+	// TODO: validate object is good first...
+	if (object)
+	{
+		void* vtable = NULL;
+		__try {
+			vtable = *(void**)(object);
+		}
+		__except (1) {
+
+			vtable = NULL;
+		}
+
+		if (vtable == NULL)
+		{
+			DebugBreak ();
+		}
+
+		//if (!GC_is_marked (object))
+		//{
+		//	DebugBreak ();
+		//}
+
+		if (!IS_MARKED (object))
+		{
+			gboolean has_references = GET_VTABLE (object)->klass->has_references;
+			if (has_references || should_process_value (object, state->filter))
+			{
+				if (array_is_full (state->all_objects))
+					array_safe_grow (state, state->all_objects);
+				array_push_back (state->all_objects, object);
+				MARK_OBJ (object);
+			}
+			// Check if klass has further references - if not skip adding
+			if (has_references)
+			{
+				if (array_is_full (state->process_array))
+					array_safe_grow (state, state->process_array);
+				array_push_back (state->process_array, object);
+				return TRUE;
+			}
 		}
 	}
 
@@ -285,9 +351,69 @@ static gboolean mono_traverse_object_internal (MonoObject* object, gboolean isSt
 	return added_objects;
 }
 
+static gboolean mono_validate_object_internal (MonoObject* object, gboolean isStruct, MonoClass* klass, LivenessState* state)
+{
+	int i;
+	MonoClassField* field;
+	MonoClass* p;
+	gboolean added_objects = FALSE;
+
+	g_assert (object);
+
+	// subtract the added offset for the vtable. This is added to the offset even though it is a struct
+	if (isStruct)
+		object--;
+
+	for (p = klass; p != NULL; p = p->parent)
+	{
+		if (p->size_inited == 0)
+			continue;
+		for (i = 0; i < mono_class_get_field_count (p); i++)
+		{
+			field = &p->fields[i];
+			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
+				continue;
+
+			if (!mono_field_can_contain_references (field))
+				continue;
+
+			if (MONO_TYPE_ISSTRUCT (field->type))
+			{
+				char* offseted = (char*)object;
+				offseted += field->offset;
+				if (field->type->type == MONO_TYPE_GENERICINST)
+				{
+					g_assert (field->type->data.generic_class->cached_class);
+					added_objects |= mono_validate_object_internal ((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, state);
+				}
+				else
+					added_objects |= mono_validate_object_internal ((MonoObject*)offseted, TRUE, field->type->data.klass, state);
+				continue;
+			}
+
+			if (field->offset == -1) {
+				g_assert_not_reached ();
+			}
+			else {
+				MonoObject* val = NULL;
+				MonoVTable* vtable = NULL;
+				mono_field_get_value (object, field, &val);
+				added_objects |= mono_add_and_validate_object (val, state);
+			}
+		}
+	}
+
+	return added_objects;
+}
+
 static void mono_traverse_object (MonoObject* object, LivenessState* state)
 {
 	mono_traverse_object_internal (object, FALSE, GET_VTABLE(object)->klass, state);
+}
+
+static void mono_validate_object (MonoObject* object, LivenessState* state)
+{
+	mono_validate_object_internal (object, FALSE, GET_VTABLE (object)->klass, state);
 }
 
 static void mono_traverse_gc_desc (MonoObject* object, LivenessState* state)
@@ -319,6 +445,20 @@ static void mono_traverse_objects (LivenessState* state)
 	{
 		object = array_pop_back(state->process_array);
 		mono_traverse_generic_object(object, state);
+	}
+	state->traverse_depth--;
+}
+
+static void mono_traverse_and_validate_objects (LivenessState* state)
+{
+	int i = 0;
+	MonoObject* object = NULL;
+
+	state->traverse_depth++;
+	while (state->process_array->len > 0)
+	{
+		object = array_pop_back (state->process_array);
+		mono_traverse_and_validate_generic_object (object, state);
 	}
 	state->traverse_depth--;
 }
@@ -385,6 +525,61 @@ static void mono_traverse_array (MonoArray* array, LivenessState* state)
 	}
 }
 
+
+static void mono_validate_array (MonoArray* array, LivenessState* state)
+{
+	size_t i = 0;
+	gboolean has_references;
+	MonoObject* object = (MonoObject*)array;
+	MonoClass* element_class;
+	size_t elementClassSize;
+	size_t array_length;
+
+	g_assert (object);
+
+
+
+	element_class = GET_VTABLE (object)->klass->element_class;
+	has_references = !mono_class_is_valuetype (element_class);
+	g_assert (element_class->size_inited != 0);
+
+	for (i = 0; i < mono_class_get_field_count (element_class); i++)
+	{
+		has_references |= mono_field_can_contain_references (&element_class->fields[i]);
+	}
+
+	if (!has_references)
+		return;
+
+	array_length = mono_array_length (array);
+	if (element_class->valuetype)
+	{
+		size_t items_processed = 0;
+		elementClassSize = mono_class_array_element_size (element_class);
+		for (i = 0; i < array_length; i++)
+		{
+			MonoObject* object = (MonoObject*)mono_array_addr_with_size (array, elementClassSize, i);
+			if (mono_validate_object_internal (object, 1, element_class, state))
+				items_processed++;
+
+			if (should_traverse_objects (items_processed, state->traverse_depth))
+				mono_traverse_and_validate_objects (state);
+		}
+	}
+	else
+	{
+		size_t items_processed = 0;
+		for (i = 0; i < array_length; i++)
+		{
+			MonoObject* val = mono_array_get (array, MonoObject*, i);
+			if (mono_add_and_validate_object (val, state))
+				items_processed++;
+
+			if (should_traverse_objects (items_processed, state->traverse_depth))
+				mono_traverse_and_validate_objects (state);
+		}
+	}
+}
 
 void mono_filter_objects(LivenessState* state)
 {
@@ -531,6 +726,112 @@ gpointer mono_unity_liveness_calculation_from_statics_managed(gpointer filter_ha
 
 }
 
+void mono_unity_heap_validation_from_statics (LivenessState* liveness_state);
+extern void mono_gc_handle_lock ();
+extern void mono_gc_handle_unlock ();
+MONO_API void mono_unity_heap_validation ()
+{
+
+	int i = 0;
+	MonoArray* res = NULL;
+	GPtrArray* objects = NULL;
+	LivenessState* liveness_state = NULL;
+	MonoError* error = NULL;
+
+	objects = g_ptr_array_sized_new (100000);
+	objects->len = 0;
+
+	mono_gc_handle_lock ();
+
+	liveness_state = mono_unity_liveness_calculation_begin (NULL, 100000, mono_unity_liveness_add_object_callback, (void*)objects, NULL, NULL);
+
+	mono_unity_heap_validation_from_statics (liveness_state);
+
+	mono_unity_liveness_calculation_end (liveness_state);
+
+	mono_gc_handle_unlock ();
+
+	g_ptr_array_free (objects, TRUE);
+}
+
+void gchandle_process (void* data, void* user_data)
+{
+	MonoObject* target = data;
+	LivenessState* liveness_state = user_data;
+
+	mono_add_and_validate_object (target, liveness_state);
+}
+
+extern void
+mono_gc_strong_handle_foreach (GFunc func, gpointer user_data);
+
+void mono_unity_heap_validation_from_statics (LivenessState* liveness_state)
+{
+	int i, j;
+	MonoDomain* domain = mono_domain_get ();
+
+	mono_reset_state (liveness_state);
+
+	mono_gc_strong_handle_foreach (gchandle_process, liveness_state);
+
+	for (i = 0; i < domain->class_vtable_array->len; ++i)
+	{
+		MonoVTable* vtable = (MonoVTable*)g_ptr_array_index (domain->class_vtable_array, i);
+		MonoClass* klass = vtable->klass;
+		MonoClassField* field;
+		if (!klass)
+			continue;
+		if (!klass->has_static_refs)
+			continue;
+		if (klass->image == mono_defaults.corlib)
+			continue;
+		if (klass->size_inited == 0)
+			continue;
+		for (j = 0; j < mono_class_get_field_count (klass); j++)
+		{
+			field = &klass->fields[j];
+			if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+				continue;
+			if (!mono_field_can_contain_references (field))
+				continue;
+			// shortcut check for special statics
+			if (field->offset == -1)
+				continue;
+
+			if (MONO_TYPE_ISSTRUCT (field->type))
+			{
+				char* offseted = (char*)mono_vtable_get_static_field_data (vtable);
+				offseted += field->offset;
+				if (field->type->type == MONO_TYPE_GENERICINST)
+				{
+					g_assert (field->type->data.generic_class->cached_class);
+					mono_validate_object_internal ((MonoObject*)offseted, TRUE, field->type->data.generic_class->cached_class, liveness_state);
+				}
+				else
+				{
+					mono_validate_object_internal ((MonoObject*)offseted, TRUE, field->type->data.klass, liveness_state);
+				}
+			}
+			else
+			{
+				MonoError error;
+				MonoObject* val = NULL;
+
+				mono_field_static_get_value_checked (mono_class_vtable (domain, klass), field, &val, &error);
+
+				if (val && mono_error_ok (&error))
+				{
+					mono_add_and_validate_object (val, liveness_state);
+				}
+				mono_error_cleanup (&error);
+			}
+		}
+	}
+	mono_traverse_and_validate_objects (liveness_state);
+	//Filter objects and call callback to register found objects
+	//mono_filter_objects (liveness_state);
+}
+
 /**
  * mono_unity_liveness_calculation_from_root:
  *
@@ -636,7 +937,8 @@ void mono_unity_liveness_free_struct (LivenessState* state)
 
 void mono_unity_liveness_stop_gc_world (LivenessState* state)
 {
-	state->onWorldStopCallback();
+	if (state->onWorldStopCallback)
+		state->onWorldStopCallback();
 #if defined(HAVE_SGEN_GC)
 	sgen_stop_world (1);
 #elif defined(HAVE_BOEHM_GC)
@@ -655,7 +957,8 @@ void mono_unity_liveness_start_gc_world (LivenessState* state)
 #else
 #error need to implement liveness GC API
 #endif
-	state->onWorldStartCallback();
+	if (state->onWorldStartCallback)
+		state->onWorldStartCallback();
 }
 
 LivenessState* mono_unity_liveness_calculation_begin (MonoClass* filter, guint max_count, register_object_callback callback, void* callback_userdata, WorldStateChanged onWorldStartCallback, WorldStateChanged onWorldStopCallback)

--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -212,6 +212,30 @@ static void mono_traverse_and_validate_generic_object (MonoObject* object, Liven
 		mono_validate_object (object, state);
 }
 
+static void validate_object_value (MonoObject* val, MonoType* storageType)
+{
+	if (val && storageType->type == MONO_TYPE_CLASS) {
+		MonoClass* storageClass = storageType->data.klass;
+		MonoClass* valClass = GET_VTABLE (val)->klass;
+		if (mono_class_is_interface (storageClass)) {
+			int found = 0;
+			for (int i = 0; i < valClass->interface_offsets_count; ++i)
+			{
+				if (valClass->interfaces_packed[i] == storageClass)
+				{
+					found = TRUE;
+					break;
+				}
+			}
+			g_assert (found);
+		}
+		else {
+			int res = mono_class_has_parent_fast (valClass, storageClass);
+			g_assert (res);
+		}
+	}
+}
+
 
 static gboolean mono_add_process_object (MonoObject* object, LivenessState* state)
 {
@@ -344,6 +368,7 @@ static gboolean mono_traverse_object_internal (MonoObject* object, gboolean isSt
 				MonoVTable *vtable = NULL;
 				mono_field_get_value (object, field, &val);
 				added_objects |= mono_add_process_object (val, state);
+				validate_object_value (val, field->type);
 			}
 		}
 	}
@@ -399,6 +424,22 @@ static gboolean mono_validate_object_internal (MonoObject* object, gboolean isSt
 				MonoVTable* vtable = NULL;
 				mono_field_get_value (object, field, &val);
 				added_objects |= mono_add_and_validate_object (val, state);
+				if (val && field->type->type == MONO_TYPE_CLASS) {
+					MonoClass* fieldClass = field->type->data.klass;
+					MonoClass* valClass = GET_VTABLE (val)->klass;
+					g_assert (valClass->byval_arg.type == MONO_TYPE_CLASS || 
+						valClass->byval_arg.type == MONO_TYPE_GENERICINST ||
+						valClass->byval_arg.type == MONO_TYPE_SZARRAY ||
+						valClass->byval_arg.type == MONO_TYPE_STRING ||
+						valClass->byval_arg.type == MONO_TYPE_OBJECT);
+					if (mono_class_is_interface (fieldClass)) {
+						/* TODO */
+					}
+					else {
+						int res = mono_class_has_parent_fast (valClass, fieldClass);
+						g_assert (res);
+					}
+				}
 			}
 		}
 	}
@@ -574,6 +615,8 @@ static void mono_validate_array (MonoArray* array, LivenessState* state)
 			MonoObject* val = mono_array_get (array, MonoObject*, i);
 			if (mono_add_and_validate_object (val, state))
 				items_processed++;
+
+			validate_object_value (val, &element_class->byval_arg);
 
 			if (should_traverse_objects (items_processed, state->traverse_depth))
 				mono_traverse_and_validate_objects (state);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3156,15 +3156,17 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 #else
 
 	if (!ji) {
-		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
-			return;
+		//if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
+		//	return;
 
-		mono_handle_native_crash ("SIGSEGV", ctx, info);
+		//mono_handle_native_crash ("SIGSEGV", ctx, info);
 
-		if (mono_do_crash_chaining) {
-			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
-			return;
-		}
+		//if (mono_do_crash_chaining) {
+		//	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+		//	return;
+		//}
+		info->handled = FALSE;
+		return;
 	}
 
 	mono_arch_handle_exception (ctx, NULL);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3156,17 +3156,15 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 #else
 
 	if (!ji) {
-		//if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
-		//	return;
+		if (!mono_do_crash_chaining && mono_chain_signal (MONO_SIG_HANDLER_PARAMS))
+			return;
 
-		//mono_handle_native_crash ("SIGSEGV", ctx, info);
+		mono_handle_native_crash ("SIGSEGV", ctx, info);
 
-		//if (mono_do_crash_chaining) {
-		//	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
-		//	return;
-		//}
-		info->handled = FALSE;
-		return;
+		if (mono_do_crash_chaining) {
+			mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
+			return;
+		}
 	}
 
 	mono_arch_handle_exception (ctx, NULL);


### PR DESCRIPTION
Backporting heap validation to 2020.3

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal @UnityAlex :
Mono: Added heap validator functionality and exposed APIs to allow for it to be ran from Unity.

