### PR TITLE
Unregister the ETW profiler hooks (case UUM-33137)

### DIFF
--- a/mono/metadata/etw-profiler.c
+++ b/mono/metadata/etw-profiler.c
@@ -314,6 +314,13 @@ DECLSPEC_NOINLINE __inline VOID __stdcall Private_EventControlCallback (_In_ LPC
 	};
 }
 
+void
+mono_profiler_cleanup_etw(MonoProfiler *prof)
+{
+	EventUnregisterMicrosoft_Windows_DotNETRuntimeRundown ();
+	EventUnregisterMicrosoft_Windows_DotNETRuntime ();
+}
+
 /* the entry point */
 MONO_API void
 mono_profiler_init_etw (const char *desc)
@@ -331,6 +338,7 @@ mono_profiler_init_etw (const char *desc)
 	mono_profiler_set_image_loaded_callback (handle, image_loaded);
 	mono_profiler_set_image_unloading_callback (handle, image_unloading);
 	mono_profiler_set_jit_done_callback (handle, method_jit_done);
+	mono_profiler_set_cleanup_callback(handle, mono_profiler_cleanup_etw);
 
 	is_initialized = TRUE;
 


### PR DESCRIPTION
If the ETW profiler hooks are left enabled, it is possible to see crashes due to a race condition during shutdown. Mono provides a profiler cleanup callback that is called after all profiler events have been unregistered, so we can be sure no code is still using the ETW hooks.

Use this cleanup callback to disable the profiler hooks then, and avoid the crashes due to the race condition.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal UUM-33137 @joshuap:
Mono: Unregister ETW profiler hooks to avoid a possible crash on shutdown.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**

This should be back ported to 2023.1, 2022.2, and 2021.3.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->