### PR TITLE
Fix Interlocked.CompareExchange float on M1

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4169,8 +4169,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			if (cfg->r4fp) {
 				arm_fmov_double_to_rx (code, ins->dreg, ins->sreg1);
 			} else {
-				arm_fcvt_ds (code, ins->dreg, ins->sreg1);
-				arm_fmov_double_to_rx (code, ins->dreg, ins->dreg);
+				arm_fcvt_ds (code, FP_TEMP_REG, ins->sreg1);
+				arm_fmov_double_to_rx (code, ins->dreg, FP_TEMP_REG);
 			}
 			break;
 		case OP_MOVE_I4_TO_F:


### PR DESCRIPTION
When float32 optimization is off there is an additional instruction to convert single-precision floating-point to double-precision.

The destination register for the fcvtds needs to be a double precision register.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

**Release notes**

Fixed UUM-9159 @bholmes :
Mono: Fix Interlocked.CompareExchange float on M1.


**Backports**

 - 2022.2
 - 2022.1
 - 2021.3

