### PR TITLE
2022.2: Update mono-build-tools-extra package

### DIFF
--- a/external/buildscripts/manifest.stevedore
+++ b/external/buildscripts/manifest.stevedore
@@ -10,7 +10,7 @@ unity-internal: android-ndk-win/r19-unity_799f451638695b9da797fcd509f9f2a8e59e35
 # macOS
 unity-internal: android-ndk-mac/r19-unity_8b169ff2a8234c85e0c5ba3c776aa94273cd3c15fdc96d213154970d87938589.7z
 unity-internal: mac-toolchain-11_0/12.2-12B5018i_351c773fb8a192039fe0f0e962314b888102b0718c734ad54f3906c0caeed1c9.zip
-unity-internal: mono-build-tools-extra/e86f1a824f0f0ff49f645277700b85189c6b1b6b_b21a8dc0fde03a54336f7682b0c91eab8cac4d402ecb11cc441ee577df2a8c74.7z
+unity-internal: mono-build-tools-extra/7c18fa4924_2473e356e796b9ce5eb37eb0543c444c0810310316fdcfc09e245c0f0df253db.7z
 unity-internal: cmake-linux-x64/3.20.0_a47b24f0bb16dca4fbd6974c03d5eb82e081318f5c9de75e1416db0020508579.7z
 
 # Linux


### PR DESCRIPTION
Remove throw from stubber for attribute setters

Attribute scanning code will invoke .ctors and setters of all attribute classes. The stubber was already not throwing in ctors of attribute classes. This commit will also ignore setters of attribute classes.

fixes UUM-18689



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-18689 @dtomar:
Mono: Remove throw from attribute setters generated by profile stubber

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->