### PR TITLE
[2022.3][mono][jit] Emit a null check when storing to valuetype fields. (#82663)

### DIFF
--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -881,6 +881,13 @@ static int ccount = 0;
 #define MONO_EMIT_NEW_IMPLICIT_EXCEPTION_LOAD_STORE(cfg) do { \
     } while (0)
 
+#define MONO_EMIT_EXPLICIT_NULL_CHECK(cfg, reg) do { \
+		cfg->flags |= MONO_CFG_HAS_CHECK_THIS; \
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, (reg), 0);	\
+		MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");		\
+		MONO_EMIT_NEW_UNALU (cfg, OP_NOT_NULL, -1, reg); \
+	} while (0)
+
 /* Emit an explicit null check which doesn't depend on SIGSEGV signal handling */
 #define MONO_EMIT_NULL_CHECK(cfg, reg, out_of_page) do { \
 		if (cfg->explicit_null_checks || (out_of_page)) {							  \

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9661,6 +9661,10 @@ calli_end:
 							EMIT_NEW_BIALU_IMM (cfg, ptr, OP_PADD_IMM, dreg, sp [0]->dreg, foffset);
 							store = mini_emit_storing_write_barrier (cfg, ptr, sp [1]);
 						} else {
+							if (MONO_TYPE_ISSTRUCT (field->type))
+								/* The decomposition might end up calling a copy/wbarrier function which doesn't do null checks */
+								MONO_EMIT_EXPLICIT_NULL_CHECK (cfg, sp [0]->dreg);
+
 							EMIT_NEW_STORE_MEMBASE_TYPE (cfg, store, field->type, sp [0]->dreg, foffset, sp [1]->dreg);
 						}
 					}


### PR DESCRIPTION
* [mono][jit] Emit a null check when storing to valuetype fields.

Fixes https://github.com/dotnet/runtime/issues/82535.

Backport of https://github.com/Unity-Technologies/mono/pull/1781 to 2022.3

Parent Bug: UUM-27537
2022.3 Port: UUM-40268

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-27537 @UnityAlex :
Mono: Fixed crash when attempting to access a field of a null valuetype object.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->