### PR TITLE
Make SmtpClient match coreclr behavior where it will adhere to whatev…

### DIFF
--- a/mcs/class/System/System.Net.Mail/SmtpClient.cs
+++ b/mcs/class/System/System.Net.Mail/SmtpClient.cs
@@ -1169,7 +1169,7 @@ try {
 			settings.UseServicePointManagerCallback = true;
 			var sslStream = new SslStream (stream, false, tlsProvider, settings);
 			CheckCancellation ();
-			sslStream.AuthenticateAsClient (Host, this.ClientCertificates, SslProtocols.Default, false);
+			sslStream.AuthenticateAsClient (Host, this.ClientCertificates, (SslProtocols)ServicePointManager.SecurityProtocol, false);
 			stream = sslStream;
 
 #else


### PR DESCRIPTION
…er protocol is set in ServicePointManager



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No
  - [X] Maybe?

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1389326 @UnityAlex :
Mono: Fix bug where the SmtpClient would ignore the ServicePointManager's SecurityProtocol level.


**Backports**
2022.1, 2021.2, 2020.3