### PR TITLE
Fixing bug in jump trampolines patching code

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -697,7 +697,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 #ifdef MONO_ARCH_HAVE_PATCH_JUMP_TRAMPOLINE
 		if (!mono_aot_only) {
 			mono_domain_lock(domain);
-			gpointer jump_tramp = g_hash_table_lookup(domain_jit_info(domain)->jump_target_got_slot_hash, m);
+			gpointer jump_tramp = g_hash_table_lookup(domain_jit_info(domain)->jump_trampoline_hash, m);
 			mono_domain_unlock(domain);
 
 			if (jump_tramp)


### PR DESCRIPTION
This is a fix from my previous commit

https://github.com/Unity-Technologies/mono/pull/1907
"Patch jump trampolines on amd64/arm64 after a method has been compiled."

Wrong hash table was specified.

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Internal UUM-54694 @bholmes :
Mono: Your release notes go here.


**Backports**

 - 2021.3
 - 2022.3
 - 2023.2
 - 2023.3


