### PR TITLE
Avoid coop suspend overhead if not enabled.

### DIFF
--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -102,6 +102,9 @@ This will put the current thread in GC Unsafe mode.
 For further explanation of what can and can't be done in GC unsafe mode:
 http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-mode
 */
+
+#if defined(ENABLE_HYBRID_SUSPEND) || defined(ENABLE_COOP_SUSPEND)
+
 #define MONO_ENTER_GC_UNSAFE	\
 	do {	\
 		MONO_STACKDATA (__gc_unsafe_dummy); \
@@ -132,6 +135,24 @@ http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-m
 #define MONO_ENTER_GC_SAFE_UNBALANCED	\
 		MONO_STACKDATA (__gc_safe_unbalanced_dummy); \
 		mono_threads_enter_gc_safe_region_unbalanced_internal (&__gc_safe_unbalanced_dummy)
+
+#else
+
+#define MONO_ENTER_GC_UNSAFE do {
+
+#define MONO_EXIT_GC_UNSAFE ; } while (0)
+
+#define MONO_ENTER_GC_UNSAFE_UNBALANCED do {
+
+#define MONO_EXIT_GC_UNSAFE_UNBALANCED ; } while (0)
+
+#define MONO_ENTER_GC_SAFE do {
+
+#define MONO_EXIT_GC_SAFE ; } while (0)
+
+#define MONO_ENTER_GC_SAFE_UNBALANCED
+
+#endif
 
 void
 mono_threads_enter_no_safepoints_region (const char *func);


### PR DESCRIPTION
In the case of Boehm GC, coop mode is not supported. This change avoids
overhead on some potentially hot code paths that are to support coop GC.

This is a micro optimization for GC embedding APIs, but I wanted to pull it out of larger GC handle optimization PR.

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

