### PR TITLE
Fix Mono default interface methods with protected virtual class methods

### DIFF
--- a/mono/metadata/class-setup-vtable.c
+++ b/mono/metadata/class-setup-vtable.c
@@ -454,7 +454,7 @@ check_interface_method_override (MonoClass *klass, MonoMethod *im, MonoMethod *c
 {
 	MonoMethodSignature *cmsig, *imsig;
 	if (strcmp (im->name, cm->name) == 0) {
-		if (! (cm->flags & METHOD_ATTRIBUTE_PUBLIC)) {
+		if ((cm->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) != METHOD_ATTRIBUTE_PUBLIC) {
 			TRACE_INTERFACE_VTABLE (printf ("[PUBLIC CHECK FAILED]"));
 			return FALSE;
 		}


### PR DESCRIPTION
Fixing the METHOD_ATTRIBUTE_PUBLIC flag check on the class method for check_interface_method_override.

This is a backport of https://github.com/dotnet/runtime/pull/82577

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [X] Yes
  - [ ] No

**Release notes**

Fixed UUM-22228 @bholmes :
Mono: Fix Mono default interface methods with protected virtual class methods.


**Backports**

 - 2023.1
 - 2022.2
 - 2021.3

