### PR TITLE
Fix source_file bug in mono_ppdb_lookup_location_internal

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -415,7 +415,9 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 	start_col = 0;
 	while (ptr < end) {
 		delta_il = mono_metadata_decode_value (ptr, &ptr);
-		if (!first && delta_il == 0) {
+		// check the current offset to ensure that we do not update docname after the target
+		// offset has been reached (the updated docname will be for the next point)
+		if (!first && delta_il == 0 && iloffset < offset) {
 			/* document-record */
 			docidx = mono_metadata_decode_value (ptr, &ptr);
 			docname = get_docname (ppdb, image, docidx);


### PR DESCRIPTION
document-records affect sequence points that follow in the byte stream, not points previously read.

When reading the document-record we may already be at the target offset. Do not update docname local if we have reached the end target already otherwise the wrong source_file will be reported for the requested offset



- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-4341 @bholmes :
Mono: Fixed wrong file path reported by mono_ppdb_lookup_location for methods that span multiple files.

**Backports**
 - 2023.3
 - 2023.2
 - 2022.3