### PR TITLE
Use a relative path to the gdiplus dynamic library (UUM-20719)

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1176,7 +1176,7 @@ if ($build)
 		}
 
 		# Need to define because Apple's SIP gets in the way of us telling mono where to find this
-		push @configureparams, "--with-libgdiplus=$addtoresultsdistdir/lib/libgdiplus.dylib";
+		push @configureparams, "--with-libgdiplus=libgdiplus.dylib";
 		push @configureparams, "--enable-minimal=com,shared_perfcounters";
 		push @configureparams, "--disable-parallel-mark";
 		push @configureparams, "--enable-verify-defines";


### PR DESCRIPTION
The absolute path will end up encoding the path on the Unity build machine in the `dllmap` entry data/config file that is shipped with Mono. This is not ideal, as it requires all users who need to use the gdiplus dynamic library to manually modify the config file to remove the absolute path.

Instead, use a relative path to start, which should allow the Mono running in Unity to pick up a local gdiplus dynamic library correctly.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-20719 @joshuap:
Mono: Use a relative path to the gdiplus dynamic library in the dllmap entry in the config file.


**Backports**

This change will be back ported to 2022.2, 2021.3, and 2020.3.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->