### PR TITLE
Comment out problematic debug logging statement that can cause a hang…

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2747,8 +2747,8 @@ thread_interrupt (DebuggerTlsData *tls, MonoThreadInfo *info, MonoJitInfo *ji)
 
 			// FIXME: printf is not signal safe, but this is only used during
 			// debugger debugging
-			if (ip)
-				PRINT_DEBUG_MSG (1, "[%p] Received interrupt while at %p, treating as suspended.\n", (gpointer)(gsize)tid, ip);
+			/*if (ip)
+				PRINT_DEBUG_MSG (1, "[%p] Received interrupt while at %p, treating as suspended.\n", (gpointer)(gsize)tid, ip);*/
 			//save_thread_context (&ctx);
 
 			if (!tls->thread)


### PR DESCRIPTION
I've added a new diagnostic to allow for mono's debugger logging to be enabled by users. In order to avoid hangs this debug statement needs to be more permanently removed. I intend to bring this to trunk as well soonish but going to start here on 2022.2 since a customer may want it sooner.
