### PR TITLE
[2022.3] Fix branch name

### DIFF
--- a/.yamato/Collate Builds.yml
+++ b/.yamato/Collate Builds.yml
@@ -20,13 +20,13 @@ triggers:
   pull_requests:
     - targets:
         only:
-          - "unity-unity-2022.3-mbe"
+          - "unity-2022.3-mbe"
   branches:
     only:
-      - "unity-unity-2022.3-mbe"
+      - "unity-2022.3-mbe"
   cancel_old_ci: true
   recurring:
-    - branch: unity-unity-2022.3-mbe
+    - branch: unity-2022.3-mbe
       frequency: daily # Should run between midnight and 6AM UTC
 
 artifacts: 


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

This typo is stopping Collate Builds from running automatically on 2022.3 commits on Mono. Only affects this branch.

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

None

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->