### PR TITLE
Fix null reference crash caused by: https://github.com/Unity-Technolo…

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -2038,7 +2038,7 @@ cominterop_setup_marshal_context (EmitMarshalContext *m, MonoMethod *method)
 	csig->hasthis = 0;
 	csig->pinvoke = 1;
 
-	memset (&m, 0, sizeof (m));
+	memset (m, 0, sizeof (m));
 	m->image = method_klass_image;
 	m->piinfo = NULL;
 	m->retobj_var = 0;


### PR DESCRIPTION
…gies/mono/pull/1509

Backport of: https://github.com/Unity-Technologies/mono/pull/1548

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1401253 @UnityAlex :
Mono: Fixed crash that would occur after calling Marshal.GetCCW.

