### PR TITLE
Hacky fix to avoid icall when performing a string.memcpy on a large a…

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -194,9 +194,9 @@ namespace System
 				((byte*)dest) [0] = ((byte*)src) [0];
 		}
 
-		internal static unsafe void Memcpy (byte *dest, byte *src, int len) {
+		internal static unsafe void Memcpy (byte *dest, byte *src, int len, bool useICall = true) {
 			// For bigger lengths, we use the heavily optimized native code
-			if (len > 32) {
+			if (len > 32 && useICall) {
 				InternalMemcpy (dest, src, len);
 				return;
 			}

--- a/mcs/class/corlib/ReferenceSources/String.cs
+++ b/mcs/class/corlib/ReferenceSources/String.cs
@@ -293,7 +293,7 @@ namespace System
 
 		static unsafe void memcpy (byte *dest, byte *src, int size)
 		{
-			Buffer.Memcpy (dest, src, size);
+			Buffer.Memcpy (dest, src, size, false);
 		}
 
 		/* Used by the runtime */


### PR DESCRIPTION
…mount of data. In a situation where an exception is supposed to be thrown the usage of the icall results in a crash.

Filed upstream bug: https://github.com/mono/mono/issues/21362

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1349195 @UnityAlex:
Mono: Fixed crash that would occur when assigning a large struct to the field of a null object.


**Backports**
2021.2

