### PR TITLE
[2023.2] app base directory will now default to / if empty

### DIFF
--- a/mcs/class/corlib/System/AppDomainSetup.cs
+++ b/mcs/class/corlib/System/AppDomainSetup.cs
@@ -143,6 +143,11 @@ namespace System
 			if (appBase == null)
 				return null;
 
+			if(appBase == "")
+			{
+				appBase = Path.DirectorySeparatorChar.ToString();
+			}
+
 			if (appBase.StartsWith ("file://", StringComparison.OrdinalIgnoreCase)) {
 				appBase = new Mono.Security.Uri (appBase).LocalPath;
 				if (Path.DirectorySeparatorChar != '/')


### PR DESCRIPTION
> The BaseDirectory is never set, and defaults to "". This causes an exception to be thrown when accessing BaseDirectory, as it can't form a valid path.
> This was remedied by considering "" as "/" which would be the root directory. 

Backport of #1939

Parent bug: UUM-48816
2023.2 port: UUM-48961

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-48816 @jeanclaudegrenier :
Mono: Accessing AppContext.BaseDirectory will no longer throw an exception.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->