### PR TITLE
Fix Crash When Global Flags are Enabled in the Windows SDK

### DIFF
--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -210,6 +210,9 @@ get_win32_restore_stack (void)
  */
 LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 {
+	if (ep->ExceptionRecord->ExceptionCode == DBG_PRINTEXCEPTION_C)
+		return EXCEPTION_CONTINUE_SEARCH;
+
 	EXCEPTION_RECORD* er;
 	CONTEXT* ctx;
 	LONG res;


### PR DESCRIPTION
Enabled certain Global Flags causes debug output to be emitted which will raise a DBG_PRINTEXCEPTION_C if a debugger is not attached to handle it.

Depending on the Global Flags enabled seh_vectored_exception_handler may itself cause debug output, raising a DBG_PRINTEXCEPTION_C exception during exception processing, causing a crash.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-49475 @scott-ferguson-unity 
Mono: Fixed crash on Windows when certain Global Flags were enabled with the GFlags SDK tool

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
* 2021.3
* 2022.3
* 2023.2
* 2023.3


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->