### PR TITLE
2022.2: Fixed issue where errorcode would not propogate back to Managed if thrown during ReadZStream.

### DIFF
--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -194,6 +194,8 @@ ReadZStream (ZStream *stream, guchar *buffer, gint length)
 	while (zs->avail_out > 0) {
 		if (zs->avail_in == 0) {
 			n = stream->func (stream->buffer, BUFFER_SIZE, stream->gchandle);
+			if (n == MONO_EXCEPTION)
+				return n;
 			n = n < 0 ? 0 : n;
 			stream->total_in += n;
 			zs->next_in = stream->buffer;


### PR DESCRIPTION
- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! ❤️

Release notes

Fixed UUM-17185 @sgomasankar-rythmos :
Mono: Fixed issue where DeflateStream would swallow exceptions instead of throwing them.

Comments to reviewers
Backport is a [CleanGraft]

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1683
