### PR TITLE
[2023.2][Backport] [UUM-53413] Fix GC memory heap reporting

### DIFF
--- a/builds/versions-win64.txt
+++ b/builds/versions-win64.txt
@@ -12,9 +12,8 @@ Copyright (C) Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
 	Suspend:       preemptive
 	GC:            sgen (concurrent by default)
 
-unity-mono-revision = 6faf82d72779aef03206c652924402bcffc2421d
+unity-mono-revision = 94d31e01206c8d38249990ec648a3d3b95854cf9
 
-unity-mono-build-scripts-revision = 6faf82d72779aef03206c652924402bcffc2421d
+unity-mono-build-scripts-revision = 94d31e01206c8d38249990ec648a3d3b95854cf9
 
-Thu 11/30/2023 
-
+Fri 10/30/2020 

--- a/builds/versions-win64.txt
+++ b/builds/versions-win64.txt
@@ -12,9 +12,9 @@ Copyright (C) Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
 	Suspend:       preemptive
 	GC:            sgen (concurrent by default)
 
-unity-mono-revision = 94d31e01206c8d38249990ec648a3d3b95854cf9
+unity-mono-revision = 6faf82d72779aef03206c652924402bcffc2421d
 
-unity-mono-build-scripts-revision = 94d31e01206c8d38249990ec648a3d3b95854cf9
+unity-mono-build-scripts-revision = 6faf82d72779aef03206c652924402bcffc2421d
 
-Fri 10/30/2020 
+Thu 11/30/2023 
 

--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -20,6 +20,9 @@ my $clean = 0;
 my $targetArch = "";
 my $debug = 0;
 my $gc = "bdwgc";
+my @vsVersions = (2019, 2022, 2017);
+my @vsEditions = ("Professional", "Enterprise", "Community");
+my @vsBaseFolder = ("ProgramFiles(x86)", "ProgramFiles");
 
 GetOptions(
 	'build=i'=>\$build,
@@ -38,17 +41,26 @@ sub CompileVCProj
 {
 	my $sln = shift;
 	my $config;
-	my $vsInstallRoot = $ENV{"ProgramFiles(x86)"} . "/Microsoft Visual Studio";
 
-	my $msbuild = "$vsInstallRoot/2019/Professional/MSBuild/Current/Bin/MSBuild.exe";
+        my $msbuild = "";
+	MSBUILDLOOP: foreach my $vsFolder (@vsBaseFolder)
+        {
+		foreach my $vsEdition (@vsEditions)
+		{
+			foreach my $vsVersion (@vsVersions)
+			{
+				$msbuild = "$ENV{$vsFolder}/Microsoft Visual Studio/$vsVersion/$vsEdition/MSBuild/Current/Bin/MSBuild.exe";
+				last MSBUILDLOOP if (-e -x $msbuild)
+			}
+		}
+        }
 
 	if (!(-e -x $msbuild))
 	{
-		print (">>> Unable to find executable MSBuild for vs19 at: $msbuild\nFalling back to vs17\n");
-		$msbuild = "$vsInstallRoot/2017/Professional/MSBuild/15.0/Bin/MSBuild.exe";
+		print (">>> Unable to find executable MSBuild\n");
 	}
 
-    $config = $debug ? "Debug" : "Release";
+	$config = $debug ? "Debug" : "Release";
 	my $arch = $targetArch;
 
 	my $target = $clean ? "/t:Clean,Build" :"/t:Build";


### PR DESCRIPTION
This PR is to update BDWGC repo with fixes to heap reporting functions.

Minor change:
- Fixes build script to detect different versions of Visual Studio properly

**Release notes**

Fixed UUM-53413@username:
Mono: Fix GC heap reporting to report reserved (free) sections

https://github.com/Unity-Technologies/bdwgc/pull/86