### PR TITLE
[2023.2] Patch recent mono_ppdb_lookup_location_internal change

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -415,12 +415,13 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 	start_col = 0;
 	while (ptr < end) {
 		delta_il = mono_metadata_decode_value (ptr, &ptr);
-		// check the current offset to ensure that we do not update docname after the target
-		// offset has been reached (the updated docname will be for the next point)
-		if (!first && delta_il == 0 && iloffset < offset) {
+		if (!first && delta_il == 0) {
 			/* document-record */
 			docidx = mono_metadata_decode_value (ptr, &ptr);
-			docname = get_docname (ppdb, image, docidx);
+			// check the current offset to ensure that we do not update docname after the target
+			// offset has been reached (the updated docname will be for the next point)
+			if (iloffset < offset)
+				docname = get_docname (ppdb, image, docidx);
 			continue;
 		}
 		if (!first && iloffset + delta_il > offset)


### PR DESCRIPTION
> Need to ensure that the ptr is advanced with mono_metadata_decode_value and the continue statement still happens.
> 
> This is a fix PR to an issue that was discovered upstream. Here is the upstream patch ihttps://github.com/https://github.com/dotnet/runtime/pull/97392

Backport of #1941

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal @bholmes :
Mono: Patch recent mono_ppdb_lookup_location_internal change

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->