### PR TITLE
Make FileSystemEventArgs.FullPath return a fully qualified path

### DIFF
--- a/external/corefx-bugfix/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/external/corefx-bugfix/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    /// <devdoc>
+    ///    Provides data for the directory events: <see cref='System.IO.FileSystemWatcher.Changed'/>, <see cref='System.IO.FileSystemWatcher.Created'/>, <see cref='System.IO.FileSystemWatcher.Deleted'/>.
+    /// </devdoc>
+    public class FileSystemEventArgs : EventArgs
+    {
+        private readonly WatcherChangeTypes _changeType;
+        private readonly string _name;
+        private readonly string _fullPath;
+
+        /// <devdoc>
+        /// Initializes a new instance of the <see cref='System.IO.FileSystemEventArgs'/> class.
+        /// </devdoc>
+        public FileSystemEventArgs(WatcherChangeTypes changeType, string directory, string name)
+        {
+            _changeType = changeType;
+            _name = name;
+            _fullPath = Combine(directory, name);
+        }
+
+        /// <summary>Combines a directory path and a relative file name into a single path.</summary>
+        /// <param name="directoryPath">The directory path.</param>
+        /// <param name="name">The file name.</param>
+        /// <returns>The combined name.</returns>
+        /// <remarks>
+        /// This is like Path.Combine, except without argument validation,
+        /// and a separator is used even if the name argument is empty.
+        /// </remarks>
+        internal static string Combine(string directoryPath, string name)
+        {
+            bool hasSeparator = false;
+            if (directoryPath.Length > 0)
+            {
+                char c = directoryPath[directoryPath.Length - 1];
+                hasSeparator = c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+            }
+
+            return hasSeparator ?
+                directoryPath + name :
+                directoryPath + Path.DirectorySeparatorChar + name;
+        }
+
+        /// <devdoc>
+        ///    Gets one of the <see cref='System.IO.WatcherChangeTypes'/> values.
+        /// </devdoc>
+        public WatcherChangeTypes ChangeType
+        {
+            get
+            {
+                return _changeType;
+            }
+        }
+
+        /// <devdoc>
+        ///    Gets the fully qualified path of the affected file or directory.
+        /// </devdoc>
+        public string FullPath
+        {
+            get
+            {
+                return _fullPath;
+            }
+        }
+
+
+        /// <devdoc>
+        ///       Gets the name of the affected file or directory.
+        /// </devdoc>
+        public string Name
+        {
+            get
+            {
+                return _name;
+            }
+        }
+    }
+}

--- a/external/corefx-bugfix/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+++ b/external/corefx-bugfix/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
@@ -20,7 +20,7 @@ namespace System.IO
         {
             _changeType = changeType;
             _name = name;
-            _fullPath = Combine(directory, name);
+            _fullPath = Path.GetFullPath(Combine(directory, name));
         }
 
         /// <summary>Combines a directory path and a relative file name into a single path.</summary>

--- a/mcs/class/System/System_xtest.dll.sources
+++ b/mcs/class/System/System_xtest.dll.sources
@@ -114,7 +114,7 @@ System/RemoteExecutorTests.cs
 # System.IO.FileSystemWatcher
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Utility/*.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Args.ErrorEventArgs.cs
-../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
+../../../external/corefx-bugfix/src/System.IO.FileSystem.Watcher/tests/Args.FileSystemEventArgs.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/Args.RenamedEventArgs.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -878,7 +878,7 @@ ReferenceSources/Win32Exception.cs
 ../../../external/corefx/src/System.Private.Uri/src/System/UriBuilder.cs
 
 ../../../external/corefx/src/System.Runtime.Extensions/src/System/CodeDom/Compiler/IndentedTextWriter.cs
-../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
+../../../external/corefx-bugfix/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventArgs.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemEventHandler.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/RenamedEventArgs.cs


### PR DESCRIPTION
As per documentation: https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemeventargs.fullpath?view=net-6.0 the `FullPath` arg should return a fully qualified path.

Diff with fix is this changeset: https://github.com/Unity-Technologies/mono/pull/1534/commits/2c52fbdaafebbc9e62a281540c0505e39be57c9b

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1376258 @UnityAlex:
Mono: Correct issue where FileSystemEventArgs.FullPath did not return a fully qualified path.


**Backports**
2021.2

