### PR TITLE
2022.2: Fix mono arm assert with large return structs

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6321,8 +6321,12 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (cinfo->ret.storage == RegTypeStructByAddr) {
 		ArgInfo *ainfo = &cinfo->ret;
 		inst = cfg->vret_addr;
-		g_assert (arm_is_imm12 (inst->inst_offset));
-		ARM_STR_IMM (code, ainfo->reg, inst->inst_basereg, inst->inst_offset);
+		if (arm_is_imm12 (inst->inst_offset)) {
+			ARM_STR_IMM (code, ainfo->reg, inst->inst_basereg, inst->inst_offset);
+		} else {
+			code = mono_arm_emit_load_imm (code, ARMREG_LR, inst->inst_offset);
+			ARM_STR_REG_REG (code, ainfo->reg, inst->inst_basereg, ARMREG_LR);
+		}
 	}
 
 	if (sig->call_convention == MONO_CALL_VARARG) {


### PR DESCRIPTION
When the return struct is large the store instruction offset is too large. When this happens, put the large offset in a register.

Bug: https://jira.unity3d.com/browse/UUM-18498
Backport: https://jira.unity3d.com/browse/UUM-18550

<!--
Thank you for your Pull Request!

Her18e are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:


Release notes

Fixed UUM-18498 @hannem-rythmos :
Mono:  Fix JIT assert on arm with large return structs

Comments to reviewers:

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1694

Cherry pick is [CleanGraft]

