### PR TITLE
2022.2: Fix Mono default interface methods with protected virtual class methods

### DIFF
--- a/mono/metadata/class-setup-vtable.c
+++ b/mono/metadata/class-setup-vtable.c
@@ -454,7 +454,7 @@ check_interface_method_override (MonoClass *klass, MonoMethod *im, MonoMethod *c
 {
 	MonoMethodSignature *cmsig, *imsig;
 	if (strcmp (im->name, cm->name) == 0) {
-		if (! (cm->flags & METHOD_ATTRIBUTE_PUBLIC)) {
+		if ((cm->flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) != METHOD_ATTRIBUTE_PUBLIC) {
 			TRACE_INTERFACE_VTABLE (printf ("[PUBLIC CHECK FAILED]"));
 			return FALSE;
 		}


### PR DESCRIPTION
**Purpose of the PR**
Fixing the METHOD_ATTRIBUTE_PUBLIC flag check on the class method for check_interface_method_override.

Parent: https://jira.unity3d.com/browse/UUM-22228
Backport: https://jira.unity3d.com/browse/UUM-22239

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Fixed UUM-22228 @knatraj-rythmos:
Mono: Fix Mono default interface methods with protected virtual class methods.

**Comment to Reviewers**
Cherry pick was a [CleanGraft]

PR to Main: https://github.com/Unity-Technologies/mono/pull/1733