### PR TITLE
[2023.2] Emit a null check when loading valuetype fields

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9745,7 +9745,9 @@ calli_end:
 				} else {
 					MonoInst *load;
 
-					MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg, foffset > mono_target_pagesize ());
+					// We may call a copy / wbarrier function which doesn't do null checks; 
+					// passing MONO_TYPE_ISSTRUCT to macro so that we emit the null check when accessing fields that are structs */
+					MONO_EMIT_NULL_CHECK (cfg, sp [0]->dreg, foffset > mono_target_pagesize () || MONO_TYPE_ISSTRUCT(field->type));
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
 					if (sp [0]->opcode == OP_LDADDR && m_class_is_simd_type (klass) && cfg->opt & MONO_OPT_SIMD) {


### PR DESCRIPTION
Backport of #1853

Bug: UUM-47983
2023.2 Port: UUM-49359

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-47983 @bholmes:
Mono: Fix runtime crash when accessing a struct field of a null object.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->