### PR TITLE
Set app context to null on thread detach

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -977,6 +977,7 @@ void
 mono_domain_unset (void)
 {
 	SET_APPDOMAIN (NULL);
+	SET_APPCONTEXT(NULL);
 }
 
 void

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1114,8 +1114,8 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 	/* There is no more any guarantee that `thread` is alive */
 	mono_memory_barrier ();
 
+	mono_domain_unset();
 	SET_CURRENT_OBJECT (NULL);
-	mono_domain_unset ();
 
 	if (!mono_thread_info_try_get_internal_thread_gchandle (info, &gchandle))
 		g_error ("%s: failed to get gchandle, info = %p", __func__, info);


### PR DESCRIPTION
When a domain is unloaded, it is possible that an InternalThread
has a reference to an app context from the unloaded domain.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Release notes**

Internal @bholmes :
Mono: Set app context to null on thread detach.

