### PR TITLE
Fix NamedPipeServerStream on windows7

### DIFF
--- a/data/config.in
+++ b/data/config.in
@@ -43,4 +43,11 @@
 	<dllmap dll="gdiplus.dll" target="@libgdiplus_install_loc@"  os="!windows"/>
 	<dllmap dll="gdi32" target="@libgdiplus_install_loc@" os="!windows"/>
 	<dllmap dll="gdi32.dll" target="@libgdiplus_install_loc@" os="!windows"/>
+
+    <!-- Some .net base class library code pinvokes into api-ms-win-core-threadpool-l1-2-0.dll. The only thing this library does is forward the call
+	to kernel32.dll (on windows desktop, versions on other platforms might forward elsewhere.  Unfortunately this library did not ship with windows7.
+	We're using the dll remap functionality in this file to have mono directly route these calls into kernel32, just like the library would do so that
+	the BCL code that relies on this can work on windows7 again.  This functionality that does not work without this workaround includes NamedServerPipeStream.
+	-->
+	<dllmap dll="api-ms-win-core-threadpool-l1-2-0.dll" target="kernel32.dll" os="windows"/>
 </configuration>


### PR DESCRIPTION
Some .net base class library code pinvokes into api-ms-win-core-threadpool-l1-2-0.dll. The only thing this library does is forward the call
	to kernel32.dll (on windows desktop, versions on other platforms might forward elsewhere.  Unfortunately this library did not ship with windows7.
	We're using the dll remap functionality in this file to have mono directly route these calls into kernel32, just like the library would do so that
	the BCL code that relies on this can work on windows7 again.  This functionality that does not work without this workaround includes NamedServerPipeStream.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->