### PR TITLE
Use only eight characters from the git revision for the artifact name

### DIFF
--- a/.yamato/Publish To Stevedore.yml
+++ b/.yamato/Publish To Stevedore.yml
@@ -10,7 +10,7 @@ dependencies:
   
 commands:
   - curl -sSo StevedoreUpload.exe "$STEVEDORE_UPLOAD_TOOL_URL"
-  - mono StevedoreUpload.exe --repo=unity-internal --version-len=11 --version="$GIT_REVISION" stevedore/MonoBleedingEdge.7z
+  - mono StevedoreUpload.exe --repo=unity-internal --version-len=8 --version="$GIT_REVISION" stevedore/MonoBleedingEdge.7z
 
 artifacts: 
   stevedore:


### PR DESCRIPTION
It looks like the artifactid.txt file that is generated by the job to upload Mono artifacts to Stevedore is now using only right characters from the git revision instead of 11. It is unclear why this has changed, but the number of characters is not material, so long as this value matches.

This allows the proper artifact name to be generated, so that consumers of this artifact can reference it correctly.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->