### PR TITLE
Restarting debugger thread after it's been stopped on call to mono_debugger_disconnect (case UUM-16704)

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -930,9 +930,13 @@ mono_debugger_get_generate_debug_info ()
 }
 
 MONO_API void
-mono_debugger_disconnect (const char *message)
+mono_debugger_disconnect ()
 {
 	stop_debugger_thread ();
+
+	//restart debugger thread now that we've forcefully disconnected any clients
+	mono_atomic_cas_i32(&agent_inited, 0, 1);
+	finish_agent_init(FALSE);
 }
 
 typedef void (*MonoDebuggerAttachFunc)(gboolean attached);
@@ -1755,6 +1759,7 @@ start_debugger_thread (MonoError *error)
 	debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);
 	g_assert (debugger_thread_handle);
 	
+	debugger_thread_exited = FALSE;
 }
 
 /*


### PR DESCRIPTION
Calling `mono_debugger_disconnect` currently stops the debugger thread permanently instead of just disconnecting any potential clients that are currently connected. The resulting behavior is when the editor is flipped from debug -> release -> debug there is no running debugger thread for clients to connect to anymore.

My proposed change restarts the debugger thread after it has been stopped in `mono_debugger_disconnect`.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-16704 @UnityAlex :
Mono: Fixed issue where the internal debugger would refuse connections after performing multiple switches between release and debug editor runtime optimizations.


**Backports**
2022.2, 2021.3, 2020.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->