### PR TITLE
2021.3: [mono][arm64] Fixed passing/receiving hfa structures with fixed buffe…

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -169,7 +169,7 @@ offset_of_first_nonstatic_field (MonoClass *klass)
 	return 0;
 }
 
-static gboolean
+gboolean
 get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len)
 {
 	ERROR_DECL (error);

--- a/mono/metadata/marshal-ilgen.h
+++ b/mono/metadata/marshal-ilgen.h
@@ -9,4 +9,7 @@
 MONO_API void
 mono_marshal_ilgen_init (void);
 
+gboolean
+get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len);
+
 #endif

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -26,6 +26,7 @@
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/metadata/abi-details.h>
+#include <mono/metadata/marshal-ilgen.h>
 
 #include "interp/interp.h"
 
@@ -1140,7 +1141,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 	gpointer iter;
 	MonoClassField *field;
 	MonoType *ftype, *prev_ftype = NULL;
-	int i, nfields = 0;
+	int nfields = 0;
 
 	klass = mono_class_from_mono_type_internal (t);
 	iter = NULL;
@@ -1154,8 +1155,22 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 			int nested_nfields, nested_esize;
 			int nested_field_offsets [16];
 
-			if (!is_hfa (ftype, &nested_nfields, &nested_esize, nested_field_offsets))
-				return FALSE;
+			MonoType *fixed_etype;
+			int fixed_len;
+			if (get_fixed_buffer_attr (field, &fixed_etype, &fixed_len)) {
+				if (fixed_etype->type != MONO_TYPE_R4 && fixed_etype->type != MONO_TYPE_R8)
+					return FALSE;
+				if (fixed_len > 16)
+					return FALSE;
+				nested_nfields = fixed_len;
+				nested_esize = fixed_etype->type == MONO_TYPE_R4 ? 4 : 8;
+				for (int i = 0; i < nested_nfields; ++i)
+					nested_field_offsets [i] = i * nested_esize;
+			} else {
+				if (!is_hfa (ftype, &nested_nfields, &nested_esize, nested_field_offsets))
+					return FALSE;
+			}
+
 			if (nested_esize == 4)
 				ftype = m_class_get_byval_arg (mono_defaults.single_class);
 			else
@@ -1163,7 +1178,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;
 			prev_ftype = ftype;
-			for (i = 0; i < nested_nfields; ++i) {
+			for (int i = 0; i < nested_nfields; ++i) {
 				if (nfields + i < 4)
 					field_offsets [nfields + i] = field->offset - MONO_ABI_SIZEOF (MonoObject) + nested_field_offsets [i];
 			}


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/mono/pull/1807 for [UUM-30210](https://jira.unity3d.com/browse/UUM-30210)

Fixes https://github.com/dotnet/runtime/issues/90423.

Cherrypicked from upstream. Pick was not clean and required some massaging.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

Bug: [UUM-30210](https://jira.unity3d.com/browse/UUM-30210)
Backport: [UUM-45434](https://jira.unity3d.com/browse/UUM-45434)
Trunk PR: https://github.com/Unity-Technologies/mono/pull/1807

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No (Cherrypicked from upstream)

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-30210 @DanRandom :
Mono: Fixed issue where a fixed buffer within a valuetype struct would not be passed by value correctly.
