### PR TITLE
Cleaning up some mono compiler errors

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5873,11 +5873,7 @@ mono_metadata_generic_class_foreach(MonoGenericClassFunc func, void* user_data)
 void
 mono_metadata_image_set_foreach(MonoImageSetFunc func, gpointer user_data)
 {
-	GenericClassForeachData data;
 	guint i;
-
-	data.func = func;
-	data.user_data = user_data;
 
 	for (i = 0; i < HASH_TABLE_SIZE; ++i)
 	{

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2460,6 +2460,12 @@ buffer_add_ptr_id (Buffer *buf, MonoDomain *domain, IdType type, gpointer val)
 	return id;
 }
 
+inline static void
+buffer_add_ptr_id_unsafe(void* buf, void* domain, int type, gpointer val)
+{
+	buffer_add_ptr_id(buf, domain, type, val);
+}
+
 static MonoClass*
 decode_typeid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
@@ -10587,7 +10593,7 @@ static void burst_mono_install_hooks_imp(BurstMonoDebuggerCallbacks* callbacks,v
 	callbacks->buffer_add_int = buffer_add_int;
 	callbacks->buffer_add_id = buffer_add_id;
 	callbacks->buffer_add_string = buffer_add_string;
-	callbacks->buffer_add_ptr_id = buffer_add_ptr_id;
+	callbacks->buffer_add_ptr_id = buffer_add_ptr_id_unsafe;
 	callbacks->mono_burst_shutdown = burst_mono_shutdown;
 
 	// This one is passed to us from unity, and we then pass it back to burst as this avoids having a 3rd copy of the callbacks


### PR DESCRIPTION
FWICT the GenericClassForeachData variable is not needed in
mono_metadata_image_set_foreach.

And in burst_mono_install_hooks_imp I am providing a wrapper function
that matches the function pointer signature that is expected.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal @bholmes :
Mono: Fixing compiler errors with function pointer mismatches.
