### PR TITLE
Implement a couple of SocketAsyncEventArgs methods

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
@@ -249,6 +249,8 @@ namespace System.Net.Sockets
 
 		internal void FinishConnectByNameSyncFailure (Exception exception, int bytesTransferred, SocketFlags flags)
 		{
+			SetResults (exception, bytesTransferred, flags);
+
 			if (current_socket != null)
 				current_socket.is_connected = false;
 			
@@ -257,6 +259,8 @@ namespace System.Net.Sockets
 
 		internal void FinishOperationAsyncFailure (Exception exception, int bytesTransferred, SocketFlags flags)
 		{
+			SetResults (exception, bytesTransferred, flags);
+
 			if (current_socket != null)
 				current_socket.is_connected = false;
 			
@@ -274,8 +278,29 @@ namespace System.Net.Sockets
 		internal void SetResults (SocketError socketError, int bytesTransferred, SocketFlags flags)
 		{
 			SocketError = socketError;
+			ConnectByNameError = null;
 			BytesTransferred = bytesTransferred;
 			SocketFlags = flags;
+		}
+
+		internal void SetResults (Exception exception, int bytesTransferred, SocketFlags flags)
+		{
+			ConnectByNameError = exception;
+			BytesTransferred = bytesTransferred;
+			SocketFlags = flags;
+
+			if (exception == null)
+			{
+				SocketError = SocketError.Success;
+			}
+			else
+			{
+				var socketException = exception as SocketException;
+				if (socketException != null)
+					SocketError = socketException.SocketErrorCode;
+				else
+					SocketError = SocketError.SocketError;
+			}
 		}
 	}
 }

--- a/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketAsyncEventArgs.cs
@@ -249,12 +249,18 @@ namespace System.Net.Sockets
 
 		internal void FinishConnectByNameSyncFailure (Exception exception, int bytesTransferred, SocketFlags flags)
 		{
-			throw new NotImplementedException ();
+			if (current_socket != null)
+				current_socket.is_connected = false;
+			
+			Complete ();
 		}
 
 		internal void FinishOperationAsyncFailure (Exception exception, int bytesTransferred, SocketFlags flags)
 		{
-			throw new NotImplementedException ();
+			if (current_socket != null)
+				current_socket.is_connected = false;
+			
+			Complete ();
 		}
 
 		internal void FinishWrapperConnectSuccess (Socket connectSocket, int bytesTransferred, SocketFlags flags)


### PR DESCRIPTION
This does the work that currently was left as a NotImplementedException.

The Reference Source code does many other things that are tied up to their implementation, Mono's implementation is different enough that none of those seem to make sense.

There is one feature there that we do not handle, and it is not clear to me if we should implement it. They support delayed Socket Disposing and a number of other features that Mono's Socket does not:

https://github.com/mono/referencesource/blob/mono/System/net/System/Net/Sockets/Socket.cs#L6151

This is an area that has been significantly been cleaned up in .NET Core and looks a lot nicer to port and reuse than what exists in Reference Source.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1388925 @dtomar-rythmos:
Mono: Implement a couple of SocketAsyncEventArgs methods.


<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->