### PR TITLE
2021.3: Do not process real proxy classes in liveness checks

### DIFF
--- a/mono/metadata/unity-liveness.c
+++ b/mono/metadata/unity-liveness.c
@@ -347,6 +347,8 @@ static gboolean mono_traverse_object_internal(MonoObject *object, gboolean isStr
 	MonoClass *p;
 	gboolean added_objects = FALSE;
 
+	if (!isStruct && mono_class_has_parent_fast(klass, mono_defaults.real_proxy_class)) return FALSE;
+
 	g_assert(object);
 
 	// subtract the added offset for the vtable. This is added to the offset even though it is a struct
@@ -397,6 +399,8 @@ static gboolean mono_validate_object_internal(MonoObject *object, gboolean isStr
 	MonoClassField* field;
 	MonoClass* p;
 	gboolean added_objects = FALSE;
+
+	if (!isStruct && mono_class_has_parent_fast(klass, mono_defaults.real_proxy_class)) return FALSE;
 
 	g_assert(object);
 


### PR DESCRIPTION
- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-13031 @sgomasankar-rythmos :
Mono: Fix Editor liveness crash when processing RealProxy classes.

Comments to reviewers
Backport is a [CleanGraft]

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1656

2022.2 PR: https://github.com/Unity-Technologies/mono/pull/1674

2022.1 PR: https://github.com/Unity-Technologies/mono/pull/1675