### PR TITLE
Add support for building classlibs on apple silicon devices

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -7,6 +7,7 @@ use lib ('external/buildscripts', "../../Tools/perl_lib","perl_lib", 'external/b
 use strict;
 use warnings;
 use Tools qw(InstallNameTool);
+use POSIX;
 
 print ">>> PATH in Build All = $ENV{PATH}\n\n";
 
@@ -204,11 +205,12 @@ if($^O eq "linux")
 }
 elsif($^O eq 'darwin')
 {
-	$monoHostArch = "x86_64";
+	$monoHostArch = (POSIX::uname)[4];
 	$existingExternalMono = "$existingExternalMonoRoot";
 	$existingExternalMonoBinDir = "bin";
 
-	if ($targetArch eq "arm64")
+	# Save time when cross compiling
+	if ($targetArch ne $monoHostArch)
 	{
 		$disableMcs = 1;
 		$test = 0;

--- a/external/buildscripts/build_classlibs_osx.pl
+++ b/external/buildscripts/build_classlibs_osx.pl
@@ -3,6 +3,7 @@ use Cwd 'abs_path';
 use Getopt::Long;
 use File::Basename;
 use File::Path;
+use POSIX;
 
 my $monoroot = File::Spec->rel2abs(dirname(__FILE__) . "/../..");
 my $monoroot = abs_path($monoroot);
@@ -14,6 +15,7 @@ my $mcsOnly = 0;
 my $skipMonoMake = 0;
 my $stevedoreBuildDeps=1;
 my $cpus = `sysctl -n hw.ncpu`;
+my $targetArch = (POSIX::uname)[4];
 
 # Handy troubleshooting/niche options
 
@@ -35,7 +37,7 @@ system(
 	"--build=$build",
 	"--clean=$clean",
 	"--mcsonly=$mcsOnly",
-	"--targetarch=x86_64",
+	"--targetarch=$targetArch",
 	"--skipmonomake=$skipMonoMake",
 	"--artifact=1",
 	"--artifactscommon=1",


### PR DESCRIPTION
Adding ability to build classlibs on arm devices

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:


**Backports**
Anywhere apple silicon support exists and we'd need to do dev work. We could do this ad-hoc.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->