### PR TITLE
2021.2 : Make Process.Start() not throw exception when Windows path contains '.

### DIFF
--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -399,14 +399,12 @@ process_unquote_application_name (gchar *appname)
 static gchar*
 process_quote_path (const gchar *path)
 {
-	gchar *res = g_shell_quote (path);
-	gchar *q = res;
-	while (*q) {
-		if (*q == '\'')
-			*q = '\"';
-		q++;
-	}
-	return res;
+	size_t len = strlen (path);
+	GString *result = g_string_sized_new (len + 3);
+	g_string_append_c (result, '"');
+	g_string_append (result, path);
+	g_string_append_c (result, '"');
+	return g_string_free (result, FALSE);
 }
 
 /* Only used when UseShellExecute is false */


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1387637 @schoudhary-rythmos :
Mono: Fixed incorrect exception being thrown via Process.Start when windows path contains '

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1543

The cherry pick was 100% clean.

Yamato shows failure due to unrelated reason "fatal: clone of 'git://github.com/mono/Newtonsoft.Json.git' into submodule path 'C:/build/output/Unity-Technologies/mono/external/Newtonsoft.Json' failed"

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->