### PR TITLE
Do not process real proxy classes in liveness checks

### DIFF
--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -347,6 +347,8 @@ static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStr
 	MonoClass *p;
 	gboolean added_objects = FALSE;
 
+	if (!isStruct && mono_class_has_parent_fast(klass, mono_defaults.real_proxy_class)) return FALSE;
+
 	g_assert(object);
 
 	// subtract the added offset for the vtable. This is added to the offset even though it is a struct
@@ -397,6 +399,8 @@ static gboolean mono_validate_object_internal(MonoObject *object, gboolean isStr
 	MonoClassField* field;
 	MonoClass* p;
 	gboolean added_objects = FALSE;
+
+	if (!isStruct && mono_class_has_parent_fast(klass, mono_defaults.real_proxy_class)) return FALSE;
 
 	g_assert(object);
 


### PR DESCRIPTION
The private fields of the proxy may be pointing to an object on another
domain and the domain may no longer be valid.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-13031 @bholmes :
Mono: Fix Editor liveness crash when processing RealProxy classes.

**Backports**

- 2021.3
- 2022.1
- 2022.2

