### PR TITLE
The MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX define doesn't exist anymore sin…

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3404,7 +3404,6 @@ print_stack_frame_to_string (StackFrameInfo *frame, MonoContext *ctx, gpointer d
 MONO_API int
 mono_unity_backtrace_from_context (void* context, void* array[], int count)
 {
-#ifdef MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX
 	MonoContext mctx;
 	void*  ip = 0;
 	void** bp = 0;
@@ -3424,9 +3423,6 @@ mono_unity_backtrace_from_context (void* context, void* array[], int count)
 	}
 
 	return idx;
-#else
-	return 0;
-#endif
 }
 /*
  * mono_handle_native_crash:


### PR DESCRIPTION
…ce e7011c780f676914f559f14f25e76c192bb2b0b2 (case 1411374)



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1411374 @dtomar-rythmos :
Mono: Fixed issue where callstacks would not be reported on OSX.

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->