### PR TITLE
Implement Arm64 Unwind Codes for Windows

### DIFF
--- a/mono/metadata/oop.c
+++ b/mono/metadata/oop.c
@@ -35,9 +35,9 @@
 #include <metadata/profiler-private.h>
 #include <mono/metadata/coree.h>
 
-#ifdef _M_X64
+
+#ifdef _WIN64
 #include <mono/mini/mini.h>
-#include <mono/mini/mini-amd64.h>
 extern GList* g_dynamic_function_table_begin;
 extern SRWLOCK g_dynamic_function_table_lock;
 #endif
@@ -152,7 +152,7 @@ mono_unity_oop_shutdown(void)
     memset(&g_oop, 0, sizeof(g_oop));
 }
 
-#ifdef _M_X64
+#ifdef _WIN64
 gboolean TryAcquireSpinWait(PSRWLOCK lock, unsigned int spinWait)
 {
     do
@@ -168,7 +168,7 @@ gboolean TryAcquireSpinWait(PSRWLOCK lock, unsigned int spinWait)
 MONO_API GList*
 mono_unity_lock_dynamic_function_access_tables64(unsigned int spinWait) 
 {
-#ifdef _M_X64
+#ifdef _WIN64
     if (spinWait >= 0x7fffffff) {
         AcquireSRWLockExclusive(&g_dynamic_function_table_lock);
     }
@@ -184,7 +184,7 @@ mono_unity_lock_dynamic_function_access_tables64(unsigned int spinWait)
 MONO_API void
 mono_unity_unlock_dynamic_function_access_tables64(void) 
 {
-#ifdef _M_X64
+#ifdef _WIN64
     ReleaseSRWLockExclusive(&g_dynamic_function_table_lock);
 #else
     return;
@@ -195,7 +195,7 @@ MONO_API GList*
 mono_unity_oop_iterate_dynamic_function_access_tables64(
     GList* current) 
 {
-#ifdef _M_X64
+#ifdef _WIN64
     if (current != NULL)
         return read_glist_next(current);
     else
@@ -213,7 +213,7 @@ mono_unity_oop_get_dynamic_function_access_table64(
     void** functionTable,
     gsize* functionTableSize)
 {
-#ifdef _M_X64
+#ifdef _WIN64
     if (!tableEntry || !moduleStart || !moduleEnd || !functionTable || !functionTableSize)
         return FALSE;
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -963,12 +963,12 @@ initialize_unwind_info_internal_ex (GSList *unwind_ops, PUNWIND_INFO unwindinfo)
 						mono_arch_unwindinfo_add_push_nonvol (unwindinfo, unwind_op_data);
 					break;
 				}
-				case DW_CFA_mono_sp_alloc_info_win64 : {
+				case DW_CFA_mono_sp_alloc_info_win64_amd64 : {
 					mono_arch_unwindinfo_add_alloc_stack (unwindinfo, unwind_op_data);
 					sp_alloced = TRUE;
 					break;
 				}
-				case DW_CFA_mono_fp_alloc_info_win64 : {
+				case DW_CFA_mono_fp_alloc_info_win64_amd64 : {
 					mono_arch_unwindinfo_add_set_fpreg (unwindinfo, unwind_op_data);
 					fp_alloced = TRUE;
 					break;

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -24,6 +24,12 @@
 
 #ifndef DISABLE_JIT
 
+#ifdef MONO_ARCH_ENABLE_PTRAUTH
+	static gboolean enable_ptrauth = TRUE;
+#else
+	static gboolean enable_ptrauth = FALSE;
+#endif
+
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
@@ -620,3 +626,598 @@ mono_arch_do_ip_adjustment (MonoContext *ctx)
 	pc = (gpointer)((guint64)MINI_FTNPTR_TO_ADDR (pc) - 1);
 	ctx->pc = (host_mgreg_t)MINI_ADDR_TO_FTNPTR (pc);
 }
+
+
+#ifdef MONO_ARCH_HAVE_UNWIND_TABLE
+
+static void 
+mono_arch_unwind_add_assert (guint32 unwind_code_size, guint32 max_offset, guint32 unwind_codes_buffer_size, guint32 offset) {
+	g_assert(offset <= max_offset);
+	if (unwind_codes_buffer_size + unwind_code_size > MONO_ARM64_MAX_UNWIND_CODE_SIZE)
+		g_error ("Larger allocation needed for the unwind information.");
+}
+
+static void
+mono_arch_unwind_add_nop (guint8* unwind_codes, guint32* unwind_code_size) {
+	mono_arch_unwind_add_assert(1, 0, *unwind_code_size, 0);
+	unwind_codes[(*unwind_code_size)++] = 0b11100011;
+}
+
+static void
+mono_arch_unwind_add_nops (guint8* unwind_codes, guint32* unwind_code_size, int nop_count) {
+	while (nop_count--)
+		mono_arch_unwind_add_nop (unwind_codes, unwind_code_size);
+}
+
+
+static void
+mono_arch_unwind_add_set_fp (guint8* unwind_codes, guint32* unwind_code_size) {
+	mono_arch_unwind_add_assert (1, 0, *unwind_code_size, 0);
+	unwind_codes[(*unwind_code_size)++] = 0b11100001;
+}
+
+static void
+mono_arch_unwind_add_pac_sign_lr (guint8* unwind_codes, guint32* unwind_code_size) {
+	mono_arch_unwind_add_assert (1, 0, *unwind_code_size, 0);
+	unwind_codes[(*unwind_code_size)++] = 0b11111100;
+}
+
+
+static void
+mono_arch_unwind_add_end (guint8* unwind_codes, guint32* unwind_code_size) {
+	mono_arch_unwind_add_assert (1, 0, *unwind_code_size, 0);
+	unwind_codes[(*unwind_code_size)++] = 0b11100100;
+}
+
+static void
+mono_arch_unwind_add_end_c (guint8* unwind_codes, guint32* unwind_code_size) {
+	mono_arch_unwind_add_assert (1, 0, *unwind_code_size, 0);
+	unwind_codes[(*unwind_code_size)++] = 0b11100101;
+}
+
+static void
+mono_arch_unwind_add_save_fplr (guint8* unwind_codes, guint32* unwind_code_size, gint32 offset) {
+
+	mono_arch_unwind_add_assert (1, 504, *unwind_code_size, offset);
+
+	unwind_codes[(*unwind_code_size)++] = 0b01000000 | offset / 8;
+}
+
+static void
+mono_arch_unwind_add_save_fplr_x (guint8* unwind_codes, guint32* unwind_code_size, gint32 offset) {
+
+	mono_arch_unwind_add_assert (1, 512, *unwind_code_size, offset);
+
+	unwind_codes[(*unwind_code_size)++] = 0b10000000 | (offset-8) / 8;
+}
+
+static void
+mono_arch_unwind_add_save_reg (guint8* unwind_codes, guint32* unwind_code_size, guint32 reg, guint32 offset, gboolean reverse) {
+
+	mono_arch_unwind_add_assert (2, 504, *unwind_code_size, offset);
+
+	guint8 reg_offset = reg - ARMREG_R19;
+	int order = reverse ? 1 : 0;
+
+	unwind_codes[*unwind_code_size + order] = 0b11010000 | reg_offset / 8;
+	unwind_codes[*unwind_code_size + 1 - order] = (reg_offset & 0x8) << 5 | (offset / 8);
+	*(unwind_code_size) += 2;
+}
+
+static void
+mono_arch_unwind_add_save_reg_x (guint8* unwind_codes, guint32* unwind_code_size, guint32 reg, guint32 offset, gboolean reverse) {
+
+	mono_arch_unwind_add_assert (2, 256, *unwind_code_size, offset);
+
+	guint8 reg_offset = reg - ARMREG_R19;
+	int order = reverse ? 1 : 0;
+
+	unwind_codes[*unwind_code_size + order] = 0b11010000 | reg_offset / 8;
+	unwind_codes[*unwind_code_size + 1 - order] = (reg_offset & 0x8) << 5 | (offset / 8);
+	*(unwind_code_size) += 2;
+}
+
+static void
+mono_arch_unwind_add_save_regp (guint8* unwind_codes, guint32* unwind_code_size, guint32 reg, guint32 offset, gboolean reverse) {
+
+	mono_arch_unwind_add_assert (2, 504, *unwind_code_size, offset);
+
+	guint8 reg_offset = reg - ARMREG_R19;
+	int order = reverse ? 1 : 0;
+
+	unwind_codes[*unwind_code_size + order] = 0b11001000 | reg_offset / 8;
+	unwind_codes[*unwind_code_size + 1 - order] = (reg_offset & 0x8) << 5 | (offset / 8);
+	*(unwind_code_size) += 2;
+}
+
+static void
+mono_arch_unwind_add_save_regp_x (guint8* unwind_codes, guint32* unwind_code_size, guint32 reg, guint32 offset, gboolean reverse) {
+
+	mono_arch_unwind_add_assert (2, 256, *unwind_code_size, offset);
+
+	guint8 reg_offset = reg - ARMREG_R19;
+	int order = reverse ? 1 : 0;
+
+	unwind_codes[*unwind_code_size + order] = 0b11001100 | reg_offset / 8;
+	unwind_codes[*unwind_code_size + 1 - order] = (reg_offset & 0x8) << 5 | (offset / 8);
+	*(unwind_code_size) += 2;
+}
+
+static void
+mono_arch_unwind_add_alloc_s (guint8* unwind_codes, guint32* unwind_code_size, guint32 size) {
+
+	mono_arch_unwind_add_assert (1, 511, *unwind_code_size, size);
+	unwind_codes[(*unwind_code_size)++] = 0b00000000 | (size / MONO_ARCH_FRAME_ALIGNMENT);
+}
+
+static void
+mono_arch_unwind_add_alloc_m (guint8* unwind_codes, guint32* unwind_code_size, guint32 size, gboolean reverse) {
+
+	mono_arch_unwind_add_assert (2, 0x7FFF, *unwind_code_size, size);
+	int order = reverse ? 1 : 0;
+	size = size / 16; // Size is multiples of 16
+	unwind_codes[*unwind_code_size + order] = 0b11000000 | (size >> 8);
+	unwind_codes[*unwind_code_size + 1 - order] = size & 0xFF;
+	*(unwind_code_size) += 2;
+}
+
+static void
+mono_arch_unwind_add_alloc_l (guint8* unwind_codes, guint32* unwind_code_size, guint32 size, gboolean reverse) {
+
+	mono_arch_unwind_add_assert (4, 0x0FFFFFFF, *unwind_code_size, size);
+	int order = reverse ? 1 : 0;
+
+	size = size / 16; // Size is multiples of 16
+	unwind_codes[*unwind_code_size + order * 3] = 0b11100000;
+	unwind_codes[*unwind_code_size + 1 + order] = size >> 16;
+	unwind_codes[*unwind_code_size + 2 - order] = (size >> 8) & 0xFF;
+	unwind_codes[*unwind_code_size + 3 - order * 3] = size & 0xFF;
+
+	(*unwind_code_size) += 4;
+}
+
+static void
+mono_arch_unwind_add_alloc_x (guint8* unwind_codes, guint32* unwind_code_size, guint32 size, gboolean reverse) {
+
+	if (size < 512)
+		mono_arch_unwind_add_alloc_s (unwind_codes, unwind_code_size, size);
+	else if (size < 0x8000)
+		mono_arch_unwind_add_alloc_m (unwind_codes, unwind_code_size, size, reverse);
+	else
+		mono_arch_unwind_add_alloc_l (unwind_codes, unwind_code_size, size, reverse);
+}
+
+static int
+mono_arch_unwind_add_reg_offset (MonoUnwindOp* unwind_op_data, GSList* next, gint stack_offset, guint8 *unwind_codes, guint32 *unwind_code_size, gboolean reverse) {
+
+	if (unwind_op_data->reg == ARMREG_SP) {
+		g_assert("I don't believe there is a way to encode this in the unwind info");
+		return 0;
+	}
+
+	if (unwind_op_data->reg == ARMREG_FP || unwind_op_data->reg == ARMREG_LR) {
+		// FP and LR are handled seperately
+		return 0;
+	}
+
+	if (unwind_op_data->reg >= ARMREG_R19 && unwind_op_data->reg <= ARMREG_R28) {
+		// Only the presreved registers have unwind codes
+		// We shoulded hit here, but emit a nop if we do
+		g_assert(unwind_op_data->reg >= ARMREG_R19 && unwind_op_data->reg <= ARMREG_R28);
+		mono_arch_unwind_add_nop(unwind_codes, unwind_code_size);
+		return 1;
+	}
+
+	MonoUnwindOp* next_unwind_op_data = NULL;
+	guint offset = stack_offset + unwind_op_data->val;
+
+	if (next && next->data)
+		next_unwind_op_data = (MonoUnwindOp*)next->data;
+
+	if (next_unwind_op_data && unwind_op_data->reg % 2 && next_unwind_op_data->op == DW_CFA_offset && next_unwind_op_data->reg == unwind_op_data->reg + 1 && next_unwind_op_data->val == unwind_op_data->val + sizeof(host_mgreg_t)) {
+		if (offset)
+			mono_arch_unwind_add_save_regp_x(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
+		else
+			mono_arch_unwind_add_save_regp(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
+
+		return 2;
+	}
+
+	if (offset)
+		mono_arch_unwind_add_save_reg_x(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
+	else
+		mono_arch_unwind_add_save_reg(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
+
+	return 1;
+}
+
+static void
+mono_arch_unwind_add_emit_subx_sp_imm (gint offset, guint8* unwind_codes, guint32* unwind_code_size, gboolean reverse) {
+
+	/* Encodes emit_subx_sp_imm:
+		mov         xip0, offet & 0xFFFF
+		movk        xip0, #4, lsl offset >> 16 // if offset > 0xFFFF
+		mov         xip1, sp
+		add         xip1, xip1, xip0
+		mov	    sp, xip1
+	*/
+	mono_arch_unwind_add_nops(unwind_codes, unwind_code_size, offset > 0xFFFF ? 4 : 3);
+	mono_arch_unwind_add_alloc_x (unwind_codes, unwind_code_size, offset, reverse);
+}
+
+typedef struct _InitilizedWindowInfoResult {
+	gint32 saved_int_regs;
+	gboolean can_use_packed_format;
+	gboolean needs_seperate_epilog;
+} InitilizedWindowInfoResult;
+
+static InitilizedWindowInfoResult
+initialize_unwind_info_prolog (GSList* unwind_ops, gint stack_offset, guint param_area, guint8 *unwind_codes, guint32 *unwind_code_size) {
+
+	InitilizedWindowInfoResult res;
+	res.saved_int_regs = 0;
+	res.needs_seperate_epilog = FALSE;
+	res.can_use_packed_format = TRUE;
+
+	if (enable_ptrauth)
+		mono_arch_unwind_add_pac_sign_lr (unwind_codes, unwind_code_size);
+
+	// Stack probes
+	if (stack_offset + param_area > 0x1000) {
+		//  stp    fp,lr,[sp,#-16]
+		//  ld imm	(1 or 2 instructions)
+		//  call __chkstk
+		//  ldp    fp,lr,[sp,#16]
+		guint probe_size = (stack_offset + param_area) / 16;
+		mono_arch_unwind_add_nops(unwind_codes, unwind_code_size, probe_size > 0xFFFF ? 5 : 4);
+		res.can_use_packed_format = FALSE;
+		res.needs_seperate_epilog = TRUE;
+	}
+
+	// Frame Setup
+	if (arm_is_ldpx_imm(-stack_offset)) {
+		if (stack_offset > 0)
+			mono_arch_unwind_add_save_fplr_x (unwind_codes, unwind_code_size, stack_offset);
+		else
+			mono_arch_unwind_add_save_fplr (unwind_codes, unwind_code_size, 0);
+	}
+	else {
+		mono_arch_unwind_add_emit_subx_sp_imm(stack_offset, unwind_codes, unwind_code_size, TRUE);
+		mono_arch_unwind_add_save_fplr (unwind_codes, unwind_code_size, 0);
+		res.can_use_packed_format = FALSE;
+	}
+
+	mono_arch_unwind_add_set_fp (unwind_codes, unwind_code_size);
+
+	if (param_area) {
+		mono_arch_unwind_add_emit_subx_sp_imm(param_area, unwind_codes, unwind_code_size, TRUE);
+		res.can_use_packed_format = FALSE;
+	}
+
+	gint32 last_saved_in_order_reg = -1;
+	guint32 last_saved_reg_offset = -1;
+	
+	MonoUnwindOp* unwind_op_data;
+
+	// Replay collected unwind info and setup Windows format.
+	for (GSList* l = unwind_ops; l; l = l->next) {
+		unwind_op_data = (MonoUnwindOp*)l->data;
+
+		switch (unwind_op_data->op) {
+		case DW_CFA_mono_prolog_nop_win64_arm64:
+			res.needs_seperate_epilog = TRUE;
+			mono_arch_unwind_add_nops (unwind_codes, unwind_code_size, unwind_op_data->val);
+			break;
+		case DW_CFA_mono_epilog_nop_win64_arm64:
+			res.needs_seperate_epilog = TRUE;
+			break;
+		case DW_CFA_mono_fp_alloc_info_win64_arm64:
+			mono_arch_unwind_add_alloc_x (unwind_codes, unwind_code_size, unwind_op_data->val, TRUE);
+			break;
+		case DW_CFA_mono_restore_offset_win64_arm64: 
+			res.needs_seperate_epilog = TRUE;
+			break;
+		case DW_CFA_offset: {
+			guint offset = stack_offset + unwind_op_data->val;
+			int reg_count;
+
+			reg_count = mono_arch_unwind_add_reg_offset(unwind_op_data, l->next, stack_offset, unwind_codes, unwind_code_size, TRUE);
+
+			if (reg_count > 0) {
+				if (last_saved_in_order_reg == -1)
+					res.can_use_packed_format = (unwind_op_data->reg == ARMREG_R19);
+				else if (unwind_op_data->reg != last_saved_in_order_reg + 1 || offset != last_saved_reg_offset + sizeof(host_mgreg_t))
+					res.can_use_packed_format = FALSE;
+
+				res.saved_int_regs += reg_count;
+				last_saved_reg_offset = offset + (reg_count - 1) * sizeof(host_mgreg_t);
+				last_saved_in_order_reg = unwind_op_data->reg + (reg_count - 1);
+				while (--reg_count > 0)
+					l = l->next;
+			}
+
+			break;
+		}
+		}
+	}
+
+	return res;
+}
+
+static void
+initialize_unwind_info_epilog (GSList* unwind_ops, gint stack_offset, gint param_area, guint8 *unwind_codes, guint32 *unwind_code_size) {
+	
+	MonoUnwindOp* unwind_op_data;
+
+	// Replay collected unwind info and setup Windows format.
+	for (GSList* l = unwind_ops; l; l = l->next) {
+		unwind_op_data = (MonoUnwindOp*)l->data;
+
+		switch (unwind_op_data->op) {
+		case DW_CFA_mono_epilog_nop_win64_arm64:
+			mono_arch_unwind_add_nops (unwind_codes, unwind_code_size, unwind_op_data->val);
+			break;
+		case DW_CFA_mono_fp_alloc_info_win64_arm64:
+			mono_arch_unwind_add_alloc_x (unwind_codes, unwind_code_size, unwind_op_data->val, FALSE);
+			break;
+		case DW_CFA_mono_restore_offset_win64_arm64: {
+			int reg_count;
+			reg_count = mono_arch_unwind_add_reg_offset(unwind_op_data, l->next, stack_offset, unwind_codes, unwind_code_size, FALSE);
+			while (--reg_count > 0)
+				l = l->next;
+			break;
+		}
+		}
+	}
+
+	if (param_area)
+		mono_arch_unwind_add_emit_subx_sp_imm(param_area, unwind_codes, unwind_code_size, FALSE);
+
+	mono_arch_unwind_add_set_fp (unwind_codes, unwind_code_size);
+
+	// Frame Setup
+	if (arm_is_ldpx_imm(-stack_offset)) {
+		if (stack_offset > 0)
+			mono_arch_unwind_add_save_fplr_x (unwind_codes, unwind_code_size, stack_offset);
+		else
+			mono_arch_unwind_add_save_fplr (unwind_codes, unwind_code_size, 0);
+	}
+	else {
+		mono_arch_unwind_add_emit_subx_sp_imm(param_area, unwind_codes, unwind_code_size, FALSE);
+		mono_arch_unwind_add_save_fplr (unwind_codes, unwind_code_size, 0);
+	}
+
+	if (enable_ptrauth)
+		mono_arch_unwind_add_pac_sign_lr (unwind_codes, unwind_code_size);
+}
+
+static guint
+mono_arch_unwinddata_get_size (UnwindData* unwinddata) {
+
+	if (unwinddata->pdata.Flag == PdataRefToFullXdata)
+		return sizeof(UnwindData) - sizeof(unwinddata->unwind_codes) + ((unwinddata->xdata.CodeWords) * sizeof(guint32));
+	return sizeof(RUNTIME_FUNCTION);
+}
+
+static guint
+mono_arch_unwindinfo_get_size (UnwindInfo* unwindinfo) {
+
+	guint size = 0;
+	for (guint i = 0; i < unwindinfo->count; i++)
+		size += mono_arch_unwinddata_get_size(&unwindinfo->unwind_data[i]);
+	return size;
+}
+
+PUnwindInfo
+mono_arch_unwindinfo_init_method_unwind_info_ex (GSList* unwind_ops, gint stack_offset, guint param_area, guint epilog_start, guint epilog_end, guint code_len) {
+
+	guint32 code_word_size = 0, epliog_unwind_codes_start = 0;
+	InitilizedWindowInfoResult res;
+	guint8 unwind_codes[MONO_ARM64_MAX_UNWIND_CODE_SIZE];
+	UnwindData* unwinddata = NULL;
+	guint numSectionsNeeded = 1;
+
+	if (unwind_ops == NULL)
+		return 0;
+
+	res = initialize_unwind_info_prolog (unwind_ops, stack_offset, param_area, unwind_codes, &code_word_size);
+
+	if (res.can_use_packed_format && !res.needs_seperate_epilog && code_len < 0x2000 && stack_offset < 0x2000 && epilog_end == code_len) {
+
+		unwinddata = (PUnwindData)g_new0(RUNTIME_FUNCTION, 1);
+		// We can use the packed format
+		unwinddata->pdata.Flag = PdataPackedUnwindFunction;
+		unwinddata->pdata.FunctionLength = code_len / MONO_ARM64_UNWIND_WORD_SIZE;
+		unwinddata->pdata.FrameSize = stack_offset / MONO_ARCH_FRAME_ALIGNMENT;
+		unwinddata->pdata.CR = enable_ptrauth ? PdataCrChainedWithPac : PdataCrChained;
+		unwinddata->pdata.RegI = res.saved_int_regs;
+		unwinddata->pdata.RegF = 0; // No floating point registers saved
+		unwinddata->pdata.H = 0;    // No home area
+	}
+	else {
+		PUnwindData current;
+		guint8* prolog_unwind_codes;
+		guint prolog_unwind_codes_len;
+		guint segment_start = 0;
+
+		numSectionsNeeded = (code_len / MONO_ARM64_UNWIND_LARGE_FUNCTION_SIZE) + 1;
+		// We can't split the epilog - create a sepreate section
+		if (epilog_start / MONO_ARM64_UNWIND_LARGE_FUNCTION_SIZE != epilog_end / MONO_ARM64_UNWIND_LARGE_FUNCTION_SIZE)
+			numSectionsNeeded++;
+
+		unwinddata = (PUnwindData)g_new0(UnwindData, numSectionsNeeded);
+		current = unwinddata;
+
+		// Reverse the codewords - they need to be in reverse order
+		for (int i = 0; i < code_word_size; i++)
+			current->unwind_codes[i] = unwind_codes[code_word_size - i - 1];
+
+		mono_arch_unwind_add_end (current->unwind_codes, &code_word_size);
+		// Count of 32 bit words
+
+		prolog_unwind_codes = current->unwind_codes;
+		prolog_unwind_codes_len = code_word_size;
+
+		while (segment_start < code_len) {
+
+			guint segment_len = min(code_len - segment_start, MONO_ARM64_UNWIND_LARGE_FUNCTION_SIZE);
+
+			current->pdata.Flag = PdataRefToFullXdata;
+			current->xdata.FunctionLength = segment_len / MONO_ARM64_UNWIND_WORD_SIZE;
+			current->xdata.Version = 0;
+			current->xdata.ExceptionDataPresent = 0;			// No exception handle data
+			current->xdata.EpilogInHeader = 1;				// Only one epilog in the header
+			current->xdata.EpilogCount = 0;					// When EpilogInHeader is true, EpilogCount is an offset into unwind codes
+
+			if (current != unwinddata) {
+				code_word_size = 0;
+				mono_arch_unwind_add_end_c (current->unwind_codes, &code_word_size);
+				memcpy(&current->unwind_codes[code_word_size], prolog_unwind_codes, prolog_unwind_codes_len);
+				code_word_size += prolog_unwind_codes_len;
+			}
+
+			current->xdata.CodeWords = ALIGN_TO(code_word_size, MONO_ARM64_UNWIND_WORD_SIZE) / MONO_ARM64_UNWIND_WORD_SIZE;
+
+			segment_start += segment_len;
+			current++;
+		}
+
+		if (res.needs_seperate_epilog) {
+			current--;
+
+			current->xdata.EpilogCount = code_word_size;	// When EpilogInHeader is true, EpilogCount is an offset into unwind codes
+			initialize_unwind_info_epilog (unwind_ops, stack_offset, param_area, current->unwind_codes, &code_word_size);
+			mono_arch_unwind_add_end (current->unwind_codes, &code_word_size);
+
+			// Count of 32 bit words
+			unwinddata->xdata.CodeWords = ALIGN_TO(code_word_size, MONO_ARM64_UNWIND_WORD_SIZE) / MONO_ARM64_UNWIND_WORD_SIZE;
+		}
+	}
+
+	PUnwindInfo unwindinfo = (PUnwindInfo)g_new0(UnwindInfo, 1);
+	unwindinfo->unwind_data = unwinddata;
+	unwindinfo->count = numSectionsNeeded;
+
+	return unwindinfo;
+}
+
+guint
+mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg) {
+
+	MonoCompile* current_cfg = (MonoCompile*)cfg;
+
+	UnwindInfo* unwindinfo = mono_arch_unwindinfo_init_method_unwind_info_ex (current_cfg->unwind_ops, current_cfg->stack_offset, current_cfg->param_area, current_cfg->epilog_begin, current_cfg->epilog_end, current_cfg->code_len);
+
+	current_cfg->arch.unwindinfo = unwindinfo;
+
+	if (unwindinfo == NULL)
+		return 0;
+
+	return mono_arch_unwindinfo_get_size(unwindinfo);
+}
+
+void
+mono_arch_unwindinfo_install_tramp_unwind_info (GSList* unwind_ops, gpointer code, guint code_size) {
+
+	if (unwind_ops == NULL)
+		return;
+
+	UnwindInfo* unwindinfo = mono_arch_unwindinfo_init_method_unwind_info_ex (unwind_ops, 0, 0, 0, code_size, code_size);
+	if (unwindinfo != NULL)
+	{
+		// We only allocate enough data for the compressed unwind info for trampolines -- see MONO_TRAMPOLINE_UNWINDINFO_SIZE
+		g_assert(MONO_TRAMPOLINE_UNWINDINFO_SIZE == mono_arch_unwindinfo_get_size (unwindinfo));
+
+		if (MONO_TRAMPOLINE_UNWINDINFO_SIZE == mono_arch_unwindinfo_get_size (unwindinfo))
+			mono_arch_unwindinfo_install_method_unwind_info (&unwindinfo, code, code_size);
+	}
+}
+
+static PUnwindData mono_arch_unwind_info_from_code (gpointer code, guint code_size) {
+
+	guint64 targetlocation;
+
+	targetlocation = (guint64) & (((guchar*)code)[code_size]);
+	g_assert(targetlocation % MONO_ARM64_UNWIND_WORD_SIZE == 0);
+	return (PUnwindData)targetlocation;
+}
+
+void
+mono_arch_unwindinfo_install_method_unwind_info (PUnwindInfo* monoui, gpointer code, guint code_size) {
+
+	PUnwindInfo unwindinfo;
+	PUnwindData targetinfo;
+	guchar codecount;
+	guint64 targetlocation;
+	gpointer code_segment = code;
+
+	if (!*monoui)
+		return;
+
+	unwindinfo = *monoui;
+
+	targetlocation = (guint64) & (((guchar*)code)[code_size]);
+	g_assert(targetlocation % MONO_ARM64_UNWIND_WORD_SIZE == 0);
+	targetinfo = mono_arch_unwind_info_from_code (code, code_size);
+
+	for (guint i = 0; i < unwindinfo->count; i++) {
+		guint segment_length;
+		PUnwindData unwinddata = &unwindinfo->unwind_data[i];
+		guint32 unwind_data_size = mono_arch_unwinddata_get_size (unwinddata);
+		memcpy(targetinfo, unwinddata, unwind_data_size);
+
+		if (unwinddata->pdata.Flag == PdataRefToFullXdata)
+			segment_length = unwinddata->xdata.FunctionLength * MONO_ARM64_UNWIND_WORD_SIZE;
+		else
+			segment_length = unwinddata->pdata.FunctionLength * MONO_ARM64_UNWIND_WORD_SIZE;
+
+		mono_arch_unwindinfo_insert_rt_func_in_table (code_segment, segment_length, targetinfo);
+		code_segment = (gchar*)code_segment + segment_length;
+		targetinfo = (PUnwindData)((gchar*)targetinfo +  unwind_data_size);
+	}
+
+	g_free(unwindinfo->unwind_data);
+	g_free(unwindinfo);
+	*monoui = NULL;
+}
+
+RUNTIME_FUNCTION
+mono_arch_unwindinfo_init (gpointer code, gsize code_offset, gsize code_size, gsize begin_range, gsize end_range, const gpointer unwinddata) {
+
+	RUNTIME_FUNCTION new_rt_func_data;
+
+	PUnwindData targetinfo = (PUnwindData)unwinddata;
+
+	new_rt_func_data.BeginAddress = code_offset;
+	if (targetinfo->pdata.Flag == PdataRefToFullXdata)
+	{
+		// Update the pdata to point to the RVA for the xdata
+		new_rt_func_data.UnwindData = code_offset + ((guint64)targetinfo - (guint64)code) + sizeof(RUNTIME_FUNCTION);
+	}
+	else
+	{
+		// Unwind data is the MONO_ARM64_UNWIND_WORD_SIZE stored in UnwindData
+		new_rt_func_data.UnwindData = targetinfo->pdata.UnwindData;
+	}
+
+	return new_rt_func_data;
+}
+
+guint32
+mono_arch_unwindinfo_get_end_address (gpointer rvaRoot, PRUNTIME_FUNCTION func) {
+
+	if (func->Flag == PdataRefToFullXdata) {
+		PUnwindData unwindInfo = (PUnwindData)func;
+		IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA* xData = (IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA*)((guint8*)mono_arch_unwindinfo_init + func->UnwindData + sizeof(guint32));
+		return func->BeginAddress + xData->FunctionLength * MONO_ARM64_UNWIND_WORD_SIZE;
+	}
+
+	return func->BeginAddress + func->FunctionLength * MONO_ARM64_UNWIND_WORD_SIZE;
+}
+
+gboolean
+mono_arch_unwindinfo_emit_epilog_codes (guint64 saved_regset, guint64 restore_regset) {
+	return saved_regset != restore_regset;
+}
+
+#endif /* MONO_ARCH_HAVE_UNWIND_TABLE*/

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -971,7 +971,7 @@ initialize_unwind_info_prolog (GSList* unwind_ops, gint stack_offset, guint para
 
 			if (reg_count > 0) {
 				if (last_saved_in_order_reg == -1)
-					res.can_use_packed_format = (unwind_op_data->reg == ARMREG_R19);
+					res.can_use_packed_format = res.can_use_packed_format && (unwind_op_data->reg == ARMREG_R19);
 				else if (unwind_op_data->reg != last_saved_in_order_reg + 1 || offset != last_saved_reg_offset + sizeof(host_mgreg_t))
 					res.can_use_packed_format = FALSE;
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5283,7 +5283,6 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (cfg->arch.args_reg) {
 		/* The register was already saved above */
 		code = emit_addx_imm (code, cfg->arch.args_reg, ARMREG_FP, cfg->stack_offset);
-		mono_emit_unwind_op_fp_alloc(cfg, code, cfg->arch.args_reg);
 	}
 
 	/* Save return area addr received in R8 */

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5211,12 +5211,13 @@ emit_setup_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset, int cfa_offse
 	 * need to be restored during EH.
 	 */
 
+	guint8* start = code;
+
 	/* pc */
 	arm_adrx (code, ARMREG_LR, code);
 	code = emit_strx (code, ARMREG_LR, ARMREG_FP, lmf_offset + MONO_STRUCT_OFFSET (MonoLMF, pc));
 
-	const int num_save_lmf_instructions = 2;
-	mono_emit_unwind_op_prolog_nop(cfg, code, num_save_lmf_instructions); 
+	mono_emit_unwind_op_prolog_nop(cfg, code, (code - start) / 4); 
 
 	/* gregs + fp + sp */
 	/* Don't emit unwind info for sp/fp, they are already handled in the prolog */

--- a/mono/mini/mini-unwind.h
+++ b/mono/mini/mini-unwind.h
@@ -77,9 +77,22 @@
  * Mono extension, Windows x64 unwind ABI needs some more details around sp alloc size and fp offset.
  */
 #if defined(TARGET_WIN32) && defined(TARGET_AMD64)
-#define DW_CFA_mono_sp_alloc_info_win64 (DW_CFA_lo_user + 1)
-#define DW_CFA_mono_fp_alloc_info_win64 (DW_CFA_lo_user + 2)
+#define DW_CFA_mono_sp_alloc_info_win64_amd64 (DW_CFA_lo_user + 1)
+#define DW_CFA_mono_fp_alloc_info_win64_amd64 (DW_CFA_lo_user + 2)
 #endif
+
+/*
+ * Mono extenions, Windows ARM64 unwind ABI needs details about regs restored in the epilog
+ * This may be different for methods with LMF data
+*/
+#if defined(TARGET_WIN32) && defined(TARGET_ARM64)
+#define DW_CFA_mono_restore_offset_win64_arm64 (DW_CFA_lo_user + 1)
+#define DW_CFA_mono_prolog_nop_win64_arm64 (DW_CFA_lo_user + 2)
+#define DW_CFA_mono_epilog_nop_win64_arm64 (DW_CFA_lo_user + 3)
+#define DW_CFA_mono_fp_alloc_info_win64_arm64 (DW_CFA_lo_user + 4)
+#endif
+
+#define DW_CFA_offset             0x80
 
 /* Represents one unwind instruction */
 typedef struct {
@@ -116,12 +129,14 @@ typedef struct {
  */
 #define mono_emit_unwind_op_mark_loc(cfg,ip,n) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_advance_loc, 0, (n))
 
-#if defined(TARGET_WIN32) && defined(TARGET_AMD64)
-#define mono_emit_unwind_op_sp_alloc(cfg,ip,size) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_sp_alloc_info_win64, 0, (size))
-#define mono_emit_unwind_op_fp_alloc(cfg,ip,reg,size) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_fp_alloc_info_win64, (reg), (size))
+#if defined(TARGET_AMD64)
+#if defined(TARGET_WIN32)
+#define mono_emit_unwind_op_sp_alloc(cfg,ip,size) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_sp_alloc_info_win64_amd64, 0, (size))
+#define mono_emit_unwind_op_fp_alloc(cfg,ip,reg,size) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_fp_alloc_info_win64_amd64, (reg), (size))
 #else
 #define mono_emit_unwind_op_sp_alloc(cfg,ip,size)
 #define mono_emit_unwind_op_fp_alloc(cfg,ip,reg,size)
+#endif
 #endif
 
 /* Similar macros usable when a cfg is not available, like for trampolines */
@@ -131,12 +146,28 @@ typedef struct {
 #define mono_add_unwind_op_same_value(op_list,code,buf,reg) do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_same_value, (reg), 0)); } while (0)
 #define mono_add_unwind_op_offset(op_list,code,buf,reg,offset) do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_offset, (reg), (offset))); } while (0)
 
-#if defined(TARGET_WIN32) && defined(TARGET_AMD64)
-#define mono_add_unwind_op_sp_alloc(op_list,code,buf,size) do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_mono_sp_alloc_info_win64, 0, (size))); } while (0)
-#define mono_add_unwind_op_fp_alloc(op_list,code,buf,reg,size) do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_mono_fp_alloc_info_win64, (reg), (size))); } while (0)
+#if defined(TARGET_AMD64)
+#if defined(TARGET_WIN32)
+#define mono_add_unwind_op_sp_alloc(op_list,code,buf,size) do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_mono_sp_alloc_info_win64_amd64, 0, (size))); } while (0)
+#define mono_add_unwind_op_fp_alloc(op_list,code,buf,reg,size) do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_mono_fp_alloc_info_win64_amd64, (reg), (size))); } while (0)
 #else
 #define mono_add_unwind_op_sp_alloc(op_list,code,buf,size)
 #define mono_add_unwind_op_fp_alloc(op_list,code,buf,reg,size)
+#endif
+#endif
+
+#if defined(TARGET_ARM64)
+#if defined(TARGET_WIN32) 
+#define mono_emit_unwind_op_restore_offset(cfg,ip,reg,offset) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_restore_offset_win64_arm64, (reg), (offset))
+#define mono_emit_unwind_op_prolog_nop(cfg,ip,ins_count) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_prolog_nop_win64_arm64, 0, (ins_count))
+#define mono_emit_unwind_op_epilog_nop(cfg,ip,ins_count) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_epilog_nop_win64_arm64, 0, (ins_count))
+#define mono_emit_unwind_op_fp_alloc(cfg,ip,size) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_fp_alloc_info_win64_arm64, 0, (size))
+#else
+#define mono_emit_unwind_op_restore_offset(cfg,ip,reg,offset)
+#define mono_emit_unwind_op_prolog_nop(cfg,ip,ins_count)
+#define mono_emit_unwind_op_epilog_nop(cfg,ip,ins_count)
+#define mono_emit_unwind_op_fp_alloc(cfg,ip,size)
+#endif
 #endif
 
 #define mono_free_unwind_info(op_list) do { GSList *l; for (l = op_list; l; l = l->next) g_free (l->data); g_slist_free (op_list); op_list = NULL; } while (0)

--- a/mono/mini/mini-unwind.h
+++ b/mono/mini/mini-unwind.h
@@ -89,7 +89,6 @@
 #define DW_CFA_mono_restore_offset_win64_arm64 (DW_CFA_lo_user + 1)
 #define DW_CFA_mono_prolog_nop_win64_arm64 (DW_CFA_lo_user + 2)
 #define DW_CFA_mono_epilog_nop_win64_arm64 (DW_CFA_lo_user + 3)
-#define DW_CFA_mono_fp_alloc_info_win64_arm64 (DW_CFA_lo_user + 4)
 #endif
 
 #define DW_CFA_offset             0x80
@@ -161,12 +160,10 @@ typedef struct {
 #define mono_emit_unwind_op_restore_offset(cfg,ip,reg,offset) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_restore_offset_win64_arm64, (reg), (offset))
 #define mono_emit_unwind_op_prolog_nop(cfg,ip,ins_count) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_prolog_nop_win64_arm64, 0, (ins_count))
 #define mono_emit_unwind_op_epilog_nop(cfg,ip,ins_count) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_epilog_nop_win64_arm64, 0, (ins_count))
-#define mono_emit_unwind_op_fp_alloc(cfg,ip,size) mono_emit_unwind_op (cfg, (ip) - (cfg)->native_code, DW_CFA_mono_fp_alloc_info_win64_arm64, 0, (size))
 #else
 #define mono_emit_unwind_op_restore_offset(cfg,ip,reg,offset)
 #define mono_emit_unwind_op_prolog_nop(cfg,ip,ins_count)
 #define mono_emit_unwind_op_epilog_nop(cfg,ip,ins_count)
-#define mono_emit_unwind_op_fp_alloc(cfg,ip,size)
 #endif
 #endif
 

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -114,7 +114,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	const char *tramp_name;
 
 	buf_len = 768;
-	buf = code = mono_global_codeman_reserve (buf_len);
+	buf = code = mono_global_codeman_reserve (buf_len + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	/*
 	 * We are getting called by a specific trampoline, ip1 contains the trampoline argument.
@@ -341,7 +341,7 @@ mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_ty
 	 */
 	tramp = mono_get_trampoline_code (tramp_type);
 
-	buf = code = mono_mem_manager_code_reserve (mem_manager, buf_len);
+	buf = code = mono_mem_manager_code_reserve (mem_manager, buf_len + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	MINI_BEGIN_CODEGEN ();
 
@@ -384,7 +384,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	MonoDomain *domain = mono_domain_get ();
 	MonoMemoryManager *mem_manager = m_method_get_mem_manager (domain, m);
 
-	start = code = mono_mem_manager_code_reserve (mem_manager, size);
+	start = code = mono_mem_manager_code_reserve (mem_manager, size + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	MINI_BEGIN_CODEGEN ();
 
@@ -407,7 +407,7 @@ mono_arch_get_static_rgctx_trampoline (MonoMemoryManager *mem_manager, gpointer 
 	guint8 *code, *start;
 	guint32 buf_len = 32;
 
-	start = code = mono_mem_manager_code_reserve (mem_manager, buf_len);
+	start = code = mono_mem_manager_code_reserve (mem_manager, buf_len + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	MINI_BEGIN_CODEGEN ();
 
@@ -448,7 +448,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	}
 
 	buf_size = 64 + 16 * depth;
-	code = buf = mono_global_codeman_reserve (buf_size);
+	code = buf = mono_global_codeman_reserve (buf_size + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	rgctx_null_jumps = g_malloc0 (sizeof (guint8*) * (depth + 2));
 	njumps = 0;
@@ -537,7 +537,7 @@ mono_arch_create_general_rgctx_lazy_fetch_trampoline (MonoTrampInfo **info, gboo
 
 	tramp_size = 32;
 
-	code = buf = mono_global_codeman_reserve (tramp_size);
+	code = buf = mono_global_codeman_reserve (tramp_size + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	mono_add_unwind_op_def_cfa (unwind_ops, code, buf, ARMREG_SP, 0);
 
@@ -577,7 +577,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 	GSList *unwind_ops = NULL;
 	MonoJumpInfo *ji = NULL;
 
-	code = buf = mono_global_codeman_reserve (tramp_size);
+	code = buf = mono_global_codeman_reserve (tramp_size + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	/* Compute stack frame size and offsets */
 	offset = 0;
@@ -677,7 +677,7 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 	int buf_len, i, framesize = 0, off_methodargs, off_targetaddr;
 
 	buf_len = 512 + 1024;
-	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
+	start = code = (guint8 *) mono_global_codeman_reserve (buf_len + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	/* allocate frame */
 	framesize += 2 * sizeof (host_mgreg_t);
@@ -783,7 +783,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	int framesize, offset, ccontext_offset;
 
 	buf_len = 512;
-	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
+	start = code = (guint8 *) mono_global_codeman_reserve (buf_len + MONO_TRAMPOLINE_UNWINDINFO_SIZE);
 
 	/* Allocate frame (FP + LR + CallContext) */
 	offset = 2 * sizeof (host_mgreg_t);

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -489,8 +489,17 @@ mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enab
 			*p ++ = op->op;
 			break;
 #if defined(TARGET_WIN32) && defined(TARGET_AMD64)
-		case DW_CFA_mono_sp_alloc_info_win64:
-		case DW_CFA_mono_fp_alloc_info_win64:
+		case DW_CFA_mono_sp_alloc_info_win64_amd64:
+		case DW_CFA_mono_fp_alloc_info_win64_amd64:
+			// Drop Windows specific unwind op's. These op's are currently
+			// only used when registering unwind info with Windows OS unwinder.
+			break;
+#endif
+#if defined(TARGET_WIN32) && defined(TARGET_ARM64)
+		case DW_CFA_mono_restore_offset_win64_arm64:
+		case DW_CFA_mono_prolog_nop_win64_arm64:
+		case DW_CFA_mono_epilog_nop_win64_arm64:
+		case DW_CFA_mono_fp_alloc_info_win64_arm64:
 			// Drop Windows specific unwind op's. These op's are currently
 			// only used when registering unwind info with Windows OS unwinder.
 			break;

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -499,7 +499,6 @@ mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enab
 		case DW_CFA_mono_restore_offset_win64_arm64:
 		case DW_CFA_mono_prolog_nop_win64_arm64:
 		case DW_CFA_mono_epilog_nop_win64_arm64:
-		case DW_CFA_mono_fp_alloc_info_win64_arm64:
 			// Drop Windows specific unwind op's. These op's are currently
 			// only used when registering unwind info with Windows OS unwinder.
 			break;


### PR DESCRIPTION
The unwind data is registered using the same functions as for
Windows Amd64, however the actual unwind data is completely
different.

Windows Arm64 records the unwind data as a 1-to-1 mapping between
the codes and the instructions in the prolog and epilog.  This is
to support unwinding in the middle of the epilog or prolog.  It's not
clear if we need this support in mono, but it has been faithfully
implemented.  This includes emitting nop unwind codes for instructions
in the header that aren't stack related.

The unwind codes also support different formats for reduce the amount
of data stored and optimize for the case were the prolog and epilog
are mirror images.  This was not the case previously, mono would restore
the preserved registers in the same order, instead of the reverse.  So
a new function was added to emit them in the reverse order.

Another important case is last managed frame methods (LMF).  These are
managed methods that will transition into native code.  These methods
always spill all of the preserved registers to stack in case they
need to recover from a managed exception, but only restore the
registers they use.  So these functions can never use the optimized
forms.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-49668 @scott-ferguson-unity 
Mono: Add support for stack unwind code registration on Windows Arm64

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
* 2023.3

**Upstream**
Upstream has no support for Windows Arm64 - we would need to upstream all of our  Windows Arm64 changes.

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->