### PR TITLE
[Windows][ARM64] Add get_last_error opcode

### DIFF
--- a/mono/mini/cpu-arm64.md
+++ b/mono/mini/cpu-arm64.md
@@ -497,6 +497,7 @@ atomic_store_r4: dest:b src1:f len:28
 atomic_store_r8: dest:b src1:f len:24
 
 generic_class_init: src1:a len:44 clob:c
+get_last_error: dest:i len:32
 gc_safe_point: src1:i len:12 clob:c
 
 fill_prof_call_ctx: src1:i len:128

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -73,7 +73,8 @@ static guint8* emit_blrx (guint8 *code, int reg);
 static guint8*
 emit_get_last_error(guint8* code, int dreg)
 {
-	arm_movx(code, dreg, TEB_LAST_ERROR_OFFSET);
+	arm_movx(code, ARMREG_R8, ARMREG_R18);
+	arm_ldrw(code, dreg, ARMREG_R8, TEB_LAST_ERROR_OFFSET);
 	return code;
 }
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -66,6 +66,27 @@ static __attribute__ ((__warn_unused_result__)) guint8* emit_load_regset (guint8
 static guint8* emit_brx (guint8 *code, int reg);
 static guint8* emit_blrx (guint8 *code, int reg);
 
+#ifdef HOST_WIN32
+
+#define TEB_LAST_ERROR_OFFSET 0x68
+
+static guint8*
+emit_get_last_error(guint8* code, int dreg)
+{
+	arm_movx(code, dreg, TEB_LAST_ERROR_OFFSET);
+	return code;
+}
+
+#else
+
+static guint8*
+emit_get_last_error(guint8* code, int dreg)
+{
+	g_assert_not_reached();
+}
+
+#endif
+
 const char*
 mono_arch_regname (int reg)
 {
@@ -4730,6 +4751,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				if ((MONO_ARCH_CALLEE_SAVED_REGS & (1 << i)) || i == ARMREG_SP || i == ARMREG_FP)
 					arm_strx (code, i, ins->sreg1, MONO_STRUCT_OFFSET (MonoContext, regs) + i * sizeof (target_mgreg_t));
 			break;
+#ifdef HOST_WIN32
+		case OP_GET_LAST_ERROR:
+			code = emit_get_last_error(code, ins->dreg);
+			break;
+#endif
 		default:
 			g_warning ("unknown opcode %s in %s()\n", mono_inst_name (ins->opcode), __FUNCTION__);
 			g_assert_not_reached ();


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Release notes

Internal [UUM-21453](https://jira.unity3d.com/browse/UUM-21453) @jem.patel
Mono: Add get_last_error opcode for Windows ARM64
