### PR TITLE
[2021.3][Backport] [UUM-53413] Fix GC memory heap reporting

### DIFF
--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -20,6 +20,9 @@ my $clean = 0;
 my $arch32 = 0;
 my $debug = 0;
 my $gc = "bdwgc";
+my @vsVersions = (2019, 2022, 2017);
+my @vsEditions = ("Professional", "Enterprise", "Community");
+my @vsBaseFolder = ("ProgramFiles(x86)", "ProgramFiles");
 
 GetOptions(
 	'build=i'=>\$build,
@@ -38,17 +41,26 @@ sub CompileVCProj
 {
 	my $sln = shift;
 	my $config;
-	my $vsInstallRoot = $ENV{"ProgramFiles(x86)"} . "/Microsoft Visual Studio";
 
-	my $msbuild = "$vsInstallRoot/2019/Professional/MSBuild/Current/Bin/MSBuild.exe";
+        my $msbuild = "";
+	MSBUILDLOOP: foreach my $vsFolder (@vsBaseFolder)
+        {
+		foreach my $vsEdition (@vsEditions)
+		{
+			foreach my $vsVersion (@vsVersions)
+			{
+				$msbuild = "$ENV{$vsFolder}/Microsoft Visual Studio/$vsVersion/$vsEdition/MSBuild/Current/Bin/MSBuild.exe";
+				last MSBUILDLOOP if (-e -x $msbuild)
+			}
+		}
+        }
 
 	if (!(-e -x $msbuild))
 	{
-		print (">>> Unable to find executable MSBuild for vs19 at: $msbuild\nFalling back to vs17\n");
-		$msbuild = "$vsInstallRoot/2017/Professional/MSBuild/15.0/Bin/MSBuild.exe";
+		print (">>> Unable to find executable MSBuild\n");
 	}
 
-    $config = $debug ? "Debug" : "Release";
+	$config = $debug ? "Debug" : "Release";
 	my $arch = $arch32 ? "Win32" : "x64";
 	my $target = $clean ? "/t:Clean,Build" :"/t:Build";
 	my $properties = "/p:Configuration=$config;Platform=$arch;MONO_TARGET_GC=$gc;MONO_USE_STATIC_C_RUNTIME=true";

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5873,11 +5873,7 @@ mono_metadata_generic_class_foreach(MonoGenericClassFunc func, void* user_data)
 void
 mono_metadata_image_set_foreach(MonoImageSetFunc func, gpointer user_data)
 {
-	GenericClassForeachData data;
 	guint i;
-
-	data.func = func;
-	data.user_data = user_data;
 
 	for (i = 0; i < HASH_TABLE_SIZE; ++i)
 	{


### PR DESCRIPTION
This PR is to update BDWGC repo with fixes to heap reporting functions.

Minor change:
- Fixes build script to detect different versions of Visual Studio properly

**Release notes**

Fixed UUM-53413@username:
Mono: Fix GC heap reporting to report reserved (free) sections

https://github.com/Unity-Technologies/bdwgc/pull/87