### PR TITLE
[Windows][ARM64] get_win32_restore_stack

### DIFF
--- a/mono/arch/arm64/arm64-codegen.h
+++ b/mono/arch/arm64/arm64-codegen.h
@@ -528,6 +528,9 @@ arm_encode_arith_imm (int imm, guint32 *shift)
 #define arm_adrpx(p, rd, target) arm_format_adrp ((p), 0x1, (rd), (target))
 #define arm_adrx(p, rd, target) arm_format_adrp ((p), 0x0, (rd), (target))
 
+/* ADRL is a pseudo instruction which uses ADRP and ADD */
+#define arm_adrlx(p, rd, target)  do { 	arm_adrpx(p, rd, target); arm_addx_imm(p, rd, rd, ((int)target) & 0xFFF); } while (0)
+
 /* Bitfield move */
 #define arm_format_bfm(p, sf, opc, N, immr, imms, rn, rd) arm_emit ((p), ((sf) << 31) | ((opc) << 29) | (0x26 << 23) | ((N) << 22) | ((N) << 22) | ((immr) << 16) | ((imms) << 10) | ((rn) << 5) | ((rd) << 0))
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed [UUM-20941](https://jira.unity3d.com/browse/UUM-20941)@jem.patel:
Mono: Implement get_win32_restore_stack for ARM64 in Mono