### PR TITLE
Fixed issue where errorcode would not propogate back to Managed if thrown during ReadZStream.

### DIFF
--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -194,6 +194,8 @@ ReadZStream (ZStream *stream, guchar *buffer, gint length)
 	while (zs->avail_out > 0) {
 		if (zs->avail_in == 0) {
 			n = stream->func (stream->buffer, BUFFER_SIZE, stream->gchandle);
+			if (n == MONO_EXCEPTION)
+				return n;
 			n = n < 0 ? 0 : n;
 			stream->total_in += n;
 			zs->next_in = stream->buffer;


### PR DESCRIPTION
Issue was introduced upstream here: 
https://github.com/Unity-Technologies/mono/commit/5068c7cc13661f7f09d962596a33e82fdb276741

It looks like they were attempting to fix the issue described in the bug but accidentally reintroduced it somewhere else.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-17185 @UnityAlex:
Mono: Fixed issue where DeflateStream would swallow exceptions instead of throwing them.



**Backports**
2022.2, 2022.1, 2021.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->