### PR TITLE
Add a random number to the Window class name for uniqueness

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
@@ -890,7 +890,7 @@ namespace System.Windows.Forms {
 				if (class_name != null)
 					return class_name;
 
-				class_name = string.Format ("Mono.WinForms.{0}.{1}", System.Threading.Thread.GetDomainID ().ToString (), classStyle);
+				class_name = string.Format ("Mono.WinForms.{0}.{1}.{2}", System.Threading.Thread.GetDomainID ().ToString (), classStyle, new Random().Next());
 
 				WNDCLASS wndClass;
 


### PR DESCRIPTION
The names are not unique across domain reloads and the class name
is re-registered with Win32causing an error.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Release notes**

Fixed UUM-13189 @bholmes :
Mono: Avoid exception when registering a window class in different domain instances.



**Backports**

 - 2022.2
 - 2022.1
 - 2021.3
