### PR TITLE
2021.3: Fixed builds failures when doing .NET Framework API builds and referencing types in System.Drawing

### DIFF
--- a/mcs/class/Facades/System.Drawing.Common/Makefile
+++ b/mcs/class/Facades/System.Drawing.Common/Makefile
@@ -15,7 +15,7 @@ SIGN_FLAGS = /delaysign /nowarn:1616,1699
 LIB_REFS = System
 LIB_MCS_FLAGS = $(SIGN_FLAGS) $(EXTRA_LIB_MCS_FLAGS) -d:FEATURE_TYPECONVERTER
 
-ifneq (,$(filter build net_4_x unityjit, $(PROFILE)))
+ifneq (,$(filter build net_4_x unityjit unityaot, $(PROFILE)))
 $(error This profile shouldn't build System.Drawing.Common.dll, it already has System.Drawing.dll)
 endif
 

--- a/mcs/class/Facades/System.Drawing.Primitives/Makefile
+++ b/mcs/class/Facades/System.Drawing.Primitives/Makefile
@@ -14,7 +14,7 @@ SIGN_FLAGS = /delaysign /nowarn:1616,1699
 LIB_REFS = System
 LIB_MCS_FLAGS = $(SIGN_FLAGS) $(EXTRA_LIB_MCS_FLAGS)
 
-ifneq (,$(filter build net_4_x unityjit, $(PROFILE)))
+ifneq (,$(filter build net_4_x unityjit unityaot, $(PROFILE)))
 # drawing types are inside System.Drawing.dll
 LIB_REFS += System.Drawing
 else

--- a/mcs/class/Facades/netstandard/Makefile
+++ b/mcs/class/Facades/netstandard/Makefile
@@ -34,7 +34,7 @@ else
 LIB_REFS += System.Web System.Transactions System.Runtime.Serialization System.Data System.Data.DataSetExtensions
 endif
 
-ifneq (,$(filter build net_4_x unityjit, $(PROFILE)))
+ifneq (,$(filter build net_4_x unityjit unityaot, $(PROFILE)))
 # drawing types are inside System.Drawing.dll
 LIB_REFS += System.Drawing
 else

--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -75,7 +75,7 @@ testing_winaot_interp_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS
 unityjit_SUBDIRS = $(common_DEPS_SUBDIRS)
 unityjit_PARALLEL_SUBDIRS = $(common_SUBDIRS) System.Net.Http.Rtc $(mobile_only_SUBDIRS)
 
-unityaot_SUBDIRS = $(common_DEPS_SUBDIRS) System.Drawing.Common
+unityaot_SUBDIRS = $(common_DEPS_SUBDIRS)
 unityaot_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS)
 
 orbis_SUBDIRS = $(common_DEPS_SUBDIRS) System.Drawing.Common

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -199,7 +199,8 @@ orbis_dirs_parallel := \
 	$(filter-out Microsoft.CSharp Mono.Data.Sqlite,$(mobile_common_dirs_parallel))
 
 unityaot_dirs_parallel := \
-	$(mobile_common_dirs_parallel)
+	$(mobile_common_dirs_parallel) \
+	System.Drawing
 
 xammac_4_5_dirs_parallel := \
 	Mono.Security \


### PR DESCRIPTION
In the unityaot profile we were includes System.Drawing.dll and
Facades/System.Drawing.Common.dll.  And referencing the implementation
of Facades/System.Drawing.Common.dll in the profile's netstandard.dll.

This means that for NetFw profile builds that include a netstandard
library we inlcude both libraries and end up with the same type
declaring in multiple assemblies.

This PR changes the unityaot profile to only include System.Drawing.dll,
which is exactly what we do for the unityjit profile, and how it
was setup prior to the Mono upgrade in 2021.2.


- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed case 1413051 @achavakula-rythmos :
IL2CPP: Fixed builds failures when doing .NET Framework API builds and referencing types in System.Drawing

Comments to reviewers

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1603
Cherry pick is [CleanGraft]

