### PR TITLE
2023.1: Added support for MONO_DEBUG_VAR_MODE_VTADDR to fix a crash in rider'…

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6238,6 +6238,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 		mono_gc_memmove_atomic (addr, val, size);
 		break;
 	case MONO_DEBUG_VAR_ADDRESS_MODE_REGOFFSET_INDIR:
+	case MONO_DEBUG_VAR_ADDRESS_MODE_VTADDR:
 		/* Same as regoffset, but with an indirection */
 		addr = (guint8 *)mono_arch_context_get_int_reg (ctx, reg);
 		addr += (gint32)var->offset;


### PR DESCRIPTION
Backport of #1801  for [UUM-43492](https://jira.unity3d.com/browse/UUM-43492)

Expands control statement to allow the Rider IDE to inspect certain variables in debug mode without crashing.

Bug: [UUM-43492](https://jira.unity3d.com/browse/UUM-43492)
Backport: [UUM-43527](https://jira.unity3d.com/browse/UUM-43527)
Trunk PR: #1801 

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed [UUM-43492](https://jira.unity3d.com/browse/UUM-43492) @Durengo:
Mono: Fixed crash in Rider when hovering a symbol to view it's value.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->