### PR TITLE
Fix for Mono Deps job to work

### DIFF
--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -10,13 +10,15 @@ dependencies:
   - .yamato/Publish To Stevedore.yml
 commands:
   - |
+    cd ../../
     git clone git@github.cds.internal.unity3d.com:unity/prtools.git
     cd prtools
-    git checkout 2023.1/main
+    git checkout main
     cmd /c cibuildscript
     cmd /c xcopy build %PRTOOLS_BUILD_DIR% /s /Y /E /I
     cd %UNITY_SOURCE_PRTOOLS_DIR%
-    %PRTOOLS_BUILD_DIR%\prtools.exe --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/stevedore/artifactid.txt --backport=%BACKPORT_BRANCH% --github-api-token=%GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%
+    git clone https://github.cds.internal.unity3d.com/unity/unity.git .
+    cmd /v /c dotnet run --project C:\build\output\prtools\PRTools\PRTools.csproj --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/stevedore/artifactid.txt --backport=%BACKPORT_BRANCH% --github-api-token=%GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%   
     if NOT %errorlevel% == 0 (
       echo "PRTools failed"
       EXIT /B %errorlevel%


### PR DESCRIPTION
We want to fix the error attached below. We believe under the mono directory something is messing up with the nuget setting which is required for .net7 packages to work

The current code is not working because of this error:
```
[17:49:14.462 Information] C:\build\output\Unity-Technologies\mono\prtools\PRTools\PRTools.csproj : error NU1102: Unable to find package ServiceStack.Text with version (>= 6.6.0) [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln] C:\build\output\Unity-Technologies\mono\p
[17:49:14.463 Information] rtools\PRTools\PRTools.csproj : error NU1102:   - Found 162 version(s) in dotnet-public [ Nearest version: 5.10.4 ] [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
C:\build\output\Unity-Technologies\mono\prtools\PRTools\PRTools.csproj : error NU1102:   - Found 0 version(s) in dotnet-eng [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
C:\build\output\Unity-Technologies\mono\prtools\PRTools\PRTools.csproj : error NU1101: Unable to find package Slack.Webhooks. No packages exist with this id in source(s): dotnet-eng, dotnet-public [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
[17:49:14.566 Information]   Failed to restore C:\build\output\Unity-Technologies\mono\prtools\PRTools\PRTools.csproj (in 3.26 sec).
[17:49:14.970 Information] C:\build\output\Unity-Technologies\mono\prtools\PRTools.Tests\PRTools.Tests.csproj : error NU1102: Unable to find package ServiceStack.Text with version (>= 6.6.0) [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
C:\build\output\Unity-Technol
[17:49:14.971 Information] ogies\mono\prtools\PRTools.Tests\PRTools.Tests.csproj : error NU1102:   - Found 162 version(s) in dotnet-public [ Nearest version: 5.10.4 ] [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
C:\build\output\Unity-Technologies\mono\prtools\PRTools.Tests\PRTools.Tests.csproj : error NU1102:   - Found 0 version(s) in dotnet-eng [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
C:\build\output\Unity-Technologies\mono\prtools\PRTools.Tests\PRTools.Tests.csproj : error NU1101: Unable to find package Slack.Webhooks. No packages exist with this id in source(s): dotnet-eng, dotnet-public [C:\build\output\Unity-Technologies\mono\prtools\PRTools.sln]
```



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->