### PR TITLE
Avoid overflow with ephemerons (case UUM-25411)

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -73,8 +73,8 @@ mono_push_other_roots(void);
 
 static void
 mono_clear_ephemerons (void);
-static void
-mono_push_ephemerons (void);
+static struct GC_ms_entry*
+mono_push_ephemerons(struct GC_ms_entry* mark_stack_ptr, struct GC_ms_entry* mark_stack_limit);
 static void*
 null_ephemerons_for_domain (MonoDomain* domain);
 
@@ -2121,8 +2121,8 @@ mono_clear_ephemerons (void)
 	}
 }
 
-static void
-mono_push_ephemerons (void)
+static struct GC_ms_entry*
+mono_push_ephemerons (struct GC_ms_entry* mark_stack_ptr, struct GC_ms_entry* mark_stack_limit)
 {
 	ephemeron_node* prev_node = NULL;
 	ephemeron_node* current_node = NULL;
@@ -2155,12 +2155,13 @@ mono_push_ephemerons (void)
 			if (!GC_is_marked (current_ephemeron->key))
 				continue;
 
-			if (current_ephemeron->value && !GC_is_marked (current_ephemeron->value)) {
-				/* the key is marked, so mark the value if needed */
-				GC_push_all (&current_ephemeron->value, &current_ephemeron->value + 1);
+			if (current_ephemeron->value) {
+				mark_stack_ptr = GC_mark_and_push(current_ephemeron->value, mark_stack_ptr, mark_stack_limit, &current_ephemeron->value);
 			}
 		}
 	}
+
+	return mark_stack_ptr;
 }
 
 static void*


### PR DESCRIPTION
Use GC_mark_and_push to safely push object for marking.

Note, these same changes will need done in IL2CPP. I will make a PR there as well.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-25411 @joncham:
Mono: Fix crash when using ConditionalWeakTable.


**Backports**

2022.2, 2021.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->