### PR TITLE
Gracefully flag and handle recursive value types

### DIFF
--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -662,8 +662,14 @@ mono_compile_create_var_for_vreg (MonoCompile *cfg, MonoType *type, int opcode, 
 	inst->backend.is_pinvoke = 0;
 	inst->dreg = vreg;
 
-	if (mono_class_has_failure (inst->klass))
+	if (mono_class_has_failure (inst->klass)) {
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_TYPE_LOAD);
+		MonoErrorBoxed* box = mono_class_get_exception_data (inst->klass);
+		if (box) {
+			MonoErrorInternal* err = (MonoErrorInternal*)&box->error;
+			cfg->exception_message = mono_error_get_message (err);
+		}
+	}
 
 	if (cfg->compute_gc_maps) {
 		if (type->byref) {


### PR DESCRIPTION
Previously code like the following would trigger a fatal assertion when mono attempted to determine the size of `_static`

```
public class Container
{
    private S0<S1<DataFoo>> _data;
}

public readonly struct DataFoo
{
    public static readonly S0<S1<DataFoo>> _static = default;
}

public struct S0<T1>
{
    public T1 _field;   
}

public struct S1<T>
{
    public S0<T> _field;
}
```



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No 

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-58734 @UnityAlex:
Mono: Fixed crash that would occur when attempting to determine the size of a recursively defined struct.

**Backports**
2023.x, 2022.x, 2021.x