### PR TITLE
Expose mono_unity_gc_is_heap_ptr for diagnostics.

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -975,6 +975,16 @@ MONO_API void mono_unity_gc_enable()
 #endif
 }
 
+MONO_API gboolean
+mono_unity_gc_is_heap_ptr(const void* ptr)
+{
+#if HAVE_BOEHM_GC
+	return GC_is_heap_ptr(ptr);
+#else
+	g_assert_not_reached();
+#endif
+}
+
 // Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API void mono_unity_gc_disable()
 {

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -196,6 +196,8 @@ typedef enum
 
 MONO_API void mono_unity_gc_set_mode(MonoGCMode mode);
 
+MONO_API gboolean mono_unity_gc_is_heap_ptr(const void*);
+
 // Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode
 MONO_API void mono_unity_gc_enable();
 // Deprecated. Remove when Unity has switched to mono_unity_gc_set_mode


### PR DESCRIPTION
Use this API diagnose when a write barrier is needed but used.

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal @joncham:
Mono: Add mono_unity_gc_is_heap_ptr 

