### PR TITLE
Fix Unity editor looping on Application.Shutdown.CleanupMono during shutdown.

### DIFF
--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -33,6 +33,7 @@
 #endif
 
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
+#define MONO_CLEANUP_WAIT ((guint32) 309960)
 
 #if !defined(HOST_WIN32)
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-XXXXXX @blackcatrecycler:
Mono: Your release notes go here.

Many users on the forum have reported getting stuck at CleanupMono when closing UnityEditor, but no one has ever proposed a solution. When this issue occurs, the only way to close it is through the Task Manager. Recently, some members of our team have also experienced this issue. I analyzed the dump file and identified that the issue occurred in the `wait_for_debugger_thread_to_stop()` method.  An indefinite wait is set here, but it seems that some machines are unable to exit the wait successfully.

My current solution is to add a time limit to the wait, approximately 5 minutes. This method may not be very elegant, but it has helped more than 20 people resolve the issue on Unity versions from 2021.3 to 2022.3. 

In the end, I think we should discuss the appropriate wait duration or the root cause of this issue.

Here are some examples from the forum:
[Application.Shutdown.CleanupMono never finishes.](https://forum.unity.com/threads/application-shutdown-cleanupmono-never-finishes.1118140/)
[Application.Shutdown.CleanupMono infinite loop](https://forum.unity.com/threads/application-shutdown-cleanupmono-infinite-loop.1152689/)
[How_to_time_the_CleanupMono_function_in_Unity3d](https://stackoverflow.com/questions/18068528/how-to-time-the-cleanupmono-function-in-unity3d)


<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->
**Backports**
I believe this solution is applicable to Unity versions from 2020 onwards.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->