### PR TITLE
It is possible for a struct to be generic and therefore when fetching…

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5432,7 +5432,7 @@ mono_struct_delete_old (MonoClass *klass, char *ptr)
 		switch (conv) {
 		case MONO_MARSHAL_CONV_NONE:
 			if (MONO_TYPE_ISSTRUCT (ftype)) {
-				mono_struct_delete_old (ftype->data.klass, cpos);
+				mono_struct_delete_old (mono_class_from_mono_type_internal(ftype), cpos);
 				continue;
 			}
 			break;


### PR DESCRIPTION
… the class we need to perform additional checks to catch this scenario. (case 1345245)



- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1345245 @UnityAlex :
Mono: Fixed crash that would occur when a generic field was in a struct during burst compilation.

**Backports**
All of them: 2019.4, 2020.3, 2021.2

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->