### PR TITLE
2022.1:Fix Interlocked.CompareExchange float on M1

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4169,8 +4169,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			if (cfg->r4fp) {
 				arm_fmov_double_to_rx (code, ins->dreg, ins->sreg1);
 			} else {
-				arm_fcvt_ds (code, ins->dreg, ins->sreg1);
-				arm_fmov_double_to_rx (code, ins->dreg, ins->dreg);
+				arm_fcvt_ds (code, FP_TEMP_REG, ins->sreg1);
+				arm_fmov_double_to_rx (code, ins->dreg, FP_TEMP_REG);
 			}
 			break;
 		case OP_MOVE_I4_TO_F:


### PR DESCRIPTION
When float32 optimization is off there is an additional instruction to convert single-precision floating-point to double-precision.
The destination register for the fcvtds needs to be a double precision register.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:
**Release notes**

Fixed UUM-9159 @ppandi-rythmos
Mono: Fix Interlocked.CompareExchange float on M1.

Cherry picked changes from the Trunk PR :https://github.com/Unity-Technologies/mono/pull/1648

The cherry pick was 100% clean.

Trunk PR Version:2023.1
2022.2:https://github.com/Unity-Technologies/mono/pull/1652
