### PR TITLE
[UWP] Fix setting culture info crashes if it wasn't queried before (case 1375944)

### DIFF
--- a/mcs/class/corlib/System.Globalization/CultureInfo.cs
+++ b/mcs/class/corlib/System.Globalization/CultureInfo.cs
@@ -1154,6 +1154,10 @@ namespace System.Globalization
 
 		internal static void SetCultureInfoForUserPreferredLanguageInAppX (CultureInfo cultureInfo)
 		{
+			// Native side needs to be initialized before we can set the new culture info
+			if (s_UserPreferredCultureInfoInAppX == null)
+				InitializeUserPreferredCultureInfoInAppX (OnCultureInfoChangedInAppX);
+
 			SetUserPreferredCultureInfoInAppX (cultureInfo.Name);
 			s_UserPreferredCultureInfoInAppX = cultureInfo;
 		}


### PR DESCRIPTION
This PR fixes case 1375944, where CultureInfo.CurrentCulture setter crashes if you try to set it on UWP before querying it first. The underlying reason for the bug was that I only called initialization function from the getter with the assumption that it is always called first (which it is in the IL2CPP test framework) but that assumption didn't hold for Unity. This work was originally done for Unity 2021.2 in https://github.com/Unity-Technologies/mono/pull/1483. The fix is simply adding the initialization function call to the setter too.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Fixed case 1375944 @zilys:
UWP: Fixed CultureInfo.CurrentCulture setter crashing when calling it before ever querying the existing current culture.

**Backports**

It needs to be backported to 2021.2.