### PR TITLE
Fix debugger crash during simulated burst domain reload

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10653,11 +10653,16 @@ void burst_mono_simulate_burst_debug_domain_reload()
 #ifndef DISABLE_SDB
 	appdomain_start_unload(NULL, g_BurstDebugDomain);
 	assembly_unload(NULL, g_BurstAssembly);
+
+	g_BurstDebugDomain->state = MONO_APPDOMAIN_UNLOADING;
+
 	appdomain_unload(NULL, g_BurstDebugDomain);
 
 	debugger_agent_free_domain_info(g_BurstDebugDomain);	// We need to call this to flush any typeids (its usually done via free_domain)
 
 	appdomain_load(NULL, g_BurstDebugDomain);
+
+	g_BurstDebugDomain->state = MONO_APPDOMAIN_CREATED;
 
 	send_type_load(g_BurstKlass);	// We must manually send the type load event, since we never actually JIT anything in this class
 #endif /* DISABLE_SDB */


### PR DESCRIPTION
During a simulated burst domain reload the domain state is never switched to unloading. This leaves it open to being accessed by certain debugger functions while it is uninitialized.

An example of this is via: get_types_for_source_file

forward port of: https://github.com/Unity-Technologies/mono/pull/1861 -- pick was clean

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-XXXXXX @UnityAlex:
Mono: Fixed crash that could occur while attaching or using the debugger while the burst domain is reloading.

**Backports**
2023.1, 2023.2, 2023.3