### PR TITLE
2023.3: Adding null check for result of mini_get_method

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9242,7 +9242,7 @@ calli_end:
 			guint32 gettype_token;
 			if ((ip = il_read_call(next_ip, end, &gettype_token)) && ip_in_bb (cfg, cfg->cbb, ip)) {
 				MonoMethod* gettype_method = mini_get_method (cfg, method, gettype_token, NULL, generic_context);
-				if (!strcmp (gettype_method->name, "GetType") && gettype_method->klass == mono_defaults.object_class) {
+				if (gettype_method && !strcmp (gettype_method->name, "GetType") && gettype_method->klass == mono_defaults.object_class) {
 					mono_class_init_internal(klass);
 					if (mono_class_get_checked (m_class_get_image (klass), m_class_get_type_token (klass), error) == klass) {
 						if (cfg->compile_aot) {


### PR DESCRIPTION
Backport of #1796 for [UUM-45293](https://jira.unity3d.com/browse/UUM-45293)

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Bug: [UUM-45293](https://jira.unity3d.com/browse/UUM-45293)
Backport: [UUM-45586](https://jira.unity3d.com/browse/UUM-45586)
Trunk PR: #1796

**Release notes**

Fixed UUM-45293 @DanRandom :
Mono: Fix Editor crash when mini_get_method fails.
