### PR TITLE
[2023.2] Fix socket read async not updating buffer

### DIFF
--- a/mcs/class/System/System.Net.Sockets/SocketTaskExtensions.cs
+++ b/mcs/class/System/System.Net.Sockets/SocketTaskExtensions.cs
@@ -254,9 +254,12 @@ namespace System.Net.Sockets
         public static ValueTask<int> ReceiveAsync(this Socket socket, Memory<byte> memory, SocketFlags socketFlags, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<int>(socket);
-            socket.BeginReceive(memory.ToArray(), 0, memory.Length, socketFlags, iar =>
+            var buffer = memory.ToArray();
+            socket.BeginReceive(buffer, 0, memory.Length, socketFlags, iar =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                Memory<byte> cp = new Memory<byte>(buffer);
+                cp.CopyTo(memory);
                 var tcsInner = (TaskCompletionSource<int>)iar.AsyncState;
                 var socketInner = (Socket)tcsInner.Task.AsyncState;
                 try { tcsInner.TrySetResult(socketInner.EndReceive(iar)); }


### PR DESCRIPTION
Backport of #1904

Parent bug: UUM-54449
2023.2 port: UUM-54452

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-54449 @jeanclaudegrenier :
Mono: Fixed issue with Socket.ReadAsync where the buffer submitted would not be updated when using a Memory.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->