### PR TITLE
2022.2: Add a random number to the Window class name for uniqueness

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
@@ -890,7 +890,7 @@ namespace System.Windows.Forms {
 				if (class_name != null)
 					return class_name;
 
-				class_name = string.Format ("Mono.WinForms.{0}.{1}", System.Threading.Thread.GetDomainID ().ToString (), classStyle);
+				class_name = string.Format ("Mono.WinForms.{0}.{1}.{2}", System.Threading.Thread.GetDomainID ().ToString (), classStyle, new Random().Next());
 
 				WNDCLASS wndClass;
 


### PR DESCRIPTION
- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-13189 @sgomasankar-rythmos :
Mono: Avoid exception when registering a window class in different domain instances.

Comments to reviewers
Backport is a [CleanGraft]

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1662