### PR TITLE
Burst - Add a method to simulate a domain reload on the burst debugger domain

### DIFF
--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -66,6 +66,7 @@ MONO_API void mono_unity_set_vprintf_func(vprintf_func func);
 
 void unity_mono_install_memory_callbacks(MonoMemoryCallbacks* callbacks);
 
+MONO_API extern void burst_mono_simulate_burst_debug_domain_reload();
 MONO_API extern void burst_mono_install_hooks(BurstMonoDebuggerCallbacks* callbacks, void* extra);
 MONO_API extern void burst_mono_update_tracking_pointers(MonoDomain* domain,MonoClass* klass);
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10633,7 +10633,7 @@ void burst_mono_update_tracking_pointers(MonoDomain* domain, MonoClass* klass)
 	burst_lock();
 	g_BurstKlass = klass;
 	g_BurstDebugDomain = domain;
-	MonoAssembly* assembly=m_class_get_image (g_BurstKlass)->assembly;
+	MonoAssembly* assembly = m_class_get_image (g_BurstKlass)->assembly;
 	g_BurstAssembly = assembly;
 	burst_unlock();
 	send_type_load(g_BurstKlass);	// We must manually send the type load event, since we never actually JIT anything in this class
@@ -10650,8 +10650,8 @@ void burst_mono_update_tracking_pointers(MonoDomain* domain, MonoClass* klass)
 void burst_mono_simulate_burst_debug_domain_reload()
 {
 #ifndef DISABLE_SDB
-	appdomain_start_unload(NULL,g_BurstDebugDomain);
-	assembly_unload(NULL,g_BurstAssembly);
+	appdomain_start_unload(NULL, g_BurstDebugDomain);
+	assembly_unload(NULL, g_BurstAssembly);
 	appdomain_unload(NULL, g_BurstDebugDomain);
 
 	debugger_agent_free_domain_info(g_BurstDebugDomain);	// We need to call this to flush any typeids (its usually done via free_domain)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -541,6 +541,7 @@ static AgentConfig agent_config;
 static MonoDomain* g_BurstDebugDomain = NULL;
 static BurstMonoDebuggerCallbacks g_BurstDebugCallbacks = { 0 };
 static MonoClass* g_BurstKlass = NULL;
+static MonoAssembly* g_BurstAssembly = NULL;
 static MonoCoopMutex g_BurstDebugMutex;
 #define burst_lock() do {mono_coop_mutex_lock (&g_BurstDebugMutex);}while(0)
 #define burst_unlock() do {mono_coop_mutex_unlock (&g_BurstDebugMutex);}while(0)
@@ -10620,15 +10621,43 @@ void burst_mono_install_hooks(BurstMonoDebuggerCallbacks* callbacks, void* domai
 #endif /* DISABLE_SDB */
 }
 
-// Called from various threads
+// In Old editors the behaviour is that burst_mono_update_tracking_pointers is called from various threads,
+//after a request from the burst managed debugger dll that the managed debugger domain needs to be torn
+//down and re-created to cause the debugger clients to refresh the information they hold about the domain.
+
+// In Newer editors, this is now only called once during initialisation, these pointers are fixed for the 
+//lifetime of the editor once installed.
 void burst_mono_update_tracking_pointers(MonoDomain* domain, MonoClass* klass)
 {
 #ifndef DISABLE_SDB
 	burst_lock();
 	g_BurstKlass = klass;
 	g_BurstDebugDomain = domain;
+	MonoAssembly* assembly=m_class_get_image (g_BurstKlass)->assembly;
+	g_BurstAssembly = assembly;
 	burst_unlock();
 	send_type_load(g_BurstKlass);	// We must manually send the type load event, since we never actually JIT anything in this class
 					//without this call, some mono debuggers will not work properly for burst
+#endif /* DISABLE_SDB */
+}
+
+// This function is only called by newer editors, currently via the main thread. It simulates
+//a domain tear down and recreate (from the debugee clients point of view), without actually freeing 
+//the domain and recreating it. Which is both more effecient than the old method, and safer because
+//the various pointers we hold statically are now fixed (after one time init)
+// The method will only be called, if the burst debugger is initialised, which means we don't need
+//to hold the burst locks here.
+void burst_mono_simulate_burst_debug_domain_reload()
+{
+#ifndef DISABLE_SDB
+	appdomain_start_unload(NULL,g_BurstDebugDomain);
+	assembly_unload(NULL,g_BurstAssembly);
+	appdomain_unload(NULL, g_BurstDebugDomain);
+
+	debugger_agent_free_domain_info(g_BurstDebugDomain);	// We need to call this to flush any typeids (its usually done via free_domain)
+
+	appdomain_load(NULL, g_BurstDebugDomain);
+
+	send_type_load(g_BurstKlass);	// We must manually send the type load event, since we never actually JIT anything in this class
 #endif /* DISABLE_SDB */
 }


### PR DESCRIPTION
This adds a mono call (which unity/burst) will leverage to fake a domain reload on the burst debug domain.

Originally the burst debug domain was torn down and recreated everytime a bursted library containing metadata was loaded into Unity. Unfortunately on large projects this can introduce significant stalls, however we don't actually need to tear down and recreate the domain, we just need to tell the client that the special type in the burst debug domain needs to be refreshed.

Note this requires an additional editor change to switch over to the new functionality, until then, it will still behave as before. 

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

**Backports**

2022.2, 2023.1

**Unity repository changes**

Accompanying PR for context. (can't go until this PR lands, as it is reliant on the new method)

https://github.cds.internal.unity3d.com/unity/unity/pull/22690
