### PR TITLE
Remove call to validate_object_value that was not in the heap validat…

### DIFF
--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -377,7 +377,6 @@ static gboolean mono_traverse_object_internal (MonoObject* object, gboolean isSt
 				MonoVTable *vtable = NULL;
 				mono_field_get_value (object, field, &val);
 				added_objects |= mono_add_process_object (val, state);
-				validate_object_value (val, field->type);
 			}
 		}
 	}


### PR DESCRIPTION
…or call path



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal @UnityAlex :
Mono: Fixed issue where part of the heap validator was being called during garbage collection.


<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->