### PR TITLE
2021.3: Pass generic context when ldftn of generic method

### DIFF
--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -56,10 +56,13 @@ mono_ldftn (MonoMethod *method)
 
 	/* if we need the address of a native-to-managed wrapper, just compile it now, trampoline needs thread local
 	 * variables that won't be there if we run on a thread that's not attached yet. */
-	if (method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED)
+	if (method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED) {
 		addr = mono_compile_method_checked (method, error);
-	else
+	} else {
 		addr = mono_create_jump_trampoline (mono_domain_get (), method, FALSE, error);
+		if (mono_method_needs_static_rgctx_invoke (method, FALSE))
+                        addr = mono_create_static_rgctx_trampoline (method, addr);
+	}
 	if (!is_ok (error)) {
 		mono_error_set_pending_exception (error);
 		return NULL;


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**
Fixed UUM-603 @gsanthamoorthy-rythmos :
Mono: Fixed crash when passing a generic class to a function pointer.

**Comments to reviewers**
The cherry pick was 100% clean.

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1644
2022.2 PR: https://github.com/Unity-Technologies/mono/pull/1645
2022.1 PR: https://github.com/Unity-Technologies/mono/pull/1646