### PR TITLE
Remove the nightly CI run of 2022.2 [skip ci]

### DIFF
--- a/.yamato/Collate Builds.yml
+++ b/.yamato/Collate Builds.yml
@@ -25,9 +25,6 @@ triggers:
     only:
       - "unity-unity-2022.2-mbe"
   cancel_old_ci: true
-  recurring:
-    - branch: unity-unity-2022.2-mbe
-      frequency: daily # Should run between midnight and 6AM UTC
 
 artifacts: 
   builds:


### PR DESCRIPTION
Unity has changed to ship version 2022.3 now, so don't run nightly jobs on the 2022.2 branch.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:
