### PR TITLE
[2021.3]Fix ephemerons with incremental GC (case 1418292).

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -72,7 +72,9 @@ static void
 mono_push_other_roots(void);
 
 static void
-mono_push_ephemerons(void);
+mono_clear_ephemerons (void);
+static void
+mono_push_ephemerons (void);
 static void*
 null_ephemerons_for_domain (MonoDomain* domain);
 
@@ -634,6 +636,9 @@ on_gc_notification (GC_EventType event)
 	case GC_EVENT_POST_START_WORLD:
 		mono_thread_info_suspend_unlock ();
 		MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_POST_START_WORLD_UNLOCKED, 0, TRUE));
+		break;
+	case GC_EVENT_RECLAIM_START:
+		mono_clear_ephemerons ();
 		break;
 	default:
 		break;
@@ -2020,7 +2025,7 @@ typedef struct {
 } Ephemeron;
 
 static void
-mono_push_ephemerons (void)
+mono_clear_ephemerons (void)
 {
 	ephemeron_node* prev_node = NULL;
 	ephemeron_node* current_node = NULL;
@@ -2060,7 +2065,46 @@ mono_push_ephemerons (void)
 			if (!GC_is_marked (current_ephemeron->key)) {
 				mono_gc_wbarrier_generic_store_internal (&current_ephemeron->key, tombstone);
 				current_ephemeron->value = NULL;
-			} else if (current_ephemeron->value && !GC_is_marked (current_ephemeron->value)) {
+			}
+		}
+	}
+}
+
+static void
+mono_push_ephemerons (void)
+{
+	ephemeron_node* prev_node = NULL;
+	ephemeron_node* current_node = NULL;
+
+	/* iterate all registered Ephemeron[] */
+	for (current_node = ephemeron_list; current_node; current_node = current_node->next)
+	{
+		Ephemeron* current_ephemeron, * array_end;
+		MonoObject* tombstone = NULL;
+		/* reveal weak link value*/
+		MonoArray* array = REVEAL_POINTER (current_node->ephemeron_array_weak_link);
+
+		/* remove unmarked (non-reachable) arrays from the list */
+		if (!GC_is_marked (array)) {
+			continue;
+		}
+
+		prev_node = current_node;
+
+		current_ephemeron = mono_array_addr_internal (array, Ephemeron, 0);
+		array_end = current_ephemeron + mono_array_length_internal (array);
+		tombstone = array->obj.vtable->domain->ephemeron_tombstone;
+
+		for (; current_ephemeron < array_end; ++current_ephemeron) {
+			/* skip a null or tombstone (empty) key */
+			if (!current_ephemeron->key || current_ephemeron->key == tombstone)
+				continue;
+
+			/* If the key is not marked, then don't mark value. */
+			if (!GC_is_marked (current_ephemeron->key))
+				continue;
+
+			if (current_ephemeron->value && !GC_is_marked (current_ephemeron->value)) {
 				/* the key is marked, so mark the value if needed */
 				GC_push_all (&current_ephemeron->value, &current_ephemeron->value + 1);
 			}


### PR DESCRIPTION
Incremental GC may result in an empty mark stack without actually
finishing the GC. Previous code assumed this and marked/cleared
ephemerons at the same time. Now they are marked whenever the mark
stack is empty, but only cleared when a GC is finished.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed case 1418292 @AswinRajGopal  :
Mono: Fix random crash on exit or domain reload.

**Comments To Reviewers**
Cherry pick is [CleanGraft]

Trunk PR: https://github.com/Unity-Technologies/mono/pull/1587
2022.1 PR: https://github.com/Unity-Technologies/mono/pull/1612