### PR TITLE
Readd legacy memory snapshot methods as stubs

### DIFF
--- a/mono/metadata/unity-memory-info.c
+++ b/mono/metadata/unity-memory-info.c
@@ -137,3 +137,14 @@ mono_unity_class_for_each(ClassReportFunc callback, void *user_data)
 	// Report all image set arrays
 	mono_metadata_image_set_foreach(ReportImageSetClasses, &reportContext);
 }
+
+MONO_API MonoManagedMemorySnapshot* 
+mono_unity_capture_memory_snapshot()
+{
+	return NULL;
+}
+
+MONO_API void
+mono_unity_free_captured_memory_snapshot(MonoManagedMemorySnapshot* snapshot)
+{
+}

--- a/mono/metadata/unity-memory-info.h
+++ b/mono/metadata/unity-memory-info.h
@@ -6,4 +6,8 @@ typedef void(*ClassReportFunc) (MonoClass* klass, void *user_data);
 
 MONO_API void mono_unity_class_for_each(ClassReportFunc callback, void* user_data);
 
+typedef struct MonoManagedMemorySnapshot MonoManagedMemorySnapshot;
+MONO_API MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot();
+MONO_API void mono_unity_free_captured_memory_snapshot(MonoManagedMemorySnapshot* snapshot);
+
 #endif


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

Revert memory profiler snapshot method removal as stubs until https://github.cds.internal.unity3d.com/unity/unity/pull/25725 removes their usage from unity/unity repository.

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

**Backports**
<!-- Use this section is the pull request should be back ported.
List the versions of Unity where this change should be back ported here.
-->
2023.1

**Unity repository changes**
<!-- Use this section if the pull request requires other changes in the Unity repository.
List any Unity repository PRs.
-->
N/A