### PR TITLE
Relax UnmanagedCallersOnly check to avoid Burst issue.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11316,7 +11316,9 @@ mono_ldptr:
 					MonoMethod *invoke;
 					int invoke_context_used;
 
-					if (G_UNLIKELY (has_unmanaged_callers_only)) {
+					if (G_UNLIKELY (has_unmanaged_callers_only) && !strstr(cmethod->name, "$BurstManaged")) {
+						/* Burst is currently generating managed methods for direct calls, including methods marked with UnmanagedCallersOnly.
+						 * Add temporary workaround to land support for UnmanagedCallersOnly until Burst can respond to the new exception being raised.*/
 						mono_error_set_not_supported (cfg->error, "Cannot create delegate from method with UnmanagedCallersOnlyAttribute");
 						CHECK_CFG_ERROR;
 					}


### PR DESCRIPTION
Burst is currently generating managed methods for direct calls, including methods marked with UnmanagedCallersOnly. Add temporary workaround to land support for UnmanagedCallersOnly until Burst can respond to the new exception being raised.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:


<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->