### PR TITLE
Indicate that release notes should be required by default [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,13 +18,16 @@ Here are a few things to think about (see below for more details). Please check 
 
 Reviewers: please consider these questions as well! :heart:
 
-<!-- Use this section if the pull request has release notes.
 **Release notes**
 
 Fixed UUM-XXXXXX @username:
 Mono: Your release notes go here.
 
-Other options: Internal, Changed, Improved, Feature. 
+<!-- Most pull requests should have release notes.
+
+Use Internal for release notes that should not be public.
+
+Other options: Changed, Improved, Feature.
 -->
 
 <!-- Use this section is the pull request should be back ported.


### PR DESCRIPTION
For most Mono pull requests, we should include release notes. This helps make the process of taking changes to the Unity repository, for Unity releases, easier.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

<!-- Use this section if the pull request has release notes.
**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

Other options: Internal, Changed, Improved, Feature. 
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->