### PR TITLE
Prefer zstd compression in .7z files

### DIFF
--- a/.yamato/scripts/collate_builds.sh
+++ b/.yamato/scripts/collate_builds.sh
@@ -1,5 +1,24 @@
+set -euxo pipefail
+
 sudo apt-get install -qy zip unzip
-sudo apt-get install -qy p7zip-full p7zip-rar
+
+# Use our forked 7za with zstd support.
+osarch=`uname -s`-`uname -m`
+case $osarch in
+	Linux-x86_64)
+		sevenzip_artifact=7za-linux-x64/9e098bea868c_201bbbd99b245a6f887497113ec305d1a7d158a1595d753e77017237ac91b722.zip
+		;;
+	*)
+		echo "Error: this script does not support $osarch"
+		exit 1
+	;;
+esac
+
+unpack_dir=external/buildscripts/artifacts/7za-zstd
+mono external/buildscripts/bee.exe steve internal-unpack public $sevenzip_artifact $unpack_dir
+chmod +x $unpack_dir/7za
+export PATH=`pwd`/$unpack_dir:$PATH
+
 perl external/buildscripts/collect_allbuilds.pl
 pwd
 ls -al

--- a/external/buildscripts/collect_allbuilds.pl
+++ b/external/buildscripts/collect_allbuilds.pl
@@ -11,6 +11,11 @@ my $monoroot = abs_path($monoroot);
 
 my $path = "incomingbuilds/";
 
+if ($^O ne "linux" && $^O ne "darwin")
+{
+	die("Unsupported platform to create stevedore artifact.")
+}
+
 rmtree("collectedbuilds");
 mkpath("collectedbuilds");
 
@@ -57,72 +62,32 @@ system("cp embedruntimes/linux64/libMonoPosixHelper.so monodistribution/lib/libM
 
 rmove('versions-aggregated.txt', 'versions.txt');
 
-my $externalBuildDeps = "$monoroot/external/buildscripts/artifacts/Stevedore";
-my $externalzip = "";
-if($^O eq "linux")
-{
-	$externalzip = "$externalBuildDeps/7za-linux-x64/7za";
-}
-elsif($^O eq 'darwin')
-{
-	$externalzip = "$externalBuildDeps/7za-mac-x64/7za";
-}
-
-
-# Create stevedore artifact
 print(">>> Create stevedore artifact $monoroot/stevedore/MonoBleedingEdge.7z");
-if($^O eq "linux" || $^O eq 'darwin')
-{
-	rmtree("../stevedore");
-	my $stevedoreMbePath = "../stevedore/MonoBleedingEdge";
-	my $stevedoreMbe7z = "../stevedore/MonoBleedingEdge.7z";
-	my $stevedoreMbeArtifactID = "../stevedore/artifactid.txt";
 
-	system("mkdir -p $stevedoreMbePath") eq 0 or die("failed to mkdir $stevedoreMbePath");
-	system("cp -r * $stevedoreMbePath/") eq 0 or die ("failed copying builds to $stevedoreMbePath\n");
-	if(-f $externalzip)
-	{
-		system("$externalzip a $stevedoreMbe7z $stevedoreMbePath/* -sdel") eq 0 or die("failed 7z up $stevedoreMbePath");
-	}
-	else
-	{
-		#Use 7z installed on the machine. If its not installed, please install it.
-		system("7z a $stevedoreMbe7z $stevedoreMbePath/* -sdel") eq 0 or die("failed 7z up $stevedoreMbePath");
-	}
-	system("rm -rf $stevedoreMbePath") eq 0 or die("failed to delete $stevedoreMbePath");
+rmtree("../stevedore");
+my $stevedoreMbePath = "../stevedore/MonoBleedingEdge";
+my $stevedoreMbe7z = "../stevedore/MonoBleedingEdge.7z";
+my $stevedoreMbeArtifactID = "../stevedore/artifactid.txt";
 
-	# Write stevedore artifact ID to file
-	my $revision = `git rev-parse --short HEAD`;
-	system("mono ../external/buildscripts/bee.exe steve new $stevedoreMbe7z MonoBleedingEdge $revision") eq 0 or die("failed running bee");
-	open (my $file, '>', $stevedoreMbeArtifactID);
-	my $artifactID = `mono ../external/buildscripts/bee.exe steve new $stevedoreMbe7z MonoBleedingEdge $revision`;
-	print $file $artifactID; 
-	print (">>> MonoBleedingEdge stevedore artifact ID: $artifactID\n");
-}
-else
-{
-	die("Unsupported platform to create stevedore artifact.")
-}
+system("mkdir -p $stevedoreMbePath") eq 0 or die("failed to mkdir $stevedoreMbePath");
+system("cp -r * $stevedoreMbePath/") eq 0 or die ("failed copying builds to $stevedoreMbePath\n");
+
+# Use our 7za fork with zstd support, installed in the PATH somewhere.
+# See .yamato/scripts/collate_builds.sh for more details.
+system("7za a $stevedoreMbe7z -m0=zstd -mx22 $stevedoreMbePath/* -sdel") eq 0 or die("failed 7z up $stevedoreMbePath");
+system("rm -rf $stevedoreMbePath") eq 0 or die("failed to delete $stevedoreMbePath");
+
+# Write stevedore artifact ID to file
+my $revision = `git rev-parse --short HEAD`;
+system("mono ../external/buildscripts/bee.exe steve new $stevedoreMbe7z MonoBleedingEdge $revision") eq 0 or die("failed running bee");
+open (my $file, '>', $stevedoreMbeArtifactID);
+my $artifactID = `mono ../external/buildscripts/bee.exe steve new $stevedoreMbe7z MonoBleedingEdge $revision`;
+print $file $artifactID; 
+print (">>> MonoBleedingEdge stevedore artifact ID: $artifactID\n");
+
 print(">>> Done creating stevedore artifact $monoroot/MonoBleedingEdge.7z");
 
 system("zip -r builds.zip *") eq 0 or die("failed zipping up builds");
 
-if($^O eq "linux" || $^O eq 'darwin')
-{
-	if(-f $externalzip)
-	{
-		system("$externalzip a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
-	}
-	else
-	{
-		#Use 7z installed on the machine. If its not installed, please install it.
-		system("7z a builds.7z * -x!builds.zip") eq 0 or die("failed 7z up builds");
-	}
-}
-else
-{
-	die("Unsupported platform for build collection.")
-}
-
-
+system("7za a builds.7z -m0=zstd -mx22 * -x!builds.zip") eq 0 or die("failed 7z up builds");
 


### PR DESCRIPTION
zstd is much faster to uncompress than 7za's default lzma2, let's try to create our .7z artifacts with zstd.

Uncompression time went from ~13.9s to ~3.2s on my mac laptop, while the compressed size increased from 224M to 273M.

On my windows workstation, the time went from ~15.7s down to ~6s.

https://jira.unity3d.com/browse/UBS-316

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No