### PR TITLE
Copied upstream Mono fix to properly call delegate virtual methods.

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1021,6 +1021,7 @@ struct _MonoDelegate {
 	MonoReflectionMethod *method_info;
 	MonoReflectionMethod *original_method_info;
 	MonoObject *data;
+	/* Whenever to resolve the target method using ldvirtftn at call time */
 	MonoBoolean method_is_virtual;
 };
 

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1150,12 +1150,11 @@ mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint
 			}
 		}
 
-		if (delegate->method_ptr == NULL && tramp_info->method == NULL && delegate->target != NULL && method->flags & METHOD_ATTRIBUTE_VIRTUAL) {
-			/* tramp_info->method == NULL happens when someone asks us to JIT some delegate's
-			 * Invoke method (see compile_special).  In that case if method is virtual, the target
-			 * could be some derived class, so we need to find the correct override.
+		if (delegate->method_is_virtual) {
+			/*
+			 * If the delegate was created by handle_delegate_ctor (virtual==TRUE), the
+			 * ldvirtftn instruction was skipped, so we have to do it now.
 			 */
-			/* FIXME: does it make sense that we get called with tramp_info for the Invoke? */
 			method = mono_object_get_virtual_method_internal (delegate->target, method);
 			enable_caching = FALSE;
 		} else if (delegate->target &&


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-55774 @jeanclaudegrenier :
Mono: Fixed issue where invoking a virtual method on a delegate would only consider the method's overrides on the first call.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
2023.3
2023.2
2022.3
2021.3


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->