### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ In newer Unity versions (2017.1+) this MonoBleedingEdge version can be used in t
 
 Unity versions 2019.3+ contain only MonoBleedingEdge.
 
+### Build the software for Unity usages
+Please refer to [Unity-build.md](https://github.com/Unity-Technologies/mono/blob/yuc434-build-repo/Unity-build.md) for instructions to build Mono for Unity usages.
+
 ### Branch Naming Convention
 Branches for released Unity versions are of the form unity-\<version\>\[-mbe\]. The '-mbe' suffix indicates the branch is for the MonoBleedingEdge version of Mono mentioned above.
 

--- a/Unity-build.md
+++ b/Unity-build.md
@@ -1,0 +1,55 @@
+## Build Mono for Unity Uasges
+
+### Clone the repo
+- Clone this repo into a directory that follows the structure required by our build scripts
+- Create some root directory: mkdir my-mono
+- Create the expected directory for the mono checkout : mkdir my-mono\mono
+- If you have a github account: git clone git@github.com:Unity-Technologies/mono my-mono\mono
+- Otherwise: git clone git://github.com/Unity-Technologies/mono my-mono/mono  You won't be able to push back changes - if you need to do this, follow the instructions here: Unity on GitHub
+- Pull the git submodules (this is required after cloning, and is often necessary when changing branches)
+  - git submodule update --init --recursive
+  - NOTE:  If on windows, run in Git Bash to be able to enter a password
+
+### Build on Windows
+
+#### Runtime
+From the root of your cloned mono directory run:
+- external\buildscripts\build_runtime_win.pl
+
+or: Open msvc/mono.sln in Visual Studio and build the Runtime/libmono-dynamic project
+
+- If you are on 2020.3 or older you can use VS 2015/VS 2019 as long as you don't upgrade the projects and have VS 2010 installed!
+
+- Don't forget to select x64 platform if you intend to use the DLLs with the 64-bit Player/Editor!
+
+- Artifacts will be in: <mono root>\msvc\build\boehm\x64\bin\Debug
+
+### Build on OSX
+You need to install pkg-config. With Homebrew installed run:
+- brew install pkg-config
+
+#### Runtime
+Optional - Enable debug build: 
+
+- Edit external/buildscripts/build_runtime_osx.pl and add '–debug=1' to the list of arguments passed to build.pl
+
+- From the root of your cloned mono directory run:
+  - perl external/buildscripts/build_runtime_osx.pl
+
+Optional: If the build fails with the error "'mach_dep.lo' is not a valid libtool object" - disable parallel build by changing (external/buildscripts/build_runtime_osx.pl) my $jobs = 4 to my $jobs = 1 and try again.
+
+After the building is completed you can verify that you have a good build universal dylib by running : 
+
+- file builds/embedruntimes/osx/libmonobdwgc-2.0.dylib
+
+If you stumble upon the build script not being able to copy the main Mono .dylib symbols file (.dSYM) don't stress, the information is embedded.
+
+#### class libraries
+
+From the root of your cloned mono directory run:
+ - perl external/buildscripts/build_classlibs_osx.pl
+
+### Build on other platforms
+- Run external/buildscripts/build_runtime_myplatform.pl (Runtime only)
+or
+- Run ./autogen.sh followed by make. (All platforms (requires cygwin on windows))


### PR DESCRIPTION
- Integrate Unity Mono build instructions from https://confluence.unity3d.com/display/DEV/Mono+Development

- remove parts regarding 'unity-trunk' or 'unity-staging' based branches since they're no longer maintained



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->