### PR TITLE
Avoid GC transitions when they are not needed.

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1908,7 +1908,7 @@ gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBui
 #ifndef DISABLE_COM
 	builder->coop_cominterop_fnptr = -1;
 #endif
-#if defined (TARGET_WASM)
+#if defined (TARGET_WASM) || !(defined(ENABLE_HYBRID_SUSPEND) || defined(ENABLE_COOP_SUSPEND))
 	return FALSE;
 #else
 	return TRUE;


### PR DESCRIPTION
If hybrid or coop is not supported by the build, it will never be needed at runtime by the generated native/icall wrappers. This improves performance of native wrappers.


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Improved @joncham:
Mono: Improved performance of managed to native transitions.

**Backports**
2022.3 (if we want performance improvement)
