### PR TITLE
vtable setup fix for generic default interface methods in mono runtime

### DIFF
--- a/mono/metadata/class-setup-vtable.c
+++ b/mono/metadata/class-setup-vtable.c
@@ -1705,11 +1705,11 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		for (int i = 0; i < iface_onum; i++) {
 			MonoMethod *decl = iface_overrides [i*2];
 			MonoMethod *override = iface_overrides [i*2 + 1];
-			if (decl->is_inflated) {
+			if (mono_class_is_gtd (override->klass)) {
+				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
+			} else if (decl->is_inflated) {
 				override = mono_class_inflate_generic_method_checked (override, mono_method_get_context (decl), error);
 				mono_error_assert_ok (error);
-			} else if (mono_class_is_gtd (override->klass)) {
-				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
 			}
 			if (!apply_override (klass, ic, vtable, decl, override, &override_map, &override_class_map, &conflict_map))
 				goto fail;


### PR DESCRIPTION
When processing the overrides from interface default methods we should
check if the interface class is a generic type definition first and
inflate with the interface class context.

Fixes dotnet/runtime#61244


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Fixed case 1394314 @bholmes :
Mono: Fix default interface method crash when using mismatched generic arguments.


**Backports**

 - 2022.1
 - 2021.2

