### PR TITLE
Avoid a crash when the debugger code fails to lookup the signature

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8858,6 +8858,8 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		burst_unlock();
 
 		MonoMethodSignature *sig = mono_method_signature_internal (method);
+		if (!sig)
+			return ERR_INVALID_ARGUMENT;
 		guint32 i;
 		char **names;
 


### PR DESCRIPTION
In this particular case, one of the method arguments has a type that
can not be resolved and the signature code returns null.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed UUM-9219 @bholmes:
Mono: Avoid an editor crash when the debugger code fails to lookup the signature of a method.


**Backports**
 - 2022.2
 - 2022.1
 - 2021.3
