### PR TITLE
Fix null reference crash

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2038,7 +2038,7 @@ cominterop_setup_marshal_context (EmitMarshalContext *m, MonoMethod *method)
 	csig->hasthis = 0;
 	csig->pinvoke = 1;
 
-	memset (&m, 0, sizeof (m));
+	memset (m, 0, sizeof (m));
 	m->image = method_klass_image;
 	m->piinfo = NULL;
 	m->retobj_var = 0;


### PR DESCRIPTION
caused by: https://github.com/Unity-Technologies/mono/pull/1509



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1351182 @UnityAlex:
Mono: Fixed crash that would occur after calling Marshal.GetCCW

Other options: Internal, Changed, Improved, Feature. 

**Backports**
2021.2

List the versions of Unity where this change should be back ported here.

