### PR TITLE
Fixing issue where linux runtimes would attempt to resolve android sp…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2078,6 +2078,12 @@ if test "x$unity_define" = "xyes"; then
    AC_MSG_NOTICE([Building for Unity])
 fi
 
+AC_ARG_ENABLE(unity-android-define,[  --enable-unity-android-define have UNITY_ANDROID defined], unity_android_define=$enableval, unity_android_define=no)
+if test "x$unity_android_define" = "xyes"; then
+   AC_DEFINE(UNITY_ANDROID, 1, [Building for Unity Android])
+   AC_MSG_NOTICE([Building for Unity Android])
+fi
+
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)
 AM_CONDITIONAL(DISABLE_EXECUTABLES, test x$enable_executables = xno)
 

--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -873,6 +873,7 @@ if ($build)
 		push @configureparams, "ac_cv_header_zlib_h=no" if($runningOnWindows);
 		push @configureparams, "--disable-btls";
 		push @configureparams, "--with-sgen=no";
+		push @configureparams, "--enable-unity-android-define=yes";
 	}
 	elsif ($tizen)
 	{

--- a/mcs/class/System/System.Net.NetworkInformation/LinuxNetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/LinuxNetworkInterface.cs
@@ -261,7 +261,7 @@ namespace System.Net.NetworkInformation {
 		bool android_use_java_api;
 #endif
 
-#if UNITY
+#if UNITY_ANDROID
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static bool unitydroid_get_network_interface_up_state (string ifname, ref bool is_up);
 #endif
@@ -314,7 +314,7 @@ namespace System.Net.NetworkInformation {
 						return OperationalStatus.Unknown;
 				}
 #endif
-#if UNITY
+#if UNITY_ANDROID
 				// Similar to above we need to go into java but in a Unity context we don't have access to Xamarin.Android
 				if (Console.IsRunningOnAndroid)
 				{


### PR DESCRIPTION
…ecific icall. (UUM-46938)



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-46938 @UnityAlex:
Mono: Fixed erroneous error message on linux when using NetworkInterface.OperationalStatus.


**Backports**
2021.3, 2022.3, 2023.1, 2023.2, 2023.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->