### PR TITLE
2021.2 : Fix PInvoke dll lookup for System.Native

### DIFF
--- a/mono/metadata/native-library.c
+++ b/mono/metadata/native-library.c
@@ -1203,14 +1203,15 @@ legacy_probe_for_module (MonoImage *image, const char *new_scope)
 	if (mono_get_find_plugin_callback ())
 	{
 		const char* unity_new_scope = mono_get_find_plugin_callback () (new_scope);
-		if (unity_new_scope == NULL)
+		if (unity_new_scope == NULL || !unity_new_scope[0])
 		{
 			mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_DLLIMPORT,
 				"DllImport unable to load unity mapped library '%s'.",
 				unity_new_scope);
 		}
 
-		new_scope = g_strdup (unity_new_scope);
+		else
+			new_scope = g_strdup (unity_new_scope);
 	}
 
 	/*


### PR DESCRIPTION
The Unity plugin code is triggering false positives. We need to check
for empty string in addition to NULL.

Fixes 1379834
Server build on OSX crashes when it can't find libmono-native.dylib



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->