### PR TITLE
2020.3 : Make SmtpClient match coreclr behavior where it will adhere to whatev…

### DIFF
--- a/mcs/class/System/System.Net.Mail/SmtpClient.cs
+++ b/mcs/class/System/System.Net.Mail/SmtpClient.cs
@@ -1169,7 +1169,7 @@ try {
 			settings.UseServicePointManagerCallback = true;
 			var sslStream = tlsProvider.CreateSslStream (stream, false, settings);
 			CheckCancellation ();
-			sslStream.AuthenticateAsClient (Host, this.ClientCertificates, SslProtocols.Default, false);
+			sslStream.AuthenticateAsClient (Host, this.ClientCertificates, (SslProtocols)ServicePointManager.SecurityProtocol, false);
 			stream = sslStream.AuthenticatedStream;
 
 #else


### PR DESCRIPTION
…er protocol is set in ServicePointManager



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1389326 @schoudhary-rythmos :
Mono: Fix bug where the SmtpClient would ignore the ServicePointManager's SecurityProtocol level.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1571

Cherry pick was 100% clean.

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed case XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->