### PR TITLE
2022.1: Implemented ProcessStartInfo.ArgumentList which was introduced in .Net Standard 2.1.

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -716,6 +716,16 @@ namespace System.Diagnostics
 
 				procInfo.envVariables = envVariables.ToArray ();
 			}
+			
+			if (startInfo.ArgumentList.Count > 0)
+			{
+				StringBuilder sb = new StringBuilder();
+				foreach (string argument in startInfo.ArgumentList)
+					PasteArguments.AppendArgument(sb, argument);
+
+				startInfo.Arguments = sb.ToString();
+			}
+
 
 			MonoIOError error;
 			IntPtr stdin_read = IntPtr.Zero, stdin_write = IntPtr.Zero;


### PR DESCRIPTION
Implement ProcessStartInfo support for the ArgumentList parameter. 

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed case 1396842 @achavakula-rythmos :
Mono: Implemented ProcessStartInfo.ArgumentList which was introduced in .Net Standard 2.1.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1547

The cherry pick was 100% clean.