### PR TITLE
Link C++ runtime statically on Windows.

### DIFF
--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -51,7 +51,7 @@ sub CompileVCProj
     $config = $debug ? "Debug" : "Release";
 	my $arch = $arch32 ? "Win32" : "x64";
 	my $target = $clean ? "/t:Clean,Build" :"/t:Build";
-	my $properties = "/p:Configuration=$config;Platform=$arch;MONO_TARGET_GC=$gc";
+	my $properties = "/p:Configuration=$config;Platform=$arch;MONO_TARGET_GC=$gc;MONO_USE_STATIC_C_RUNTIME=true";
 
 	print (">>> $msbuild $properties $target $sln\n\n");
 	system($msbuild, $properties, $target, $sln) eq 0


### PR DESCRIPTION
- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes (to 2021.2, doing it myself)
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1373476  @zilys:
Windows: Fixed Windows player not start on machines that don't have Visual C++ runtime installed.