### PR TITLE
2020.3:Restarting debugger thread after it's been stopped on call to mono_debugger_disconnect (case UUM-16704) 

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1114,7 +1114,7 @@ mono_debugger_disconnect ()
 	// only closes the debugger client socket.
 
 	//restart debugger thread now that we've forcefully disconnected any clients
-	mono_atomic_cas_i32(&agent_inited, 0, 1);
+	mono_atomic_cas_i32(&inited, 0, 1);
 	finish_agent_init(FALSE);
 	transport_close2();
 }

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1112,6 +1112,10 @@ mono_debugger_disconnect ()
 	// loop already handles the debugger client disconnection properly,
 	// so calling transport_close2 method is enough since the method
 	// only closes the debugger client socket.
+
+	//restart debugger thread now that we've forcefully disconnected any clients
+	mono_atomic_cas_i32(&agent_inited, 0, 1);
+	finish_agent_init(FALSE);
 	transport_close2();
 }
 
@@ -1886,6 +1890,7 @@ start_debugger_thread (void)
 
 	debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);
 	g_assert (debugger_thread_handle);
+	debugger_thread_exited = FALSE;
 }
 #endif // RUNTIME_IL2CPP
 


### PR DESCRIPTION
Calling mono_debugger_disconnect currently stops the debugger thread permanently instead of just disconnecting any potential clients that are currently connected. The resulting behavior is when the editor is flipped from debug -> release -> debug there is no running debugger thread for clients to connect to anymore.
My proposed change restarts the debugger thread after it has been stopped in mono_debugger_disconnect.

Bug:https://jira.unity3d.com/browse/UUM-16704
Backport:https://jira.unity3d.com/browse/UUM-17046

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-16704 @ppandi-rythmos
Mono: Fixed issue where the internal debugger would refuse connections after performing multiple switches between release and debug editor runtime optimizations.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1701

Trunk PR Version:2023.1

*2022.2:https://github.com/Unity-Technologies/mono/pull/1705

*2021.3:https://github.com/Unity-Technologies/mono/pull/1706

Backport is not a clean graft.

I've done the modifications at line no: 1117 as per 2020.3