### PR TITLE
2022.1: Fixing unityjit makefile source list for Win32 (case 1397970)

### DIFF
--- a/mcs/class/System.Security/win32_unityjit_System.Security.dll.exclude.sources
+++ b/mcs/class/System.Security/win32_unityjit_System.Security.dll.exclude.sources
@@ -1,0 +1,1 @@
+#include win32_System.Security.dll.exclude.sources

--- a/mcs/class/System.Security/win32_unityjit_System.Security.dll.sources
+++ b/mcs/class/System.Security/win32_unityjit_System.Security.dll.sources
@@ -1,0 +1,1 @@
+#include win32_System.Security.dll.sources


### PR DESCRIPTION
Bringing the implementation from corefx. This is equivalent to what
is done for win32_net_4_x_System.Security.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed case 1397970 @ppandi-rythmos :
Mono: Fix PlatformNotSupportedException when calling System.Security.Cryptography.ProtectedData.Protect.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1575

The cherry pick was 100% clean.