### PR TITLE
Fix hang on shutdown by grabbing the rest of a previous fix

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1456,6 +1456,9 @@ socket_transport_close1 (void)
 	/* Close the read part only so it can still send back replies */
 	/* Also shut down the connection listener so that we can exit normally */
 #ifdef HOST_WIN32
+	MonoThreadInfo* info = mono_thread_info_lookup(debugger_thread_id);
+	if (info)
+		mono_threads_suspend_abort_syscall(info);
 	/* SD_RECEIVE doesn't break the recv in the debugger thread */
 	shutdown (conn_fd, SD_BOTH);
 	shutdown (listen_fd, SD_BOTH);


### PR DESCRIPTION
Previous fix: https://github.com/Unity-Technologies/mono/pull/574



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:


Fixed case 1374958 @UnityAlex:
Mono: Fixed hang on shutdown specific to windows where the debugger thread's blocking accept call wasn't being cancelled.



**Backports**
2021.2


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->