### PR TITLE
Adding icall destination for android network up state function on Linux to avoid confusing error.

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -547,7 +547,7 @@ NOHANDLES(ICALL(LINUXNETWORKCHANGE_2, "CreateNLSocket", ves_icall_System_Net_Net
 NOHANDLES(ICALL(LINUXNETWORKCHANGE_3, "ReadEvents", ves_icall_System_Net_NetworkInformation_LinuxNetworkChange_ReadEvents))
 #endif
 
-#if defined(ANDROID) && defined(UNITY)
+#if defined(UNITY)
 ICALL_TYPE(LINUXNETWORKINTERFACE, "System.Net.NetworkInformation.LinuxNetworkInterface", LINUXNETWORKINTERFACE_1)
 NOHANDLES(ICALL(LINUXNETWORKINTERFACE_1, "unitydroid_get_network_interface_up_state", ves_icall_Unity_Android_Network_Interface_Up_State))
 #endif

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -2027,5 +2027,12 @@ ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBool
 	}
 	return FALSE;
 }
+#else
+MonoBoolean
+ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBoolean* is_up)
+{
+	//No-op to avoid error message on linux. This is not called at runtime.
+	return FALSE;
+}
 #endif
 

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -266,9 +266,9 @@ typedef uint8_t (*android_network_up_state)(const char* ifName, uint8_t* is_up);
 
 MONO_API void
 mono_unity_set_android_network_up_state_func(android_network_up_state func);
+#endif
 
 MonoBoolean
 ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBoolean* is_up);
-#endif
 
 #endif


### PR DESCRIPTION


<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-46938 @UnityAlex:
Mono: Correct confusing error printed when using NetworkInterface.OperationalStatus on Linux.

**Backports**
2021.3, 2022.3, 2023.1, 2023.2, 2023.3