### PR TITLE
fixed build script error on intel arch macs

### DIFF
--- a/external/buildscripts/build_all_osx.pl
+++ b/external/buildscripts/build_all_osx.pl
@@ -82,9 +82,12 @@ if ($buildArm64)
 if ($artifact)
 {
 	print(">>> Moving built binaries to final output directories\n");
-
-	CopyEmbedRuntimeBinaries($embedDirSourceARM64, "$embedDirRoot/osx-arm64");
-
+    
+    if ($buildArm64)
+    {
+        CopyEmbedRuntimeBinaries($embedDirSourceARM64, "$embedDirRoot/osx-arm64");
+    }
+    
 	# Merge stuff in the monodistribution directory
 	my $distDirRoot = "$buildsroot/monodistribution";
 	my $distDirDestinationBin = "$buildsroot/monodistribution/bin";


### PR DESCRIPTION
When trying to build on intel arch mac, the build all osx script would try to move arm64 binaries that would not exist. This fix ensures this only happens if we are building arm64.
