### PR TITLE
Add missing handle function enter/return macros (case 1391935)

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3917,9 +3917,13 @@ mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
+	HANDLE_FUNCTION_ENTER ();
+
 	ERROR_DECL (error);
 	mono_field_static_get_value_checked (vt, field, value, MONO_HANDLE_NEW (MonoString, NULL), error);
 	mono_error_cleanup (error);
+
+	HANDLE_FUNCTION_RETURN ();
 }
 
 /**


### PR DESCRIPTION
The mono_field_static_get_value method uses a handle, but did not set up
enter/exit macros properly, so this handle was leaked.

Some code in Unity calls this embedding API method pretty often, which
can lead to the mark stack overflowing in the GC code.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1391935 @joshuap:
Mono: Avoid an intermittent "Unexpected mark stack overflow" error.

**Backports**

This will be back ported to 2022.1 and 2021.2. It came in with the Mono upgrade, so we don't need to back port it further.