### PR TITLE
2022.2: Avoid a crash when the debugger code fails to lookup the signature

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -8852,6 +8852,8 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		burst_unlock();
 
 		MonoMethodSignature *sig = mono_method_signature_internal (method);
+		if (!sig)
+			return ERR_INVALID_ARGUMENT;
 		guint32 i;
 		char **names;
 


### PR DESCRIPTION
In this particular case, one of the method arguments has a type that can not be resolved and the signature code returns null.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-9219 @gsanthamoorthy-rythmos :
Mono: Avoid an editor crash when the debugger code fails to lookup the signature of a method.

**Comments to reviewers**
Cherry-pick is [CleanGraft]

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1658