### PR TITLE
2023.1:Fix DST Being Ignored for CET (UUM-33155)

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.Unity.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.Unity.cs
@@ -26,7 +26,7 @@ namespace System {
 			DaylightSavingFirstTransitionIdx,
 			DaylightSavingSecondTransitionIdx,
 			UtcOffsetIdx,
-			AdditionalDaylightOffsetIdx
+			DaylightDeltaIdx
 		};
 
 		enum TimeZoneNames
@@ -48,14 +48,14 @@ namespace System {
 				return rulesForYear;
 			var firstTransition = new DateTime (data[(int)TimeZoneData.DaylightSavingFirstTransitionIdx]);
 			var secondTransition = new DateTime (data[(int)TimeZoneData.DaylightSavingSecondTransitionIdx]);
-			var daylightOffset = new TimeSpan (data[(int)TimeZoneData.AdditionalDaylightOffsetIdx]);
+			var daylightDelta = new TimeSpan (data[(int)TimeZoneData.DaylightDeltaIdx]);
 
 			/* C# TimeZoneInfo does not support timezones the same way as unix. In unix, timezone files are specified by region such as
 			 * America/New_York or Asia/Singapore. If a region like Asia/Singapore changes it's timezone from +0730 to +08, the UTC offset
 			 * has changed, but there is no support in the C# code to transition to this new UTC offset except for the case of daylight
 			 * savings time. As such we'll only generate timezone rules for a region at the times associated with the timezone of the current year.
 			 */
-			if(data[(int)TimeZoneData.AdditionalDaylightOffsetIdx] == 0 || data[(int)TimeZoneData.UtcOffsetIdx] == data[(int)TimeZoneData.AdditionalDaylightOffsetIdx])
+			if(data[(int)TimeZoneData.DaylightDeltaIdx] == 0)
 				return rulesForYear;
 
 			// If the first and second transition DateTime objects are the same, ValidateAdjustmentRule will throw
@@ -79,7 +79,7 @@ namespace System {
 
 				var fullYearRule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (beginningOfYear,
 																					endOfYearDay,
-																					daylightOffset,
+																					daylightDelta,
 																					startOfDaylightSavingsTime,
 																					endOfDaylightSavingsTime);
 				rulesForYear.Add (fullYearRule);
@@ -95,7 +95,7 @@ namespace System {
 				var transitionOutOfDaylightSavingsRule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (
 																					new DateTime (year, 1, 1),
 																					new DateTime (firstTransition.Year, firstTransition.Month, firstTransition.Day),
-																					daylightOffset,
+																					daylightDelta,
 																					startOfFirstDaylightSavingsTime,
 																					endOfFirstDaylightSavingsTime);
 				rulesForYear.Add (transitionOutOfDaylightSavingsRule);
@@ -110,7 +110,7 @@ namespace System {
 				var transitionIntoDaylightSavingsRule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule (
 																					new DateTime (firstTransition.Year, firstTransition.Month, firstTransition.Day).AddDays (1),
 																					endOfYearDay,
-																					daylightOffset,
+																					daylightDelta,
 																					startOfSecondDaylightSavingsTime,
 																					endOfSecondDaylightSavingsTime);
 				rulesForYear.Add (transitionIntoDaylightSavingsRule);
@@ -138,7 +138,7 @@ namespace System {
 				if (!System.CurrentSystemTimeZone.GetTimeZoneData (year, out data, out names, out dst_inverted))
 					throw new NotSupportedException ("Can't get timezone name.");
 
-				disableDaylightSavings = data[(int)TimeZoneData.AdditionalDaylightOffsetIdx] == 0 || data[(int)TimeZoneData.UtcOffsetIdx] == data[(int)TimeZoneData.AdditionalDaylightOffsetIdx];
+				disableDaylightSavings = data[(int)TimeZoneData.DaylightDeltaIdx] == 0;
 				if (!disableDaylightSavings)
 				{
 					daylightDisplayName = names[(int)TimeZoneNames.DaylightNameIdx];


### PR DESCRIPTION
The check to determine if a time zone had daylight savings time incorrectly treated the 3rd element of the data array as the UTC offset for daylight savings time.  It is in fact the delta time from the time zone's normal UTC offset.  E.g. for US Eastern Time the daylight delta is 1, not 4.
This causes a problem for Central European Time which has a UTC offset of 1 and daylight time delta of 1, so for CET we were ignoring daylight savings time.

*Bug:https://jira.unity3d.com/browse/UUM-33155
*Backport:https://jira.unity3d.com/browse/UUM-33222

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-33155 @ppandi-rythmos :
Mono: Fixed daylight savings time being ignored for the Central European time zone

**Comments to reviewers**
Cherry-pick is [CleanGraft]

PR to main: https://github.com/Unity-Technologies/mono/pull/1757