### PR TITLE
Fix constructing semi-unknown cultures through CultureInfo constructor (case 1375955)

### DIFF
--- a/mcs/class/corlib/System.Globalization/CultureInfo.cs
+++ b/mcs/class/corlib/System.Globalization/CultureInfo.cs
@@ -727,7 +727,7 @@ namespace System.Globalization
 				return;
 			}
 
-			if (!construct_internal_locale_from_name (name.ToLowerInvariant ())) {
+			if (!ConstructLocaleFromName (name.ToLowerInvariant ())) {
 				throw CreateNotFoundException (name);
 			}
 
@@ -846,18 +846,8 @@ namespace System.Globalization
 			name = name.ToLowerInvariant ();
 			CultureInfo ci = new CultureInfo ();
 
-			if (!ci.construct_internal_locale_from_name (name)) {
-				int idx = name.Length - 1;
-				if (idx > 0) {
-					while ((idx = name.LastIndexOf ('-', idx - 1)) > 0) {
-						if (ci.construct_internal_locale_from_name (name.Substring (0, idx)))
-							break;
-					}
-				}
-
-				if (idx <= 0)
-					throw CreateNotFoundException (src_name);
-			}
+			if (!ci.ConstructLocaleFromName (name))
+				throw CreateNotFoundException (src_name);
 
 			if (ci.IsNeutralCulture)
 				ci = CreateSpecificCultureFromNeutral (ci.Name);
@@ -867,6 +857,22 @@ namespace System.Globalization
 			ci.m_cultureData = CultureData.GetCultureData (ci.m_name, false, ci.datetime_index, ci.CalendarType, ci.number_index, ci.iso2lang,
 				ti.ansi, ti.oem, ti.mac, ti.ebcdic, ti.right_to_left, ((char)ti.list_sep).ToString ());
 			return ci;
+		}
+
+		bool ConstructLocaleFromName (string name)
+		{
+			if (construct_internal_locale_from_name (name))
+				return true;
+
+			int idx = name.Length - 1;
+			if (idx > 0) {
+				while ((idx = name.LastIndexOf ('-', idx - 1)) > 0) {
+					if (construct_internal_locale_from_name (name.Substring (0, idx)))
+						return true;
+				}
+			}
+
+			return false;
 		}
 
 		//


### PR DESCRIPTION
In CultureInfo.cs, Mono had two ways to construct CultureInfo from a string:

• Directly from the string, in CultureInfo constructor. It throws an exception in case the locale name doesn't match anything;
• In CultureInfo.CreateSpecific() it tries to first use the locale name as is, but if that fails, it will strip parts of the string that are after a dash (for instance, `en-DE` becomes just `en`) and keeps trying to use that new locale name until the string is empty.

This PR makes CultureInfo constructor go through the second path as well.

I looked a bit at how CoreCLR handles this and it seems it uses OS specific logic to parse the locale names, instead of hardcoding all possible locales in the runtime. Unfortunately, doing that in Mono and IL2CPP would result in a huge refactor so I decided against doing it.

I'd love to add a test for this. I think the best place to do it is in the IL2CPP repo, but I'm not sure how to synchronize this PR with Mono update in IL2CPP.

Slack thread: https://unity.slack.com/archives/C070AA8N5/p1636591855168500

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] I don't know!
  - [ ] No

**Release notes**

Fixed case 1375955 @zilys:
Scripting: fixed CultureInfo.CurrentCulture throwing an exception on some locales (for instance, en-DE).

**Backports**

It should be backporting to Unity 2021.2.