### PR TITLE
Report error rather than aborting (case 1343949).

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2038,6 +2038,7 @@ cominterop_setup_marshal_context (EmitMarshalContext *m, MonoMethod *method)
 	csig->hasthis = 0;
 	csig->pinvoke = 1;
 
+	memset (&m, 0, sizeof (m));
 	m->image = method_klass_image;
 	m->piinfo = NULL;
 	m->retobj_var = 0;

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -3099,7 +3099,10 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
 		}
 		else {
-			g_assert_not_reached ();
+			if (m->error)
+				mono_error_set_marshal_directive (m->error, "Marshalling of non-string arrays to managed code is not implemented.");
+			else
+				g_assert_not_reached ();
 		}
 
 		if (is_string)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3890,6 +3890,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	m.retobj_var = 0;
 	m.csig = csig;
 	m.image = get_method_image (method);
+	m.error = error;
 
 	if (invoke)
 		mono_marshal_set_callconv_from_modopt (invoke, csig, TRUE);
@@ -3966,6 +3967,10 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	}
 
 	mono_marshal_emit_managed_wrapper (mb, invoke_sig, mspecs, &m, method, target_handle);
+
+	if (!is_ok (m.error)) {
+		return NULL;
+	}
 
 	if (!target_handle) {
 		WrapperInfo *info;

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -51,6 +51,7 @@ typedef struct {
 	MonoClass *retobj_class;
 	MonoMethodSignature *csig; /* Might need to be changed due to MarshalAs directives */
 	MonoImage *image; /* The image to use for looking up custom marshallers */
+	MonoError* error; /* allows reporting of error from marshaling logic */
 } EmitMarshalContext;
 
 typedef enum {

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -284,6 +284,12 @@ mono_error_set_platform_not_supported (MonoError *error, const char *message)
 	mono_error_set_generic_error (error, "System", "PlatformNotSupportedException", "%s", message);
 }
 
+static inline void
+mono_error_set_marshal_directive (MonoError* error, const char* message)
+{
+	mono_error_set_generic_error (error, "System.Runtime.InteropServices", "MarshalDirectiveException", "%s", message);
+}
+
 MonoException*
 mono_error_prepare_exception (MonoError *error, MonoError *error_out);
 


### PR DESCRIPTION
Pass MonoError object via the EmitMarshalContext so that marshaling
logic can report problems that can be raised as exceptions to user
when calling APIs such as Marshal.GetFunctionPointerForDelegate.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

**Release notes**

Fixed case 1343949 @joncham:
Mono: Raise exception rather than crashing when calling Marshal.GetFunctionPointerForDelegate with a delegate that cannot be marshalled. 

**Backports**