### PR TITLE
Remove handling SIGINT when Mono is embedded in Unity and the Player

### DIFF
--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -323,6 +323,9 @@ MONO_SIG_HANDLER_FUNC (static, sigwinch_handler)
  * terminal is resized.    It sets an internal variable that is checked
  * by System.Console when the Terminfo driver has been activated.
  */
+
+extern GString* gEmbeddingHostName;
+
 static void
 console_set_signal_handlers ()
 {
@@ -340,10 +343,16 @@ console_set_signal_handlers ()
 	sigaction (SIGCONT, &sigcont, &save_sigcont);
 	
 	// Interrupt handler
-	sigint.sa_handler = (void (*)(int)) sigint_handler;
-	sigint.sa_flags = SA_RESTART;
-	sigemptyset (&sigint.sa_mask);
-	sigaction (SIGINT, &sigint, &save_sigint);
+	if (!gEmbeddingHostName)
+	{
+		// If gEmbeddingHostName is set, mono is embedded
+		// and the owning application needs to be in
+		// control of SIGNINT
+		sigint.sa_handler = (void (*)(int)) sigint_handler;
+		sigint.sa_flags = SA_RESTART;
+		sigemptyset (&sigint.sa_mask);
+		sigaction (SIGINT, &sigint, &save_sigint);
+	}
 
 	// Window size changed
 	sigwinch.sa_handler = (void (*)(int)) sigwinch_handler;
@@ -362,7 +371,8 @@ void
 console_restore_signal_handlers ()
 {
 	sigaction (SIGCONT, &save_sigcont, NULL);
-	sigaction (SIGINT, &save_sigint, NULL);
+	if (sigint.sa_handler)
+		sigaction (SIGINT, &save_sigint, NULL);
 	sigaction (SIGWINCH, &save_sigwinch, NULL);
 }
 #endif


### PR DESCRIPTION
Fixes fogbugz 1376434



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1376434 @dtomar-rythmos :
Mono: Remove handling SIGINT when Mono is embedded in Unity and the Player.

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->