### PR TITLE
Implement ProcessStartInfo support for the ArgumentList parameter.

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -716,6 +716,16 @@ namespace System.Diagnostics
 
 				procInfo.envVariables = envVariables.ToArray ();
 			}
+			
+			if (startInfo.ArgumentList.Count > 0)
+			{
+				StringBuilder sb = new StringBuilder();
+				foreach (string argument in startInfo.ArgumentList)
+					PasteArguments.AppendArgument(sb, argument);
+
+				startInfo.Arguments = sb.ToString();
+			}
+
 
 			MonoIOError error;
 			IntPtr stdin_read = IntPtr.Zero, stdin_write = IntPtr.Zero;


### PR DESCRIPTION
I am currently looking into adding a runtime test for this on the Unity side but this appears to work in my local testing.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No
  - [X] Maybe? -- mono/mono still active?

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1396842 @UnityAlex:
Mono: Implemented ProcessStartInfo.ArgumentList which was introduced in .Net Standard 2.1.


**Backports**
2021.2

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->