### PR TITLE
[2023.1] Adding icall destination for android network up state function on Lin…

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -547,7 +547,7 @@ NOHANDLES(ICALL(LINUXNETWORKCHANGE_2, "CreateNLSocket", ves_icall_System_Net_Net
 NOHANDLES(ICALL(LINUXNETWORKCHANGE_3, "ReadEvents", ves_icall_System_Net_NetworkInformation_LinuxNetworkChange_ReadEvents))
 #endif
 
-#if defined(ANDROID) && defined(UNITY)
+#if defined(UNITY)
 ICALL_TYPE(LINUXNETWORKINTERFACE, "System.Net.NetworkInformation.LinuxNetworkInterface", LINUXNETWORKINTERFACE_1)
 NOHANDLES(ICALL(LINUXNETWORKINTERFACE_1, "unitydroid_get_network_interface_up_state", ves_icall_Unity_Android_Network_Interface_Up_State))
 #endif

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -2017,5 +2017,12 @@ ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBool
 	}
 	return FALSE;
 }
+#else
+MonoBoolean
+ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBoolean* is_up)
+{
+	//No-op to avoid error message on linux. This is not called at runtime.
+	return FALSE;
+}
 #endif
 

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -264,9 +264,9 @@ typedef uint8_t (*android_network_up_state)(const char* ifName, uint8_t* is_up);
 
 MONO_API void
 mono_unity_set_android_network_up_state_func(android_network_up_state func);
+#endif
 
 MonoBoolean
 ves_icall_Unity_Android_Network_Interface_Up_State (MonoString *ifName, MonoBoolean* is_up);
-#endif
 
 #endif


### PR DESCRIPTION
…ux to avoid confusing error.

Backport of #1847

Parent Bug: UUM-46938
2023.1 Port: UUM-47830

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-46938 @UnityAlex:
Mono: Correct confusing error printed when using NetworkInterface.OperationalStatus on Linux.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->