### PR TITLE
[UUM-53413] Fix & extend GC memory heap reporting

### DIFF
--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -20,6 +20,9 @@ my $clean = 0;
 my $targetArch = "";
 my $debug = 0;
 my $gc = "bdwgc";
+my @vsVersions = (2019, 2022, 2017);
+my @vsEditions = ("Professional", "Enterprise", "Community");
+my @vsBaseFolder = ("ProgramFiles(x86)", "ProgramFiles");
 
 GetOptions(
 	'build=i'=>\$build,
@@ -38,17 +41,26 @@ sub CompileVCProj
 {
 	my $sln = shift;
 	my $config;
-	my $vsInstallRoot = $ENV{"ProgramFiles(x86)"} . "/Microsoft Visual Studio";
 
-	my $msbuild = "$vsInstallRoot/2019/Professional/MSBuild/Current/Bin/MSBuild.exe";
+        my $msbuild = "";
+	MSBUILDLOOP: foreach my $vsFolder (@vsBaseFolder)
+        {
+		foreach my $vsEdition (@vsEditions)
+		{
+			foreach my $vsVersion (@vsVersions)
+			{
+				$msbuild = "$ENV{$vsFolder}/Microsoft Visual Studio/$vsVersion/$vsEdition/MSBuild/Current/Bin/MSBuild.exe";
+				last MSBUILDLOOP if (-e -x $msbuild)
+			}
+		}
+        }
 
 	if (!(-e -x $msbuild))
 	{
-		print (">>> Unable to find executable MSBuild for vs19 at: $msbuild\nFalling back to vs17\n");
-		$msbuild = "$vsInstallRoot/2017/Professional/MSBuild/15.0/Bin/MSBuild.exe";
+		print (">>> Unable to find executable MSBuild\n");
 	}
 
-    $config = $debug ? "Debug" : "Release";
+	$config = $debug ? "Debug" : "Release";
 	my $arch = $targetArch;
 
 	my $target = $clean ? "/t:Clean,Build" :"/t:Build";

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1914,63 +1914,28 @@ mono_unity_start_gc_world()
 #endif
 }
 
-
+typedef void (*MonoGCHeapForeachFunc)(void* userData, gpointer start, gpointer end, uint32_t type);
 #if HAVE_BOEHM_GC
-static void EnumerateGCHeapSectionsCallback(void *userdata, gpointer chunk_start, gpointer chunk_end, GC_heap_section_type type)
+typedef struct GCHeapForeachContextStruct
 {
-	if (type != GC_HEAP_SECTION_TYPE_USED)
-		return;
+	void* userData;
+	MonoGCHeapForeachFunc callback;
 
-	execution_ctx *ctx = (execution_ctx *)userdata;
-	mono_heap_chunk chunk;
-	chunk.start = chunk_start;
-	chunk.size = (uint8_t *)chunk_end - (uint8_t *)chunk_start;
-	ctx->callback(&chunk, ctx->user_data);
+} GCHeapForeachContext;
+void GCHeapForeachCallback(void* userData, gpointer start, gpointer end, GC_heap_section_type type)
+{
+	GCHeapForeachContext* ctx = (GCHeapForeachContext*)userData;
+	ctx->callback(userData, start, end, type);
 }
 #endif
-
 MONO_API void
-mono_unity_gc_heap_foreach(GFunc callback, gpointer user_data)
+mono_unity_gc_heap_foreach(MonoGCHeapForeachFunc callback, gpointer user_data)
 {
 #if HAVE_BOEHM_GC
-	execution_ctx ctx;
+	GCHeapForeachContext ctx;
+	ctx.userData = user_data;
 	ctx.callback = callback;
-	ctx.user_data = user_data;
-
-	GC_foreach_heap_section(&ctx, EnumerateGCHeapSectionsCallback);
-#else
-	g_assert_not_reached();
-#endif
-}
-
-#if HAVE_BOEHM_GC
-typedef struct
-{
-	gpointer start;
-	size_t size;
-	int type;
-} MonoHeapChunk2;
-
-static void EnumerateGCHeapSectionsCallback2(void* userData, gpointer start, gpointer end, GC_heap_section_type type)
-{
-	execution_ctx* ctx = (execution_ctx*)userData;
-	MonoHeapChunk2 chunk;
-	chunk.start = start;
-	chunk.size = (uint8_t*)end - (uint8_t*)start;
-	chunk.type = type;
-	ctx->callback(&chunk, ctx->user_data);
-}
-#endif
-
-MONO_API void
-mono_unity_gc_heap_foreach_2(GFunc callback, gpointer user_data)
-{
-#if HAVE_BOEHM_GC
-	execution_ctx ctx;
-	ctx.callback = callback;
-	ctx.user_data = user_data;
-
-	GC_foreach_heap_section(&ctx, EnumerateGCHeapSectionsCallback2);
+	GC_foreach_heap_section(&ctx, GCHeapForeachCallback);
 #else
 	g_assert_not_reached();
 #endif

--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1915,12 +1915,12 @@ mono_unity_start_gc_world()
 }
 
 #if HAVE_BOEHM_GC
-void handle_gc_heap_chunk(void* userData, gpointer start, gpointer end, GC_heap_section_type type)
+static void handle_gc_heap_chunk(void* userData, gpointer chunk_start, gpointer chunk_end, GC_heap_section_type type)
 {
 	execution_ctx* ctx = (execution_ctx*)userData;
 	mono_heap_chunk chunk;
-	chunk.start = start;
-	chunk.size = (uint8_t *)end - (uint8_t *)start;
+	chunk.start = chunk_start;
+	chunk.size = (uint8_t *)chunk_end - (uint8_t *)chunk_start;
 	ctx->callback(&chunk, ctx->user_data);
 }
 #endif
@@ -1929,8 +1929,8 @@ mono_unity_gc_heap_foreach(GFunc callback, gpointer user_data)
 {
 #if HAVE_BOEHM_GC
 	execution_ctx ctx;
-	ctx.user_data = user_data;
 	ctx.callback = callback;
+	ctx.user_data = user_data;
 	GC_foreach_heap_section(&ctx, handle_gc_heap_chunk);
 #else
 	g_assert_not_reached();

--- a/winconfig.h
+++ b/winconfig.h
@@ -23,6 +23,9 @@
 /* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
 #undef ENABLE_HYBRID_SUSPEND
 
+/* Override allocators for Memory Profiler memory tracking */
+#define ENABLE_OVERRIDABLE_ALLOCATORS 1
+
 /* No ENABLE_DEFINES below this point */
 
 /* Keep in sync with netcore runtime-preset in configure.ac */


### PR DESCRIPTION
This PR is to update BDWGC repo with fixes to heap reporting functions.
Also it:
- Fixes build script to detect different versions of Visual Studio properly
- Enabled memory allocation override function. It wasn't used previously, as together with our allocators, it was causing performance regression. However, we recently introduced a fast allocator for IL2CPP, which can also be used for Mono.

**Release notes**

Fixed UUM-53413@username:
Mono: Fix GC heap reporting to report reserved (free) sections

https://github.com/Unity-Technologies/bdwgc/pull/82
