### PR TITLE
Add trailing backslash to UNC paths for (case UUM-29631)

### DIFF
--- a/external/corefx-bugfix/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/external/corefx-bugfix/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -92,6 +92,23 @@ namespace System.IO.Enumeration
         /// </summary>
         private IntPtr CreateDirectoryHandle(string path, bool ignoreNotFound = false)
         {
+            // GetFileAttributesEx sometimes does not understand long form UNC paths
+            // without adding a trailing backslash. So we check explicitly for such a
+            // path, and add the required trail.
+            if ((path.StartsWith(@"\?\") || path.StartsWith(@"\\?\"))
+                && path.Contains(@"GLOBALROOT\Device\Harddisk"))
+            {
+                // 'Partition' length is 9 and can be followed by a number between '1' and '14'.
+                int diff = path.Length - path.IndexOf("Partition");
+
+                // Previous code get rid of any directory separator ('/')
+                // This leaves only "PartitionX", "PartitionXX" or "PartitionX\" to check.
+                if (diff <= 11 && path[path.Length - 1] != '\\')
+                {
+                    path += '\\';
+                }
+            }
+
             IntPtr handle = System.IO.FileSystem.UnityCreateFile_IntPtr(
                 path,
                 Interop.Kernel32.FileOperations.FILE_LIST_DIRECTORY,


### PR DESCRIPTION
Calls to `GetFileAttributesEx` can fail incorrectly if a UNC path does not have a trailing backslash. Modify the class library code to append this trailing character when necessary.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-29631 @joshuap:
IL2CPP: Correct the behavior of .NET File APIs for some DLC paths on GameCore.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**

These changes should be back ported to 2023.1, 2022.2, and 2021.3.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->