### PR TITLE
[2022.3] Fixing bug in jump trampolines patching code

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -697,7 +697,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 #ifdef MONO_ARCH_HAVE_PATCH_JUMP_TRAMPOLINE
 		if (!mono_aot_only) {
 			mono_domain_lock(domain);
-			gpointer jump_tramp = g_hash_table_lookup(domain_jit_info(domain)->jump_target_got_slot_hash, m);
+			gpointer jump_tramp = g_hash_table_lookup(domain_jit_info(domain)->jump_trampoline_hash, m);
 			mono_domain_unlock(domain);
 
 			if (jump_tramp)


### PR DESCRIPTION
> This is a fix from my previous commit
> 
> #1907
> "Patch jump trampolines on amd64/arm64 after a method has been compiled."
> 
> Wrong hash table was specified.

Backport of #1955

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

None

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->