### PR TITLE
Change SafeSocketHandle to handle a 0 file descriptor for UNITY AOT

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
+++ b/mcs/class/System/System.Net.Sockets/SafeSocketHandle.cs
@@ -15,8 +15,11 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.Sockets {
 
+#if UNITY_AOT
+	sealed class SafeSocketHandle : SafeHandleMinusOneIsInvalid {
+#else
 	sealed class SafeSocketHandle : SafeHandleZeroOrMinusOneIsInvalid {
-
+#endif
 		List<Thread> blocking_threads;
 		Dictionary<Thread, StackTrace> threads_stacktraces;
 


### PR DESCRIPTION
Discovered a console that uses 0 as the file descriptor for a socket.
The documentation on POSIX states that only -1 is invalid.
Also the dotnet/runtime repo has already made this change.

This is part of the fix for fogbugz 1389108



- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:


**Backports**

List the versions of Unity where this change should be back ported here.

 - 2022.1
 - 2021.2
 - 2020.3 - Maybe, unclear if this would be safe prior to Mono upgrade

