### PR TITLE
Adding in ability for the client certificate selection callback to function correctly on Windows

### DIFF
--- a/mcs/class/System.Net.Http/Makefile
+++ b/mcs/class/System.Net.Http/Makefile
@@ -41,6 +41,11 @@ ifeq (wasm,$(PROFILE))
 API_BIN_REFS := System.Net.Http.WebAssemblyHttpHandler
 endif
 
+ifneq (,$(filter unityjit unityaot,$(PROFILE)))
+LIB_MCS_FLAGS += -d:SECURITY_DEP
+LIB_REFS += Mono.Security
+endif
+
 TEST_LIB_REFS = System System.Core
 TEST_MCS_FLAGS =
 

--- a/mcs/class/System.Net.Http/legacy.sources
+++ b/mcs/class/System.Net.Http/legacy.sources
@@ -59,3 +59,4 @@ System.Net.Http.Headers/WarningHeaderValue.cs
 
 ../../../external/corefx/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CancellationHelper.cs
 ../../../external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+../../../external/corefx/src/System.Net.Http/src/System/Net/Http/HttpUtilities.cs

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -92,11 +92,11 @@ namespace Mono.Net.Security
 
 			settings = request.TlsSettings;
 
-			if (settings == null && request.ServerCertificateValidationCallback != null)
-			{
+			if (settings == null)
 				settings = MonoTlsSettings.CopyDefaultSettings ();
+				
+			if (settings.RemoteCertificateValidationCallback == null)
 				settings.RemoteCertificateValidationCallback = MNS.Private.CallbackHelpers.PublicToMono(request.ServerCertificateValidationCallback);
-			}
 
 			provider = request.TlsProvider ?? MonoTlsProviderFactory.GetProviderInternal ();
 			status = WebExceptionStatus.SecureChannelFailure;


### PR DESCRIPTION
This is also needed to fix UUM-57031


<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-57031 @UnityAlex:
Mono: Fixed issue where the client certificate selection callback did not function correctly on windows.

**Backports**
2023.x, 2022.x, 2021.x
