### PR TITLE
Fix Superluminal integration after upstream merge issue.

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -107,7 +107,7 @@ get_pe_debug_info (MonoImage *image, const char** out_path, guint8 *out_guid, gi
 				guid_found = TRUE;
 
 				if (out_path != NULL) {
-					*out_path = g_strdup (dir.path);
+					*out_path = g_strdup (data + 24);
 				}
 			}
 		}


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/mono/pull/1505

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No


**Release notes**

Fixed case 1373568 @joncham :
Mono: Fixed Superluminal symbol integration.

**Backports**
2021.2