### PR TITLE
2022.3: Avoid throwing TypeLoadException for generic 2D arrays (case UUM-34854)

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1124,8 +1124,10 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 
 	mono_class_setup_supertypes (klass);
 
-	if (mono_class_is_ginst (eclass))
-		mono_class_init_internal (eclass);
+	// NOTE: this is probably too aggressive if eclass is not a valuetype.  It looks like we
+	// only need the size info in order to set MonoClass:has_references for this array type -
+	// and for that we only need to setup the fields of the element type if it's not a reference
+	// type.
 	if (!eclass->size_inited)
 		mono_class_setup_fields (eclass);
 	mono_class_set_type_load_failure_causedby_class (klass, eclass, "Could not load array element type");


### PR DESCRIPTION
Mono was a bit too aggressive with its TypeLoadException processing, not allowing some valid code in this case. This change applies the fix from:

https://github.com/dotnet/runtime/pull/85828

Bug: https://jira.unity3d.com/browse/UUM-34854
Backport: https://jira.unity3d.com/browse/UUM-38035


<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-34854 @Saiprasad945 :
Mono: Avoid an incorrect TypeLoadException when a generic type has a field which is a 2D array of itself.

**Comments to reviewers**
Cherry-pick is [CleanGraft]
PR to Main: https://github.com/Unity-Technologies/mono/pull/1774
2023.1 PR: https://github.com/Unity-Technologies/mono/pull/1777
<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->