### PR TITLE
Fix PInvoke dll lookup for System.Native

### DIFF
--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -1203,14 +1203,15 @@ legacy_probe_for_module (MonoImage *image, const char *new_scope)
 	if (mono_get_find_plugin_callback ())
 	{
 		const char* unity_new_scope = mono_get_find_plugin_callback () (new_scope);
-		if (unity_new_scope == NULL)
+		if (unity_new_scope == NULL || !unity_new_scope[0])
 		{
 			mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_DLLIMPORT,
 				"DllImport unable to load unity mapped library '%s'.",
 				unity_new_scope);
 		}
 
-		new_scope = g_strdup (unity_new_scope);
+		else
+			new_scope = g_strdup (unity_new_scope);
 	}
 
 	/*


### PR DESCRIPTION
The Unity plugin code is triggering false positives. We need to check
for empty string in addition to NULL.

Fixes 1379834
Server build on OSX crashes when it can't find libmono-native.dylib


- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Backports**

 - 2021.2

