### PR TITLE
2021.3: Make sure MonoClass has been inited before returning blittable flag

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -368,6 +368,8 @@ MONO_API gboolean
 mono_class_is_blittable(MonoClass *klass)
 {
 	g_assert(klass);
+	if (!klass->fields_inited)
+		mono_class_setup_fields(klass);
 	return klass->blittable;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

Backport of #1791 for [UUM-35682](https://jira.unity3d.com/browse/UUM-35682)

Fix for UUM-35682 "IsBlittable returns incorrect value, if type hasn't been resolved in mono"

Depending how user type representations have been set up on the Mono side, we can end up in a state where MonoClass blittable is being read without the fields being inited. This should never be the case since we haven't calculated a value for blittable in this situation, and it's therefore just in its default state of FALSE which may or may not happen to be correct for the type.

Adds simple check to init the type's fields before returning blittable.

Note that there is an existing workaround for the issue - https://github.cds.internal.unity3d.com/unity/unity/pull/16698/commits/2c0044797baf2132e15cf8214cd82b3da06aec63 - which effectively walks through all the types in the assemblies and 'touches' them all to make sure they are set up properly on the Mono side. This works but is not seen as a long term solution due to the performance impact. I'll add a Unity repo PR to revert that once this Mono change is brought over to Unity.

Bug: [UUM-35682](https://jira.unity3d.com/browse/UUM-35682)
Backport: [UUM-45689](https://jira.unity3d.com/browse/UUM-45689)
Trunk PR: #1791 

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed [UUM-45689](https://jira.unity3d.com/browse/UUM-45689) @DanRandom:
Mono: Fixed issue where blittable flag could be incorrect when it was read before MonoClass was inited

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

**Unity repository changes**
Temporary workaround for this issue https://github.cds.internal.unity3d.com/unity/unity/pull/16698/commits/2c0044797baf2132e15cf8214cd82b3da06aec63 should be reverted, but not until this Mono change has landed in the Unity repo. @jhcdunity3d will add a Unity PR to do that once that happens.