### PR TITLE
[2023.1] Diagnostic hang logging

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -628,8 +628,11 @@ struct _MonoInternalThread {
 	struct _MonoInternalThread *internal_thread;
 	MonoObject *start_obj;
 	MonoException *pending_exception;
+#elif HOST_WIN32
+	void* unused [3];
 #else
-	void* unused [3]; // same size as netcore
+	void* unused [2]; // same size as netcore
+	guint64 os_tid;
 #endif
 	/* This is used only to check that we are in sync between the representation
 	 * of MonoInternalThread in native and InternalThread in managed


### PR DESCRIPTION
Backport of #1782 to unity-2023.1-mbe

"Adding some logging to dump the TID of the thread we're waiting on if we hang during a domain reload."

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Improved @UnityAlex:
Mono: Added logging that will now list the threads that are being waited on during a domain reload.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->