### PR TITLE
Remove handling SIGINT when Mono is embedded in Unity and the Player (case 1376434)

### DIFF
--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -323,6 +323,9 @@ MONO_SIG_HANDLER_FUNC (static, sigwinch_handler)
  * terminal is resized.    It sets an internal variable that is checked
  * by System.Console when the Terminfo driver has been activated.
  */
+
+extern GString* gEmbeddingHostName;
+
 static void
 console_set_signal_handlers ()
 {
@@ -340,10 +343,16 @@ console_set_signal_handlers ()
 	sigaction (SIGCONT, &sigcont, &save_sigcont);
 	
 	// Interrupt handler
-	sigint.sa_handler = (void (*)(int)) sigint_handler;
-	sigint.sa_flags = SA_RESTART;
-	sigemptyset (&sigint.sa_mask);
-	sigaction (SIGINT, &sigint, &save_sigint);
+	if (!gEmbeddingHostName)
+	{
+		// If gEmbeddingHostName is set, mono is embedded
+		// and the owning application needs to be in
+		// control of SIGNINT
+		sigint.sa_handler = (void (*)(int)) sigint_handler;
+		sigint.sa_flags = SA_RESTART;
+		sigemptyset (&sigint.sa_mask);
+		sigaction (SIGINT, &sigint, &save_sigint);
+	}
 
 	// Window size changed
 	sigwinch.sa_handler = (void (*)(int)) sigwinch_handler;
@@ -362,7 +371,8 @@ void
 console_restore_signal_handlers ()
 {
 	sigaction (SIGCONT, &save_sigcont, NULL);
-	sigaction (SIGINT, &save_sigint, NULL);
+	if (sigint.sa_handler)
+		sigaction (SIGINT, &save_sigint, NULL);
 	sigaction (SIGWINCH, &save_sigwinch, NULL);
 }
 #endif


### PR DESCRIPTION


Fixes fogbugz 1376434


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Release notes**

Fixed case 1376434 @bholmes :
Mono: Remove handling SIGINT when Mono is embedded in Unity and the Player.

**Backports**

 - 2022.1
 - 2021.2
 - 2020.3
 - 2019.4

