### PR TITLE
[2022.3] Handle cases where the number of entries in a directory changes

### DIFF
--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.c
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.c
@@ -465,7 +465,6 @@ int32_t SystemNative_ReadDirR(struct DIRWrapper* dirWrapper, uint8_t* buffer, in
         {
             dirWrapper->result = malloc(numEntries * sizeof(struct dirent));
             dirWrapper->curIndex = 0;
-            dirWrapper->numEntries = numEntries;
 #if HAVE_REWINDDIR
             rewinddir (dirWrapper->dir);
 #else
@@ -473,13 +472,14 @@ int32_t SystemNative_ReadDirR(struct DIRWrapper* dirWrapper, uint8_t* buffer, in
             dirWrapper->dir = opendir(dirWrapper->dirPath);
 #endif
             size_t index = 0;
-            while ((entry = readdir(dirWrapper->dir)))
+            while ((entry = readdir(dirWrapper->dir)) && index < numEntries)
             {
                 memcpy(&((struct dirent*)dirWrapper->result)[index], entry, sizeof(struct dirent));
                 index++;
             }
 
             qsort(dirWrapper->result, numEntries, sizeof(struct dirent), cmpstring);
+            dirWrapper->numEntries = index; 
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

> This is a similar PR to https://github.cds.internal.unity3d.com/unity/il2cpp/pull/4449
> If the number of entries in a directory changes while
> SystemNative_ReadDirR is running, the code should handle those cases
> correctly.
> 
> if there are more files added after the number of entries was
> calculated, ensure that the buffer for the number of entries does not
> overflow.
> 
> If the number of entries is fewer, ensure that uninitialized data in the
> array of entries is not used by the client code.

Backport of #1895

Parent bug: UUM-58474
2022.3 port: UUM-60033

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-58474 @yuc434
Mono: Fixed a race condition when the number of files in a directory changes while this code is executing.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->