### PR TITLE
Ensure that we acquire all needed locks before suspending threads and GC

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1879,6 +1879,13 @@ MONO_API void
 mono_unity_stop_gc_world()
 {
 #if HAVE_BOEHM_GC
+	// Metadata access does mono_loader_lock. We access it when we capture classes 
+	// and other information. So does the debugger, which can create a deadlock.
+	mono_loader_lock();
+	// We need to lock domain sooner, to make sure than no other thread is currently
+	// holding lock, as mono_unity_domain_mempool_chunk_foreach will need it for:
+	// mono_unity_domain_mempool_chunk_foreach -> mono_mem_manager_lock -> mono_domain_lock
+	mono_domain_lock(mono_domain_get());
 	GC_stop_world_external();
 #else
 	g_assert_not_reached();
@@ -1890,6 +1897,8 @@ mono_unity_start_gc_world()
 {
 #if HAVE_BOEHM_GC
 	GC_start_world_external();
+	mono_domain_unlock(mono_domain_get());
+	mono_loader_unlock();
 #else
 	g_assert_not_reached();
 #endif


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

Backport of #1792 to unity-2022.3-mbe

Fixes UUM-40688
2022.3 Port: UUM-40748

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-40688 @antonk:
Mono: Fixes deadlock on taking a memory profiler snapshot

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->