### PR TITLE
Remove !sig->is_inflated assert from icall wrapper generator.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3686,7 +3686,7 @@ mono_marshal_get_native_func_wrapper_indirect (MonoClass *caller_class, MonoMeth
 	MonoImage *image = m_class_get_image (caller_class);
 	g_assert (sig->pinvoke);
 	g_assert (!sig->hasthis && ! sig->explicit_this);
-	g_assert (!sig->is_inflated && !sig->has_type_parameters);
+	g_assert (!sig->has_type_parameters);
 
 #if 0
 	/*


### PR DESCRIPTION
If the method or type containing the icall instruction has a generic parameter, the resulting signature is "inflated" even if the generic parameter is not used in the signature. 

Fixes UUM-27888

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No



**Release notes**

Fixed UUM-27888 @bholmes :
Mono: Remove !sig->is_inflated assert from icall wrapper generator.


**Backports**

 - 2023.1
 - 2022.2
 - 2022.1
 - 2021.3
