### PR TITLE
2021.3:Remove !sig->is_inflated assert from icall wrapper generator. 

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3686,7 +3686,7 @@ mono_marshal_get_native_func_wrapper_indirect (MonoClass *caller_class, MonoMeth
 	MonoImage *image = m_class_get_image (caller_class);
 	g_assert (sig->pinvoke);
 	g_assert (!sig->hasthis && ! sig->explicit_this);
-	g_assert (!sig->is_inflated && !sig->has_type_parameters);
+	g_assert (!sig->has_type_parameters);
 
 #if 0
 	/*


### PR DESCRIPTION
If the method or type containing the icall instruction has a generic parameter, the resulting signature is "inflated" even if the generic parameter is not used in the signature. This breaks some methods in SlimDX, and probably other C++/CLI code.

*Bug:https://jira.unity3d.com/browse/UUM-27888
*Backport:https://jira.unity3d.com/browse/UUM-28859

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-27888 @ppandi-rythmos :
Mono: Remove !sig->is_inflated assert from icall wrapper generator.

**Comments to reviewers**

Cherry picked changes from the Trunk PR : https://github.com/Unity-Technologies/mono/pull/1736

**Cherry-pick is [CleanGraft].**

Trunk PR Version:2023.2

2022.2:https://github.com/Unity-Technologies/mono/pull/1738