### PR TITLE
[2022.3] remove unnecessary unity clone in update mono il2cpp deps

### DIFF
--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -14,11 +14,8 @@ commands:
     git clone git@github.cds.internal.unity3d.com:unity/prtools.git
     cd prtools
     git checkout main
-    cmd /c cibuildscript
-    cmd /c xcopy build %PRTOOLS_BUILD_DIR% /s /Y /E /I
     cd %UNITY_SOURCE_PRTOOLS_DIR%
     git config --global core.longpaths true
-    git clone https://github.cds.internal.unity3d.com/unity/unity.git .
     cmd /v /c dotnet run --project C:\build\output\prtools\PRTools\PRTools.csproj --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/stevedore/artifactid.txt --backport=%BACKPORT_BRANCH% --github-api-token=%GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%      
     if NOT %errorlevel% == 0 (
       echo "PRTools failed"

--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -22,3 +22,4 @@ commands:
       EXIT /B %errorlevel%
     )
 timeout: 1
+


### PR DESCRIPTION
… anyway. Don't clone main Unity repo - it's not needed for this job and just wastes time (#1878)

> Just tidying up a couple of unnecessary steps that waste time - no need to build PRTools explicitly, it's executed with 'dotnet run' on the .proj, and the clone of Unity is not needed for this job and takes a non-trivial amount of time (the job is modifying il2cpp-deps.stevedore in the IL2CPP repo, via PRTools).

Backport of #1878

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

None

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->