### PR TITLE
Backport callback support for Android's NetworkInterface OperationalStatus fix.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2072,6 +2072,12 @@ if test "x$mono_feature_disable_processes" = "xyes"; then
 	AC_MSG_NOTICE([Disabled process support])
 fi
 
+AC_ARG_ENABLE(unity-define,[  --enable-unity-define have UNITY defined], unity_define=$enableval, unity_define=no)
+if test "x$unity_define" = "xyes"; then
+   AC_DEFINE(UNITY, 1, [Building for Unity])
+   AC_MSG_NOTICE([Building for Unity])
+fi
+
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)
 AM_CONDITIONAL(DISABLE_EXECUTABLES, test x$enable_executables = xno)
 

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -278,6 +278,7 @@ if ($build)
 	push @configureparams, "--enable-ignore-dynamic-loading=yes";
 	push @configureparams, "--enable-dont-register-main-static-data=yes";
 	push @configureparams, "--enable-thread-local-alloc=no";
+	push @configureparams, "--enable-unity-define=yes";
 
 	if(!($disableMcs))
 	{

--- a/mcs/class/System/System.Net.NetworkInformation/LinuxNetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/LinuxNetworkInterface.cs
@@ -32,6 +32,7 @@
 //
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.IO;
 using System.Globalization;
 
@@ -260,6 +261,11 @@ namespace System.Net.NetworkInformation {
 		bool android_use_java_api;
 #endif
 
+#if UNITY
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		private extern static bool unitydroid_get_network_interface_up_state (string ifname, ref bool is_up);
+#endif
+
 		internal string IfacePath {
 			get { return iface_path; }
 		}
@@ -303,6 +309,17 @@ namespace System.Net.NetworkInformation {
 					// to us here.
 					bool is_up = false;
 					if (_monodroid_get_network_interface_up_state (Name, ref is_up))
+						return is_up ? OperationalStatus.Up : OperationalStatus.Down;
+					else
+						return OperationalStatus.Unknown;
+				}
+#endif
+#if UNITY
+				// Similar to above we need to go into java but in a Unity context we don't have access to Xamarin.Android
+				if (Console.IsRunningOnAndroid)
+				{
+					bool is_up = false;
+					if (unitydroid_get_network_interface_up_state(Name, ref is_up))
 						return is_up ? OperationalStatus.Up : OperationalStatus.Down;
 					else
 						return OperationalStatus.Unknown;

--- a/mcs/class/corlib/System.IO/LogcatTextWriter.cs
+++ b/mcs/class/corlib/System.IO/LogcatTextWriter.cs
@@ -12,9 +12,6 @@ namespace System.IO {
 
 	class LogcatTextWriter : TextWriter {
 
-		const string LibLog = "/system/lib/liblog.so";
-		const string LibLog64 = "/system/lib64/liblog.so";
-
 		readonly byte[] appname;
 
 		TextWriter stdout;
@@ -87,11 +84,6 @@ namespace System.IO {
 			fixed (byte *b_appname = appname) {
 				Log (b_appname, 1 << 5 /* G_LOG_LEVEL_MESSAGE */, b_message);
 			}
-		}
-
-		public static bool IsRunningOnAndroid ()
-		{
-			return File.Exists (LibLog) || File.Exists (LibLog64);
 		}
 
 		[MethodImpl(MethodImplOptions.InternalCall)]

--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -131,6 +131,13 @@ namespace System
 			SetupStreams (inputEncoding, outputEncoding);
 		}
 
+#if MONODROID || UNITY
+		const string LibLog = "/system/lib/liblog.so";
+		const string LibLog64 = "/system/lib64/liblog.so";
+
+		internal static bool IsRunningOnAndroid = File.Exists (LibLog) || File.Exists (LibLog64);
+#endif
+
 		static void SetupStreams (Encoding inputEncoding, Encoding outputEncoding)
 		{
 #if MONO_FEATURE_CONSOLE
@@ -151,7 +158,7 @@ namespace System
 				stderr = TextWriter.Synchronized (new UnexceptionalStreamWriter (OpenStandardError (0), outputEncoding) { AutoFlush = true });
 
 #if MONODROID && !MOBILE_DESKTOP_HOST
-				if (LogcatTextWriter.IsRunningOnAndroid ()) {
+				if (IsRunningOnAndroid ()) {
 					stdout = TextWriter.Synchronized (new LogcatTextWriter ("mono-stdout", stdout));
 					stderr = TextWriter.Synchronized (new LogcatTextWriter ("mono-stderr", stderr));
 				}

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -547,6 +547,11 @@ NOHANDLES(ICALL(LINUXNETWORKCHANGE_2, "CreateNLSocket", ves_icall_System_Net_Net
 NOHANDLES(ICALL(LINUXNETWORKCHANGE_3, "ReadEvents", ves_icall_System_Net_NetworkInformation_LinuxNetworkChange_ReadEvents))
 #endif
 
+#if defined(ANDROID) && defined(UNITY)
+ICALL_TYPE(LINUXNETWORKINTERFACE, "System.Net.NetworkInformation.LinuxNetworkInterface", LINUXNETWORKINTERFACE_1)
+NOHANDLES(ICALL(LINUXNETWORKINTERFACE_1, "unitydroid_get_network_interface_up_state", ves_icall_Unity_Android_Network_Interface_Up_State))
+#endif
+
 #if !defined(DISABLE_SOCKETS)
 ICALL_TYPE(MAC_IFACE_PROPS, "System.Net.NetworkInformation.MacOsIPInterfaceProperties", MAC_IFACE_PROPS_1)
 HANDLES(MAC_IFACE_PROPS_1, "ParseRouteInfo_icall", ves_icall_System_Net_NetworkInformation_MacOsIPInterfaceProperties_ParseRouteInfo, MonoBoolean, 2, (MonoString, MonoArrayOut))

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1976,3 +1976,29 @@ mono_unity_class_has_failure(const MonoClass* klass)
 {
 	return mono_class_has_failure(klass);
 }
+
+#ifdef ANDROID
+static android_network_up_state network_up_state_func = NULL;
+
+MONO_API void
+mono_unity_set_android_network_up_state_func (android_network_up_state func)
+{
+	network_up_state_func = func;
+}
+
+MonoBoolean
+ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBoolean* is_up)
+{
+	if (network_up_state_func)
+	{
+		ERROR_DECL(unused);
+		char* ifNameUtf = mono_string_to_utf8_checked(ifName, unused);
+		mono_error_cleanup(unused);
+		MonoBoolean retVal = network_up_state_func(ifNameUtf, is_up);
+		mono_free(ifNameUtf);
+		return retVal;
+	}
+	return FALSE;
+}
+#endif
+

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -257,4 +257,14 @@ MONO_API gboolean mono_unity_class_is_open_constructed_type (MonoClass *klass);
 
 MONO_API gboolean mono_unity_class_has_failure (const MonoClass* klass);
 
+#ifdef ANDROID
+typedef uint8_t (*android_network_up_state)(const char* ifName, uint8_t* is_up);
+
+MONO_API void
+mono_unity_set_android_network_up_state_func(android_network_up_state func);
+
+MonoBoolean
+ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBoolean* is_up);
+#endif
+
 #endif


### PR DESCRIPTION
Unity does not build with MONODROID and therefore does not have access to the Xamarin.Android implementation since we're technically running the linux BCL on Android instead of the Android BCL that regular mono uses.

backport of: https://github.com/Unity-Technologies/mono/pull/1708

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->