### PR TITLE
ProcessWaitHandle is not supported in UNITY_AOT

### DIFF
--- a/mcs/class/System/linux_unityaot_System.dll.exclude.sources
+++ b/mcs/class/System/linux_unityaot_System.dll.exclude.sources
@@ -4,3 +4,5 @@ System.Security.Cryptography.X509Certificates/OSX509Certificates.cs
 System.IO/FileSystemWatcher.DefaultEventAttribute.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.ProcessWaitHandle.cs
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.ProcessWaitHandle.Unix.cs

--- a/mcs/class/System/linux_unityaot_System.dll.sources
+++ b/mcs/class/System/linux_unityaot_System.dll.sources
@@ -4,6 +4,7 @@
 ../System.Web/System.Web.Util/HttpEncoder.cs
 System.CodeDom/CodeCompileUnit.cs
 System.CodeDom/CodeTypeDeclaration.cs
+../referencesource/System/services/monitoring/system/diagnosticts/processwaithandle.cs
 
 #include unityaot_fsw.sources
 

--- a/mcs/class/System/macos_unityaot_System.dll.exclude.sources
+++ b/mcs/class/System/macos_unityaot_System.dll.exclude.sources
@@ -4,4 +4,5 @@ System.Security.Cryptography.X509Certificates/OSX509Certificates.cs
 System.IO/FileSystemWatcher.DefaultEventAttribute.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
-
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.ProcessWaitHandle.cs
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.ProcessWaitHandle.Unix.cs

--- a/mcs/class/System/macos_unityaot_System.dll.sources
+++ b/mcs/class/System/macos_unityaot_System.dll.sources
@@ -4,4 +4,5 @@
 ../System.Web/System.Web.Util/HttpEncoder.cs
 System.CodeDom/CodeCompileUnit.cs
 System.CodeDom/CodeTypeDeclaration.cs
+../referencesource/System/services/monitoring/system/diagnosticts/processwaithandle.cs
 #include unityaot_fsw.sources

--- a/mcs/class/System/win32_unityaot_System.dll.exclude.sources
+++ b/mcs/class/System/win32_unityaot_System.dll.exclude.sources
@@ -7,3 +7,4 @@ System.IO/FileSystemWatcher.DefaultEventAttribute.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/CertificateHelper.Unix.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.cs
 ../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
+../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.ProcessWaitHandle.cs

--- a/mcs/class/System/win32_unityaot_System.dll.sources
+++ b/mcs/class/System/win32_unityaot_System.dll.sources
@@ -7,6 +7,7 @@
 System.Net.NetworkInformation/Win32UnixFactoryPal.cs
 
 ../../../external/corefx/src/Common/src/Interop/Windows/kernel32/Interop.CloseHandle.cs
+../referencesource/System/services/monitoring/system/diagnosticts/processwaithandle.cs
 
 System.CodeDom/CodeCompileUnit.cs
 System.CodeDom/CodeTypeDeclaration.cs

--- a/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/processwaithandle.cs
+++ b/mcs/class/referencesource/System/services/monitoring/system/diagnosticts/processwaithandle.cs
@@ -11,6 +11,11 @@ namespace System.Diagnostics {
         [ResourceExposure(ResourceScope.None)]
         [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
         internal ProcessWaitHandle( SafeProcessHandle processHandle): base() {
+
+#if UNITY_AOT
+            throw new PlatformNotSupportedException();
+#else
+
             SafeWaitHandle waitHandle = null;
             bool succeeded = NativeMethods.DuplicateHandle(
                 new HandleRef(this, NativeMethods.GetCurrentProcess()),
@@ -33,6 +38,7 @@ namespace System.Diagnostics {
             }
 
             this.SafeWaitHandle = waitHandle;         
+#endif // #if UNITY_AOT
         }
     }
 }


### PR DESCRIPTION
Converted a process handle to a wait handle is not implemented in IL2CPP.  Since we don't have current plans to support this throw a PlatformNotSupportedException()

Previously this would work, but would laster crash when calling WaitOne().

This was reported as a crash when calling `Process.HasExited` - however process the root cause is that we don't support converting a process handle to a `WaitHandle` and `ProcessWaitHandle` is used in more than [once place](https://github.com/search?q=repo%3AUnity-Technologies%2Fmono%20ProcessWaitHandle&type=code) - so I added the `throw` to the `ProcessWaitHandle` constructor.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-55384 @scott-ferguson-unity:
IL2CPP: Throw a PlatformNotSupportedException for Process.HasExited

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->


**Backports**
* 2021.3
* 2022.3
* 2023.2
* 2023.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->