### PR TITLE
Fixed System.Windows.Forms.SendKeys.Send under windows

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
@@ -287,21 +287,24 @@ namespace System.Windows.Forms {
 			internal Int32 yHotspot;
 			internal IntPtr hbmMask;
 			internal IntPtr hbmColor;
-		}    
+		}
 		
 		[StructLayout(LayoutKind.Explicit)]
-		internal struct INPUT {
+		internal struct InputUnion {
 			[FieldOffset(0)]
-			internal Int32 type;
-
-			[FieldOffset(4)]
 			internal MOUSEINPUT mi;
 
-			[FieldOffset(4)]
+			[FieldOffset(0)]
 			internal KEYBDINPUT ki;
 
-			[FieldOffset(4)]
+			[FieldOffset(0)]
 			internal HARDWAREINPUT hi;
+		}
+		
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct INPUT {
+			internal Int32 type;
+			internal InputUnion U;
 		}
 
 		[StructLayout (LayoutKind.Sequential)]
@@ -3251,10 +3254,10 @@ namespace System.Windows.Forms {
 				MSG msg = (MSG)keys.Dequeue();
 
 				
-				inputs[i].ki.wScan = 0;
-				inputs[i].ki.time = 0;
-				inputs[i].ki.dwFlags = (Int32)(msg.message == Msg.WM_KEYUP ? InputFlags.KEYEVENTF_KEYUP : 0);
-				inputs[i].ki.wVk = (short)msg.wParam.ToInt32();
+				inputs[i].U.ki.wScan = 0;
+				inputs[i].U.ki.time = 0;
+				inputs[i].U.ki.dwFlags = (Int32)(msg.message == Msg.WM_KEYUP ? InputFlags.KEYEVENTF_KEYUP : 0);
+				inputs[i].U.ki.wVk = (short)msg.wParam.ToInt32();
 				inputs[i].type = INPUT_KEYBOARD;
 				i++;
 			}


### PR DESCRIPTION
Fixed alignment of INPUT to support 64 bits which is 8 and not 4.
Calling System.Windows.Forms.SendKeys.Send function could let system's input in a bad state and might need a reboot.

From pinvoke.net and System.Windows.Forms sources.
On 64-Bit systems, the offset of the mi, ki and hi fields is 8, because the nested struct uses the alignment of its biggest member, which is 8 (due to the 64-bit pointer in dwExtraInfo). By separating the union into its own structure, rather than placing the mi, ki and hi fields directly in the INPUT structure, we assure that the .Net structure will have the correct alignment on both 32 and 64 bit.

https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.INPUT.cs
https://www.pinvoke.net/default.aspx/Structures/INPUT.html


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed @bmalrat :
Mono: Fixed System.Windows.Forms.SendKeys.Send on Windows.

**Backports**
2021.3, 2020.3

