### PR TITLE
Mark AppDomain.IsAppXModel as Intrinsic for UNITY_AOT

### DIFF
--- a/mcs/class/corlib/ReferenceSources/AppDomain.cs
+++ b/mcs/class/corlib/ReferenceSources/AppDomain.cs
@@ -6,6 +6,9 @@ namespace System {
 
 	public partial class AppDomain
 	{
+		#if UNITY_AOT
+		[System.Runtime.CompilerServices.Intrinsic]
+		#endif
 		internal static bool IsAppXModel ()
 		{
 			return false;


### PR DESCRIPTION
When the linker is set to experimental stripping it will strip
this IsAppXModel() and all the code paths where it could be true.
But IL2CPP replaces this with an intrinsic.  Adding the
IntrinsicAttribute will keep the linker from stripping the method.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->