### PR TITLE
2023.2: Do not call exit in g_assertion_message

### DIFF
--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -212,7 +212,12 @@ g_assertion_message (const gchar *format, ...)
 	failure_assertion = g_logv_nofree (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, format, args);
 
 	va_end (args);
-	exit (0);
+
+#ifdef HOST_WIN32
+	RaiseException(0xE0000001, EXCEPTION_NONCONTINUABLE, 0, NULL);
+#else
+	g_assert_abort();
+#endif
 }
 
 // Emscriptem emulates varargs, and fails to stack pack multiple outgoing varargs areas,


### PR DESCRIPTION
Backport of #1800 for [UUM-43015](https://jira.unity3d.com/browse/UUM-43015)

This will ensure that we get crash dump when g_assertion_message is called.

Bug: [UUM-43015](https://jira.unity3d.com/browse/UUM-43015)
Backport: [UUM-46058](https://jira.unity3d.com/browse/UUM-46058)
Trunk PR: #1800 

<!--
Thanks for submitting a pull request to the IL2CPP repository, we appreciate it!

Here are a few things to think about (see below for more details). Please check
each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes require other changes in the Unity repository?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed [UUM-43015](https://jira.unity3d.com/browse/UUM-43015) @Durengo:
Mono: Produce crash dump when g_assertion_message is called.