### PR TITLE
2020.3 : When the user provides a handler the existing hack to propogate the H…

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -365,7 +365,7 @@ namespace System.Net.Http
 			Timer ts = (Timer)prop.GetValue (cts);
 			if (ts != null) {
 				prop = typeof(Timer).GetField ("due_time_ms", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
-				timeout = TimeSpan.FromMilliseconds ((long)prop.GetValue (ts));
+				Timeout = TimeSpan.FromMilliseconds ((long)prop.GetValue (ts));
 			}
 			
 			Volatile.Write (ref sentRequest, true);

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.cs
@@ -35,6 +35,7 @@ using System.Collections.Specialized;
 using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Linq;
+using System.Reflection;
 
 namespace System.Net.Http
 {
@@ -356,7 +357,17 @@ namespace System.Net.Http
 		{
 			if (disposed)
 				throw new ObjectDisposedException (GetType ().ToString ());
-
+			
+			// We need to preserve the timeout provided in the cancellationToken if there is one. Unfortunately reflection is the only way to access this (case 1365107)
+			FieldInfo prop = typeof(CancellationToken).GetField ("_source", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+			CancellationTokenSource cts = (CancellationTokenSource)prop.GetValue (cancellationToken);
+			prop = typeof(CancellationTokenSource).GetField ("_timer", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+			Timer ts = (Timer)prop.GetValue (cts);
+			if (ts != null) {
+				prop = typeof(Timer).GetField ("due_time_ms", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+				timeout = TimeSpan.FromMilliseconds ((long)prop.GetValue (ts));
+			}
+			
 			Volatile.Write (ref sentRequest, true);
 			var wrequest = CreateWebRequest (request);
 			HttpWebResponse wresponse = null;


### PR DESCRIPTION
HttpClient timeout through to MonoWebRequestHandler does not work and the only place where the timeout is held is within the CancellationToken. Implemented a somewhat dirty fix using reflection to preserve the timeout. This change only impacts windows as MacOS and Linux both use the corefx version where this issue has been fixed more elegantly. (case 1365107)

Remove incorrect nullable annotation from Timer



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:



**Release notes**

Fixed case 1365107 @alexthibodeau:
Mono: Fixed issue where the timeout of a HttpClient handler was not being used for requests.

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->