### PR TITLE
access violation when clearing a max length array, due to an int over…

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1027,7 +1027,7 @@ ves_icall_System_Array_ClearInternal (MonoArrayHandle arr, int idx, int length, 
 {
 	icallarray_print ("%s arr:%p idx:%d len:%d\n", __func__, MONO_HANDLE_RAW (arr), (int)idx, (int)length);
 
-	int sz = mono_array_element_size (mono_handle_class (arr));
+	size_t sz = mono_array_element_size (mono_handle_class (arr));
 	mono_gc_bzero_atomic (mono_array_addr_with_size_fast (MONO_HANDLE_RAW (arr), sz, idx), length * sz);
 }
 #endif


### PR DESCRIPTION
…flow (int gets implicitly cast to size_t to a value of max size_t, which is way more than the intended size)



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-40408 @jeanclaudegrenier 
Mono: Fixed access violation when clearing an array of max length

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->
2023.2
2023.1
2022.3
2021.3


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->