### PR TITLE
Prevent inlining of calli native wrapper (case 1396617).

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7158,7 +7158,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 					g_assert (!fsig->hasthis && !fsig->pinvoke);
 
-					gboolean inline_wrapper = cfg->opt & MONO_OPT_INLINE || cfg->compile_aot;
+					/* UNITY: avoid inlining as no LMF will be setup, causing problems with exception handling.
+					* See FB case 1396617 and https://github.com/dotnet/runtime/issues/64073
+					* gboolean inline_wrapper = (cfg->opt & MONO_OPT_INLINE || cfg->compile_aot); */
+					gboolean inline_wrapper = FALSE;
 					if (inline_wrapper) {
 						int costs = inline_method (cfg, wrapper, fsig, sp, ip, cfg->real_offset, TRUE);
 						CHECK_CFG_EXCEPTION;


### PR DESCRIPTION
A last managed frame structure is not setup for calli instructions
outside of wrapper methods. Without an LMF, proper exception unwinding
cannot occur.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1396617 @joncham:
Mono: Fix incorrect Burst exception control flow in Unity Editor.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->

Upstream issue filed here: https://github.com/dotnet/runtime/issues/64073