### PR TITLE
Stop using git protocol for submodules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ build_osx_runtime:
             env_vars:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - cp .yamato/config/Stevedore.conf ~/Stevedore.conf
   - cd external/buildscripts
   - ./bee
@@ -66,7 +66,7 @@ build_osx_classlibs:
             env_vars:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - cp .yamato/config/Stevedore.conf ~/Stevedore.conf
   - cd external/buildscripts
   - ./bee
@@ -103,7 +103,7 @@ build_android:
             env_vars:
               - PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - cp .yamato/config/Stevedore.conf ~/Stevedore.conf
   - cd external/buildscripts
   - ./bee
@@ -132,7 +132,7 @@ build_win:
           flavor: b1.xlarge
           type: Unity::VM
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - perl external/buildscripts/build_runtime_win64.pl --stevedorebuilddeps=1
   - powershell mkdir -p incomingbuilds/win64
   - powershell cp -r builds/* incomingbuilds/win64/
@@ -157,7 +157,7 @@ build_win_x86:
           flavor: b1.xlarge
           type: Unity::VM
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - perl external/buildscripts/build_runtime_win.pl --stevedorebuilddeps=1
   - powershell mkdir -p incomingbuilds/win32
   - powershell cp -r builds/* incomingbuilds/win32/
@@ -182,7 +182,7 @@ build_win_bare_minimum:
           flavor: b1.xlarge
           type: Unity::VM
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - perl external/buildscripts/build_unityscript_bareminimum_win.pl
   - powershell mkdir -p incomingbuilds/bareminimum
   - powershell cp -r builds/* incomingbuilds/bareminimum/
@@ -200,7 +200,7 @@ build_linux_x64:
   - buildfarm
   - linux
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - cd external/buildscripts
   - ./bee
   - cd ../..
@@ -221,7 +221,7 @@ build_linux_x86:
   - buildfarm
   - linux
   script:
-  - git submodule update --init --recursive
+  - git -c url.https://.insteadof=git:// submodule update --init --recursive
   - cd external/buildscripts
   - ./bee
   - cd ../..

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,63 +1,63 @@
 [submodule "external/aspnetwebstack"]
 	path = external/aspnetwebstack
-	url = git://github.com/mono/aspnetwebstack.git
+	url = https://github.com/mono/aspnetwebstack.git
 [submodule "external/Newtonsoft.Json"]
 	path = external/Newtonsoft.Json
-	url = git://github.com/mono/Newtonsoft.Json.git
+	url = https://github.com/mono/Newtonsoft.Json.git
 [submodule "external/cecil"]
 	path = external/cecil
-	url = git://github.com/mono/cecil.git
+	url = https://github.com/mono/cecil.git
 [submodule "external/rx"]
 	path = external/rx
-	url = git://github.com/mono/rx.git
+	url = https://github.com/mono/rx.git
 	branch = rx-oss-v2.2
 [submodule "external/ikvm"]
 	path = external/ikvm
-	url = git://github.com/mono/ikvm-fork.git
+	url = https://github.com/mono/ikvm-fork.git
 [submodule "external/ikdasm"]
 	path = external/ikdasm
-	url = git://github.com/mono/ikdasm.git
+	url = https://github.com/mono/ikdasm.git
 [submodule "external/reference-assemblies"]
 	path = external/binary-reference-assemblies
-	url = git://github.com/mono/reference-assemblies.git
+	url = https://github.com/mono/reference-assemblies.git
 [submodule "external/nunit-lite"]
 	path = external/nunit-lite
-	url = git://github.com/mono/NUnitLite.git
+	url = https://github.com/mono/NUnitLite.git
 [submodule "external/nuget-buildtasks"]
 	path = external/nuget-buildtasks
-	url = git://github.com/mono/NuGet.BuildTasks
+	url = https://github.com/mono/NuGet.BuildTasks
 [submodule "external/cecil-legacy"]
 	path = external/cecil-legacy
-	url = git://github.com/mono/cecil.git
+	url = https://github.com/mono/cecil.git
 	branch = mono-legacy-0.9.5
 [submodule "external/boringssl"]
 	path = external/boringssl
-	url = git://github.com/mono/boringssl.git
+	url = https://github.com/mono/boringssl.git
 	branch = mono
 [submodule "external/corefx"]
 	path = external/corefx
-	url = git://github.com/mono/corefx.git
+	url = https://github.com/mono/corefx.git
 [submodule "external/bockbuild"]
 	path = external/bockbuild
-	url = git://github.com/mono/bockbuild.git
+	url = https://github.com/mono/bockbuild.git
 [submodule "external/linker"]
 	path = external/linker
-	url = git://github.com/mono/linker.git
+	url = https://github.com/mono/linker.git
 [submodule "external/roslyn-binaries"]
 	path = external/roslyn-binaries
-	url = git://github.com/mono/roslyn-binaries.git
+	url = https://github.com/mono/roslyn-binaries.git
 [submodule "external/corert"]
 	path = external/corert
-	url = git://github.com/mono/corert.git
+	url = https://github.com/mono/corert.git
 [submodule "external/xunit-binaries"]
 	path = external/xunit-binaries
-	url = git://github.com/mono/xunit-binaries.git
+	url = https://github.com/mono/xunit-binaries.git
 [submodule "external/api-doc-tools"]
 	path = external/api-doc-tools
-	url = git://github.com/mono/api-doc-tools.git
+	url = https://github.com/mono/api-doc-tools.git
 [submodule "external/api-snapshot"]
 	path = external/api-snapshot
-	url = git://github.com/mono/api-snapshot.git
+	url = https://github.com/mono/api-snapshot.git
 [submodule "external/bdwgc"]
 	path = external/bdwgc
-	url = git://github.com/Unity-Technologies/bdwgc.git
+	url = https://github.com/Unity-Technologies/bdwgc.git

--- a/.yamato/scripts/build_android.sh
+++ b/.yamato/scripts/build_android.sh
@@ -1,4 +1,4 @@
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 cp .yamato/config/Stevedore.conf ~/Stevedore.conf
 cd external/buildscripts
 ./bee

--- a/.yamato/scripts/build_linux_x64.sh
+++ b/.yamato/scripts/build_linux_x64.sh
@@ -1,8 +1,8 @@
 sudo apt-get install -y schroot
 sudo apt-get install -y binutils debootstrap
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 # try again in case previous update failed
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 export UNITY_THISISABUILDMACHINE=1
 cd external/buildscripts
 ./bee

--- a/.yamato/scripts/build_linux_x86.sh
+++ b/.yamato/scripts/build_linux_x86.sh
@@ -1,7 +1,7 @@
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 export UNITY_THISISABUILDMACHINE=1
 # try again in case previous update failed
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 cd external/buildscripts
 ./bee
 cd ../..

--- a/.yamato/scripts/build_osx_classlibs.sh
+++ b/.yamato/scripts/build_osx_classlibs.sh
@@ -1,4 +1,4 @@
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 cp .yamato/config/Stevedore.conf ~/Stevedore.conf
 cd external/buildscripts
 ./bee

--- a/.yamato/scripts/build_osx_runtime.sh
+++ b/.yamato/scripts/build_osx_runtime.sh
@@ -1,4 +1,4 @@
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 cp .yamato/config/Stevedore.conf ~/Stevedore.conf
 cd external/buildscripts
 ./bee

--- a/.yamato/scripts/build_win.bat
+++ b/.yamato/scripts/build_win.bat
@@ -1,5 +1,5 @@
 @echo off
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 
 perl external/buildscripts/build_runtime_win64.pl --stevedorebuilddeps=1
 if NOT %errorlevel% == 0 (

--- a/.yamato/scripts/build_win_bare_minimum.bat
+++ b/.yamato/scripts/build_win_bare_minimum.bat
@@ -1,5 +1,5 @@
 @echo off
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 
 perl external/buildscripts/build_unityscript_bareminimum_win.pl
 if NOT %errorlevel% == 0 (

--- a/.yamato/scripts/build_win_x86.bat
+++ b/.yamato/scripts/build_win_x86.bat
@@ -1,5 +1,5 @@
 @echo off
-git submodule update --init --recursive
+git -c url.https://.insteadof=git:// submodule update --init --recursive
 
 perl external/buildscripts/build_runtime_win.pl --stevedorebuilddeps=1
 if NOT %errorlevel% == 0 (

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ cloned in a single pass:
 Once cloned, submodules can be updated to pull down the latest changes.
 This can also be done after an initial non-recursive clone:
 
-	$ git submodule update --init --recursive
+	$ git -c url.https://.insteadof=git:// submodule update --init --recursive
 
 To pull external changes into a submodule:
 

--- a/scripts/submodules/versions.mk
+++ b/scripts/submodules/versions.mk
@@ -77,7 +77,7 @@ reset-$(1)::
 		echo "*** [$(1)] git checkout -f" $(NEEDED_$(2)_BRANCH) && (cd $($(2)_PATH) ; git checkout -f $(NEEDED_$(2)_BRANCH) || git checkout -f -b $($(2)_BRANCH_AND_REMOTE)); \
 		echo "*** [$(1)] git reset --hard $(NEEDED_$(2)_VERSION)" && (cd $($(2)_PATH) && git reset --hard $(NEEDED_$(2)_VERSION)); \
 	fi
-	@echo "*** [$(1)] git submodule update --init --recursive" && (cd $($(2)_PATH) && git submodule update --init --recursive)
+	@echo "*** [$(1)] git -c url.https://.insteadof=git:// submodule update --init --recursive" && (cd $($(2)_PATH) && git -c url.https://.insteadof=git:// submodule update --init --recursive)
 
 print-$(1)::
 	@printf "*** %-16s %-45s %s (%s)\n" "$(DIRECTORY_$(2))" "$(MODULE_$(2))" "$(NEEDED_$(2)_VERSION)" "$(NEEDED_$(2)_BRANCH)"

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -2,7 +2,7 @@
 SUBMODULE_ERROR='Could not recursively update all git submodules. You may experience compilation problems if some submodules are out of date'
 SUBMODULE_OK='Git submodules updated successfully'
 if test -d .git; then \
-	   (git submodule update --init --recursive && echo $SUBMODULE_OK) \
+	   (git -c url.https://.insteadof=git:// submodule update --init --recursive && echo $SUBMODULE_OK) \
 	|| (git submodule init && git submodule update --recursive && echo $SUBMODULE_OK) \
 	|| (git submodule init && git submodule update && echo $SUBMODULE_ERROR) \
 	|| (echo 'Git submodules could not be updated. Compilation will fail') \


### PR DESCRIPTION
GitHub is removing support for unencrypted git soon: https://github.blog/2021-09-01-improving-git-protocol-security-github/

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No



