### PR TITLE
Cache stack bounds in TLS

### DIFF
--- a/mono/utils/mono-threads-linux.c
+++ b/mono/utils/mono-threads-linux.c
@@ -10,9 +10,55 @@
 #include <pthread.h>
 #include <sys/syscall.h>
 
+#if defined(UNITY)
+// store the stack bounds and address in thread local storage.
+//
+// This is a performance improvement over using pthread functions to query these values.  This change is big
+// enough to create a ~2.5 order of magnitude improvement in scripting_thread_has_sufficient_execution_stack
+// dominated performance tests (i.e. things that invoke CloneObject a lot).
+
+static MONO_KEYWORD_THREAD size_t s_stack_bounds = 0;
+static MONO_KEYWORD_THREAD guint8 *s_stack_addr = NULL;
+#endif
+
 void
 mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 {
+#if defined(UNITY)
+	// unity specific change - cache the values we retrieve in thread local storage (TLS)
+	if (s_stack_bounds)
+	{
+		*stsize = s_stack_bounds;
+		*staddr = s_stack_addr;
+	}
+	else
+	{
+		pthread_attr_t attr;
+		gint res;
+ 
+		*staddr = NULL;
+		*stsize = (size_t)-1;
+ 
+		res = pthread_attr_init (&attr);
+		if (G_UNLIKELY (res != 0))
+			g_error ("%s: pthread_attr_init failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+ 
+		res = pthread_getattr_np (pthread_self (), &attr);
+		if (G_UNLIKELY (res != 0))
+			g_error ("%s: pthread_getattr_np failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+ 
+		res = pthread_attr_getstack (&attr, (void**)staddr, stsize);
+		if (G_UNLIKELY (res != 0))
+			g_error ("%s: pthread_attr_getstack failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+ 
+		res = pthread_attr_destroy (&attr);
+		if (G_UNLIKELY (res != 0))
+			g_error ("%s: pthread_attr_destroy failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+ 
+		s_stack_bounds = *stsize;
+		s_stack_addr = *staddr;
+	}
+#else
 	pthread_attr_t attr;
 	gint res;
 
@@ -34,7 +80,7 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	res = pthread_attr_destroy (&attr);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_attr_destroy failed with \"%s\" (%d)", __func__, g_strerror (res), res);
-
+#endif // defined(UNITY)
 }
 
 guint64


### PR DESCRIPTION
This is a performance improvement over using pthread functions to query these values.  The difference is big enough in performance tests dominated by `scripting_thread_has_sufficient_execution_stack` (things that invoke CloneObject a lot) to result in a ~2.5 order magnitude improvement.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed DOTS-9856 @jvalenzu :
Mono: Cache results of `pthread_attr_getstack` in TLS for performance


**Unity repository changes**

List any Unity repository PRs.
jiv todo
