### PR TITLE
2022.2:Use a relative path to the gdiplus dynamic library (UUM-20719)

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -1176,7 +1176,7 @@ if ($build)
 		}
 
 		# Need to define because Apple's SIP gets in the way of us telling mono where to find this
-		push @configureparams, "--with-libgdiplus=$addtoresultsdistdir/lib/libgdiplus.dylib";
+		push @configureparams, "--with-libgdiplus=libgdiplus.dylib";
 		push @configureparams, "--enable-minimal=com,shared_perfcounters";
 		push @configureparams, "--disable-parallel-mark";
 		push @configureparams, "--enable-verify-defines";


### PR DESCRIPTION
The absolute path will end up encoding the path on the Unity build machine in the `dllmap` entry data/config file that is shipped with Mono. This is not ideal, as it requires all users who need to use the gdiplus dynamic library to manually modify the config file to remove the absolute path.

Instead, use a relative path to start, which should allow the Mono running in Unity to pick up a local gdiplus dynamic library correctly.

Bug:https://jira.unity3d.com/browse/UUM-20719
Backport:https://jira.unity3d.com/browse/UUM-20811

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:


**Release notes**

Fixed UUM-20719 @ppandi-rythmos :
Mono: Use a relative path to the gdiplus dynamic library in the dllmap entry in the config file.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1699

Trunk  PR Version:2023.1

**ES-Normal**
 Cherry-pick is [CleanGraft].