### PR TITLE
2021.2 : Fixing more default interface problems (case 1365974) 

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1569,6 +1569,8 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, MonoDomain *domain, gpointer*
 				 * add_imt_builder_entry anyway.
 				 */
 				method = mono_class_get_method_by_index (mono_class_get_generic_class (iface)->container_class, method_slot_in_interface);
+				if (m_method_is_static (method))
+					continue;				
 				if (mono_method_get_imt_slot (method) != slot_num) {
 					vt_slot ++;
 					continue;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -832,7 +832,7 @@ get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 	}
 
 	method = jinfo_get_method (ji);
-	if (mono_method_get_context (method)->method_inst) {
+	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method)) {
 		/* A MonoMethodRuntimeGenericContext* */
 		return info;
 	} else if ((method->flags & METHOD_ATTRIBUTE_STATIC) || m_class_is_valuetype (method->klass)) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -860,12 +860,13 @@ mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_inf
 
 	method = jinfo_get_method (ji);
 	g_assert (method->is_inflated);
-	if (mono_method_get_context (method)->method_inst) {
+	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method)) {
 		MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext *)generic_info;
 
 		klass = mrgctx->class_vtable->klass;
 		context.method_inst = mrgctx->method_inst;
-		g_assert (context.method_inst);
+		if (!mini_method_is_default_method (method))
+			g_assert (context.method_inst);		
 	} else {
 		MonoVTable *vtable = (MonoVTable *)generic_info;
 
@@ -877,6 +878,12 @@ mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_inf
 		method_container_class = mono_class_get_generic_class (method->klass)->container_class;
 	else
 		method_container_class = method->klass;
+
+	if (mini_method_is_default_method (method)) {
+		if (mono_class_is_ginst (klass) || mono_class_is_gtd (klass))
+			context.class_inst = mini_class_get_context (klass)->class_inst;
+		return context;
+	}
 
 	/* class might refer to a subclass of method's class */
 	while (!(klass == method->klass || (mono_class_is_ginst (klass) && mono_class_get_generic_class (klass)->container_class == method_container_class))) {

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -565,7 +565,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 		/*
 		 * The caller is gshared code, compute the actual method to call from M and this/rgctx.
 		 */
-		if (m->is_inflated && mono_method_get_context (m)->method_inst) {
+		if (m->is_inflated && (mono_method_get_context (m)->method_inst || mini_method_is_default_method (m))) {
 			MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext*)mono_arch_find_static_call_vtable (regs, code);
 
 			klass = mrgctx->class_vtable->klass;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -643,11 +643,13 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 		return NULL;
 
 	if (generic_virtual || variant_iface) {
-		if (m_class_is_valuetype (vt->klass)) /*FIXME is this required variant iface?*/
+		if (m_class_is_valuetype (vt->klass)  && !mini_method_is_default_method (m)) /*FIXME is this required variant iface?*/
 			need_unbox_tramp = TRUE;
 	} else if (orig_vtable_slot) {
-		if (m_class_is_valuetype (m->klass))
+		if (m_class_is_valuetype (m->klass)) {
+			g_assert (!mini_method_is_default_method (m));
 			need_unbox_tramp = TRUE;
+		}
 	}
 
 	addr = mini_add_method_trampoline (m, compiled_method, need_rgctx_tramp, need_unbox_tramp);


### PR DESCRIPTION
Several cherry-picks for default interface methods....

Fix crash in common_call_trampoline due to inconsistent rgctx mode https://github.com/mono/mono/pull/21250

[mini] Don't add unbox tramopline on generic DIM calls (https://github.com/mono/mono/pull/21208)
Don't unbox a valuetype this if the generic method is a DIM

Fixes https://github.com/dotnet/runtime/issues/58394

[mono] Fix StackTrace from a dim and Vtable offsets for static interf…
…ace method

Fix StackTrace when called from a DIM.
Fix the other test case that was added for @bholmes, and this case when the method TestMethod5 was being called it was executing TestMethod10, and this was fixed skipping static interface methods when was calculating vtable offsets.

Should this pull request have release notes?
 Yes
 No
Do these changes need to be back ported?
 Yes
 No
Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
 Yes
 No
Reviewers: please consider these questions as well! ❤️

**Release notes**

Fixed case 1365974 @schoudhary-rythmos :
Mono: Fix generic default interface method crash with Environment.StackTrace.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1551

The cherry pick was 100% clean.