### PR TITLE
[mono] 2022.2: Throw a managed exception for a null large struct copy (UUM-10796)

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -194,9 +194,9 @@ namespace System
 				((byte*)dest) [0] = ((byte*)src) [0];
 		}
 
-		internal static unsafe void Memcpy (byte *dest, byte *src, int len, bool useICall = true) {
+		internal static unsafe void Memcpy (byte *dest, byte *src, int len) {
 			// For bigger lengths, we use the heavily optimized native code
-			if (len > 32 && useICall) {
+			if (len > 32) {
 				InternalMemcpy (dest, src, len);
 				return;
 			}

--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -197,6 +197,15 @@ namespace System
 		internal static unsafe void Memcpy (byte *dest, byte *src, int len) {
 			// For bigger lengths, we use the heavily optimized native code
 			if (len > 32) {
+#if UNITY
+				// We need to check if the destination is non-null. We need to do
+				// that in managed code, so at the normal Mono NullReferenceException
+				// handling will work. So attempt to dereference the destination here.
+				// This check is pretty cheap, and will cause a proper managed
+				// exception if the value is null.
+				long dereferencedValue = *dest;
+				System.Threading.Interlocked.Read(ref dereferencedValue);
+#endif
 				InternalMemcpy (dest, src, len);
 				return;
 			}

--- a/mcs/class/corlib/ReferenceSources/String.cs
+++ b/mcs/class/corlib/ReferenceSources/String.cs
@@ -293,7 +293,7 @@ namespace System
 
 		static unsafe void memcpy (byte *dest, byte *src, int size)
 		{
-			Buffer.Memcpy (dest, src, size, false);
+			Buffer.Memcpy (dest, src, size);
 		}
 
 		/* Used by the runtime */


### PR DESCRIPTION
This change is a different approach to fix an issue previously fixed in:

 https://github.com/Unity-Technologies/mono/pull/1530

 That original change worked, but caused a performance regression in at
 least one benchmark. This change maintains the correct behavior, but
 is a cheap check at allows the optimized code path to execute.


- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

**Release notes**

Fixed UUM-10796 @joshuap:
Mono: Improve the performance of large struct copies.

