### PR TITLE
2021.3:Fix setting or getting pointer fields with reflection.

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/FieldInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/FieldInfoTest.cs
@@ -536,24 +536,70 @@ namespace MonoTests.System.Reflection
 		public static unsafe void* ip;
 
 		[Test]
-		public unsafe void GetSetValuePointers ()
+		public unsafe void GetSetValuePointersStatic ()
 		{
 			Pointer p0 = (Pointer)typeof (FieldInfoTest).GetField ("ip").GetValue (null);
 			int *p0i = (int*)Pointer.Unbox (p0);
 			Assert.AreEqual (IntPtr.Zero, new IntPtr (p0i));
 
 			int i = 5;
+
 			void *p = &i;
 			typeof (FieldInfoTest).GetField ("ip").SetValue (null, (IntPtr)p);
-			Pointer p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip").GetValue (null);
 
+			Pointer p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip").GetValue (null);
 			int *pi = (int*)Pointer.Unbox (p2);
 			Assert.AreEqual (5, *pi);
 
 			typeof (FieldInfoTest).GetField ("ip").SetValue (null, (UIntPtr)p);
-			p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip").GetValue (null);
 
+			p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip").GetValue (null);
 			pi = (int*)Pointer.Unbox (p2);
+			Assert.AreEqual (5, *pi);
+
+			FieldInfoTest.ip = p;
+
+			p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip").GetValue (null);
+			pi = (int*)Pointer.Unbox (p2);
+			Assert.AreEqual (5, *pi);
+
+			typeof (FieldInfoTest).GetField ("ip").SetValue (null, (IntPtr)p);
+			pi = (int*)FieldInfoTest.ip;
+			Assert.AreEqual (5, *pi);
+		}
+
+		public unsafe void* ip_inst;
+
+		[Test]
+		public unsafe void GetSetValuePointersInstance ()
+		{
+			Pointer p0 = (Pointer)typeof (FieldInfoTest).GetField ("ip_inst").GetValue (this);
+			int *p0i = (int*)Pointer.Unbox (p0);
+			Assert.AreEqual (IntPtr.Zero, new IntPtr (p0i));
+
+			int i = 5;
+
+			void *p = &i;
+			typeof (FieldInfoTest).GetField ("ip_inst").SetValue (this, (IntPtr)p);
+
+			Pointer p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip_inst").GetValue (this);
+			int *pi = (int*)Pointer.Unbox (p2);
+			Assert.AreEqual (5, *pi);
+
+			typeof (FieldInfoTest).GetField ("ip_inst").SetValue (this, (UIntPtr)p);
+
+			p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip_inst").GetValue (this);
+			pi = (int*)Pointer.Unbox (p2);
+			Assert.AreEqual (5, *pi);
+
+			this.ip_inst = p;
+
+			p2 = (Pointer)typeof (FieldInfoTest).GetField ("ip_inst").GetValue (this);
+			pi = (int*)Pointer.Unbox (p2);
+			Assert.AreEqual (5, *pi);
+
+			typeof (FieldInfoTest).GetField ("ip_inst").SetValue (this, (IntPtr)p);
+			pi = (int*)this.ip_inst;
 			Assert.AreEqual (5, *pi);
 		}
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3423,11 +3423,7 @@ mono_field_set_value_internal (MonoObject *obj, MonoClassField *field, void *val
 		return;
 
 	dest = (char*)obj + field->offset;
-#if ENABLE_NETCORE
 	mono_copy_value (field->type, dest, value, value && field->type->type == MONO_TYPE_PTR);
-#else
-	mono_copy_value (field->type, dest, value, FALSE);
-#endif
 }
 
 /**
@@ -3470,7 +3466,7 @@ mono_field_static_set_value_internal (MonoVTable *vt, MonoClassField *field, voi
 	} else {
 		dest = (char*)mono_vtable_get_static_field_data (vt) + field->offset;
 	}
-	mono_copy_value (field->type, dest, value, FALSE);
+	mono_copy_value (field->type, dest, value, value && field->type->type == MONO_TYPE_PTR);
 	/* This is not needed by sgen, as it does not seem 
 	to need write barriers for uncollectable objects (like the vtables storing static 
 +	fields), but it is needed for incremental boehm. */
@@ -3740,12 +3736,7 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 			mono_field_get_value_internal (obj, field, v);
 		}
 
-#if ENABLE_NETCORE
 		args [0] = ptr;
-#else
-		/* MONO_TYPE_PTR is passed by value to runtime_invoke () */
-		args [0] = ptr ? *ptr : NULL;
-#endif
 		args [1] = mono_type_get_object_checked (mono_domain_get (), type, error);
 		goto_if_nok (error, return_null);
 


### PR DESCRIPTION
Setting a pointer via reflection incorrectly added an extra layer of indirection, and getting a pointer via reflection incorrectly dereferenced the value once.
As a result, setting and then getting only via reflection worked correctly, but doing either step by directly accessing the field and the other via reflection was broken.
Also adjusts FieldInfoTest to test this, for both static and instance fields (the set path especially is different for those.)

*Bug:https://jira.unity3d.com/browse/UUM-31140
*Backport:https://jira.unity3d.com/browse/UUM-31172

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**
Fixed UUM-31140 @ppandi-rythmos :
Mono: Fixed issue where setting a pointer via reflection included an additional layer of redirection.

**Comments to reviewers**
Cherry-pick is [CleanGraft]

**ES-High**

PR to main: https://github.com/Unity-Technologies/mono/pull/1752

2023.1:https://github.com/Unity-Technologies/mono/pull/1759

2022.2:https://github.com/Unity-Technologies/mono/pull/1760