### PR TITLE
Use double precision floating point for macOS ARM64 (case 1401410)

### DIFF
--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -178,7 +178,8 @@ typedef struct {
 #define MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP 1
 #define MONO_ARCH_LLVM_TARGET_LAYOUT "e-i64:64-i128:128-n32:64-S128"
 #ifdef TARGET_OSX
-#define MONO_ARCH_FORCE_FLOAT32 1
+// UNITY: disable 32-bit floating point to match other platforms and architectures
+// #define MONO_ARCH_FORCE_FLOAT32 1
 #endif
 
 // Does the ABI have a volatile non-parameter register, so tailcall


### PR DESCRIPTION
For all other platforms and architectures, Mono promotes all floating
point operations to double precision. While using single precision
allows for getting performance in some cases, it makes macOS ARM64 Mono
behave differently from other platform/architecture combinations.

So disable this feature to keep it consistent.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal case 1401410 @joshuap:
Mono: Use double precision floating point operations on macOS ARM64 to match the behavior on other platforms and architectures.

**Backports**

This should be back ported to 2022.1 and 2021.2.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->