### PR TITLE
[Windows] [ARM64] NullReferenceException not being handled correctly on ARM64

### DIFF
--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -532,9 +532,8 @@ handle_signal_exception (gpointer obj)
 gboolean
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
-#if defined(MONO_CROSS_COMPILE)
-	g_assert_not_reached ();
-#else
+#if defined(MONO_ARCH_USE_SIGACTION)
+
 	MonoJitTlsData *jit_tls;
 	void *sigctx = ctx;
 
@@ -552,8 +551,16 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	UCONTEXT_REG_SET_PC (sigctx, addr);
 	host_mgreg_t sp = UCONTEXT_REG_SP (sigctx) - MONO_ARCH_REDZONE_SIZE;
 	UCONTEXT_REG_SET_SP (sigctx, sp);
-#endif
+#else
+	MonoContext mctx;
 
+	mono_sigctx_to_monoctx (ctx, &mctx);
+
+	mono_handle_exception (&mctx, obj);
+
+	mono_monoctx_to_sigctx (&mctx, ctx);
+
+#endif
 	return TRUE;
 }
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -532,7 +532,11 @@ handle_signal_exception (gpointer obj)
 gboolean
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
-#if defined(MONO_ARCH_USE_SIGACTION)
+#if defined(MONO_CROSS_COMPILE)
+
+	g_assert_not_reached();
+
+#elif defined(MONO_ARCH_USE_SIGACTION)
 
 	MonoJitTlsData *jit_tls;
 	void *sigctx = ctx;


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Release notes

Internal [UUM-21461](https://jira.unity3d.com/browse/UUM-21461) @jem.patel
Mono: NullReferenceException not being handled correctly for ARM64