### PR TITLE
Zero out memory when gc is allocating strings

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1063,8 +1063,8 @@ mono_gc_alloc_string (MonoVTable *vtable, size_t size, gint32 len)
 
 	obj->object.vtable = vtable;
 	obj->object.synchronisation = NULL;
+	memset(mono_object_get_data((MonoObject*)obj), 0, size - MONO_ABI_SIZEOF(MonoObject));
 	obj->length = len;
-	obj->chars [len] = 0;
 
 	if (G_UNLIKELY (mono_profiler_allocations_enabled ()))
 		MONO_PROFILER_RAISE (gc_allocation, (&obj->object));


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-35559 @username: @PatrickSycz 
Mono: This fixes string initialization when creating a new string with the intention of all characters getting set to null. Clears the memory chunk when allocating strings to prevent garbage characters

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->