### PR TITLE
[2023.1] Avoid GC transitions when they are not needed.

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1908,7 +1908,7 @@ gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBui
 #ifndef DISABLE_COM
 	builder->coop_cominterop_fnptr = -1;
 #endif
-#if defined (TARGET_WASM)
+#if defined (TARGET_WASM) || !(defined(ENABLE_HYBRID_SUSPEND) || defined(ENABLE_COOP_SUSPEND))
 	return FALSE;
 #else
 	return TRUE;


### PR DESCRIPTION
If hybrid or coop is not supported by the build, it will never be needed at runtime by the generated native/icall wrappers. This improves performance of native wrappers.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-XXXXXX @username:
Mono: Your release notes go here.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->