### PR TITLE
Safely interrupt the GC finalize thread on shutdown [Case1363998]

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1152,6 +1152,7 @@ mono_gc_clear_domain (MonoDomain *domain)
 void
 mono_gc_suspend_finalizers (void)
 {
+	GC_set_interrupt_finalizers ();
 }
 
 int

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -1177,7 +1177,8 @@ mono_gc_cleanup (void)
 					ret = guarded_wait (gc_thread->handle, 100, FALSE);
 					if (ret == MONO_THREAD_INFO_WAIT_RET_TIMEOUT) {
 						/* The finalizer thread refused to exit, suspend it forever. */
-						mono_thread_internal_suspend_for_shutdown (gc_thread);
+						g_warning ("Finalizer thread did not exit, forcing thread exit.");
+						mono_thread_internal_terminate_for_shutdown (gc_thread);
 						break;
 					}
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -926,7 +926,7 @@ finalize_domain_objects (void)
 	mono_gc_invoke_finalizers ();
 
 #ifdef HAVE_BOEHM_GC
-	while (g_hash_table_size (domain->finalizable_objects_hash) > 0) {
+	while (g_hash_table_size (domain->finalizable_objects_hash) > 0 &&!suspend_finalizers) {
 		int i;
 		GPtrArray *objs;
 		/* 
@@ -938,7 +938,7 @@ finalize_domain_objects (void)
 		g_hash_table_foreach (domain->finalizable_objects_hash, collect_objects, objs);
 		/* printf ("FINALIZING %d OBJECTS.\n", objs->len); */
 
-		for (i = 0; i < objs->len; ++i) {
+		for (i = 0; i < objs->len && !suspend_finalizers; ++i) {
 			MonoObject *o = (MonoObject*)g_ptr_array_index (objs, i);
 			/* FIXME: Avoid finalizing threads, etc */
 			mono_gc_run_finalize (o, 0);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -301,6 +301,7 @@ mono_thread_internal_current_handle (void);
 gboolean
 mono_thread_internal_abort (MonoInternalThread *thread, gboolean appdomain_unload);
 void mono_thread_internal_suspend_for_shutdown (MonoInternalThread *thread);
+void mono_thread_internal_terminate_for_shutdown (MonoInternalThread* thread);
 
 gboolean mono_thread_internal_has_appdomain_ref (MonoInternalThread *thread, MonoDomain *domain);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6016,6 +6016,27 @@ mono_thread_internal_suspend_for_shutdown (MonoInternalThread *thread)
 	mono_thread_info_safe_suspend_and_run (thread_get_tid (thread), FALSE, suspend_for_shutdown_critical, NULL);
 }
 
+static void
+terminate_for_shutdown_async_call (gpointer unused)
+{
+	mono_thread_info_exit (1);
+}
+
+static SuspendThreadResult
+terminate_for_shutdown_critical (MonoThreadInfo* info, gpointer unused)
+{
+	mono_thread_info_setup_async_call (info, terminate_for_shutdown_async_call, NULL);
+	return MonoResumeThread;
+}
+
+void
+mono_thread_internal_terminate_for_shutdown (MonoInternalThread* thread)
+{
+	g_assert (thread != mono_thread_internal_current ());
+
+	mono_thread_info_safe_suspend_and_run (thread_get_tid (thread), FALSE, terminate_for_shutdown_critical, NULL);
+}
+
 /**
  * mono_thread_is_foreign:
  * \param thread the thread to query


### PR DESCRIPTION
During shutdown we wait for 40 seconds to allow all finalizers to
complete. After this time the code attempts to terminate or suspend the
thread which can cause crashes or hangs.

This change adds flags to the finalizer thread to break long running
loops and allow the thread to safely exit.

Depends on bdwgc PR landing:
https://github.com/Unity-Technologies/bdwgc/pull/66


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Release notes**

Fixed case 1363998@username:
Mono: Safely interrupt the GC finalize thread on shutdown.


**Backports**

Lets discuss below...
