### PR TITLE
2021.3: Throw exception when marshaling generic return types (case 1390445)

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6328,7 +6328,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 	/* ret = method (...) */
 	mono_mb_emit_managed_call (mb, method, NULL);
 
-	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
+	if (MONO_TYPE_ISSTRUCT (sig->ret) && sig->ret->type != MONO_TYPE_GENERICINST) {
 		MonoClass *klass = mono_class_from_mono_type_internal (sig->ret);
 		mono_class_init_internal (klass);
 		if (!(mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass))) {
@@ -6372,6 +6372,10 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 		case MONO_TYPE_SZARRAY:
 			mono_emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
 			break;
+		case MONO_TYPE_GENERICINST: {
+			mono_mb_emit_byte (mb, CEE_POP);
+			break;
+		}
 		default:
 			g_warning ("return type 0x%02x unknown", sig->ret->type);	
 			g_assert_not_reached ();

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3867,6 +3867,11 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 		mono_method_get_marshal_info (invoke, mspecs);
 	}
 
+	if (invoke_sig->ret->type == MONO_TYPE_GENERICINST) {
+		mono_error_set_generic_error (error, "System.Runtime.InteropServices", "MarshalDirectiveException", "%s", "Cannot marshal 'return value': Non-blittable generic types cannot be marshaled.");
+		return NULL;
+	}
+
 	sig = mono_method_signature_internal (method);
 
 	mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_NATIVE_TO_MANAGED);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3859,17 +3859,19 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 			mono_error_set_invalid_program (error, "method %s with UnmanagedCallersOnlyAttribute has non-blittable parameters or return type", mono_method_full_name (method, TRUE));
 			return NULL;
 		}
-		mspecs = g_new0 (MonoMarshalSpec*, invoke_sig->param_count + 1);
 	} else {
 		invoke = mono_get_delegate_invoke_internal (delegate_klass);
 		invoke_sig = mono_method_signature_internal (invoke);
-		mspecs = g_new0 (MonoMarshalSpec*, invoke_sig->param_count + 1);
-		mono_method_get_marshal_info (invoke, mspecs);
 	}
 
 	if (invoke_sig->ret->type == MONO_TYPE_GENERICINST) {
 		mono_error_set_generic_error (error, "System.Runtime.InteropServices", "MarshalDirectiveException", "%s", "Cannot marshal 'return value': Non-blittable generic types cannot be marshaled.");
 		return NULL;
+	}
+
+	mspecs = g_new0 (MonoMarshalSpec*, invoke_sig->param_count + 1);
+	if (invoke) {
+		mono_method_get_marshal_info (invoke, mspecs);
 	}
 
 	sig = mono_method_signature_internal (method);

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -1155,6 +1155,13 @@ mono_test_marshal_icall_delegate (IcallDelegate del)
 	return strcmp (res, "ABC") == 0 ? 0 : 1;
 }
 
+typedef char* (STDCALL *NullableReturnDelegate) (void);
+LIBTEST_API void STDCALL
+mono_test_marshal_nullable_ret_delegate (NullableReturnDelegate del)
+{
+	del ();
+}
+
 LIBTEST_API int STDCALL  
 mono_test_marshal_stringbuilder (char *s, int n)
 {

--- a/mono/tests/pinvoke3.cs
+++ b/mono/tests/pinvoke3.cs
@@ -197,6 +197,9 @@ public class Tests {
 	[DllImport ("libtest", EntryPoint="mono_test_marshal_icall_delegate")]
 	public static extern int mono_test_marshal_icall_delegate (IcallDelegate del);
 
+	[DllImport ("libtest", EntryPoint="mono_test_marshal_nullable_ret_delegate")]
+	public static extern int mono_test_marshal_nullable_ret_delegate (NullableReturnDelegate del);
+
 	public delegate string IcallDelegate (IntPtr p);
 
 	public delegate int TestDelegate (int a, ref SimpleStruct ss, int b);
@@ -224,6 +227,8 @@ public class Tests {
 	public delegate int DelegateByrefDelegate (ref return_int_delegate del);
 
 	public delegate int VirtualDelegate (int i);
+
+	public delegate Nullable<int> NullableReturnDelegate ();
 
 	public static int Main () {
 		return TestDriver.RunTests (typeof (Tests));
@@ -1267,5 +1272,24 @@ public class Tests {
 		var m = typeof (Marshal).GetMethod ("PtrToStringAnsi", new Type[] { typeof (IntPtr) });
 
 		return mono_test_marshal_icall_delegate ((IcallDelegate)Delegate.CreateDelegate (typeof (IcallDelegate), m));
+	}
+
+	private static Nullable<int> nullable_ret_cb () {
+		return 0;
+	}
+
+	public static int test_0_generic_return () {
+		try {
+			Marshal.GetFunctionPointerForDelegate<NullableReturnDelegate> (nullable_ret_cb);
+			return 1;
+		} catch (MarshalDirectiveException) {
+		}
+		try {
+			mono_test_marshal_nullable_ret_delegate (nullable_ret_cb);
+			return 2;
+		} catch (MarshalDirectiveException) {
+		}
+
+		return 0;
 	}
 }


### PR DESCRIPTION
Throw a MarshalDirectiveException when marshalling generic instances as return types from pinvoke callbacks.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed case 1390445 @gsanthamoorthy-rythmos :
Mono: Throw a MarshalDirectiveException when marshaling generic instances as return types from pinvoke callbacks.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1561
2022.1 PR: https://github.com/Unity-Technologies/mono/pull/1561

The cherry pick was 100% clean.