### PR TITLE
Diagnostic hang logging

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -628,8 +628,11 @@ struct _MonoInternalThread {
 	struct _MonoInternalThread *internal_thread;
 	MonoObject *start_obj;
 	MonoException *pending_exception;
+#elif HOST_WIN32
+	void* unused [3];
 #else
-	void* unused [3]; // same size as netcore
+	void* unused [2]; // same size as netcore
+	guint64 os_tid;
 #endif
 	/* This is used only to check that we are in sync between the representation
 	 * of MonoInternalThread in native and InternalThread in managed


### PR DESCRIPTION
Adding some logging to dump the TID of the thread we're waiting on if we hang during a domain reload.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Improved @UnityAlex:
Mono: Added logging that will now list the threads that are being waited on during a domain reload.


**Backports**
2023.1, 2022.3, 2021.3
