### PR TITLE
[2023.2] Disallow unrestricted polymorphic deserialization in DataSet

### DIFF
--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -1,0 +1,649 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+using System.IO;
+using System.Xml.Serialization;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Dynamic;
+
+namespace System.Data.Common
+{
+    internal sealed class ObjectStorage : DataStorage
+    {
+        private static readonly object s_defaultValue = null;
+
+        private enum Families { DATETIME, NUMBER, STRING, BOOLEAN, ARRAY };
+
+        private object[] _values;
+        private readonly bool _implementsIXmlSerializable;
+
+        internal ObjectStorage(DataColumn column, Type type)
+        : base(column, type, s_defaultValue, DBNull.Value, typeof(ICloneable).IsAssignableFrom(type), GetStorageType(type))
+        {
+            _implementsIXmlSerializable = typeof(IXmlSerializable).IsAssignableFrom(type);
+        }
+
+        public override object Aggregate(int[] records, AggregateType kind)
+        {
+            throw ExceptionBuilder.AggregateException(kind, _dataType);
+        }
+
+        public override int Compare(int recordNo1, int recordNo2)
+        {
+            object valueNo1 = _values[recordNo1];
+            object valueNo2 = _values[recordNo2];
+
+            if (valueNo1 == valueNo2)
+                return 0;
+            if (valueNo1 == null)
+                return -1;
+            if (valueNo2 == null)
+                return 1;
+
+            IComparable icomparable = (valueNo1 as IComparable);
+            if (null != icomparable)
+            {
+                try
+                {
+                    return icomparable.CompareTo(valueNo2);
+                }
+                catch (ArgumentException e)
+                {
+                    ExceptionBuilder.TraceExceptionWithoutRethrow(e);
+                }
+            }
+            return CompareWithFamilies(valueNo1, valueNo2);
+        }
+
+        public override int CompareValueTo(int recordNo1, object value)
+        {
+            object valueNo1 = Get(recordNo1);
+
+            if (valueNo1 is IComparable)
+            {
+                if (value.GetType() == valueNo1.GetType())
+                    return ((IComparable)valueNo1).CompareTo(value);
+            }
+
+            if (valueNo1 == value)
+                return 0;
+
+            if (valueNo1 == null)
+            {
+                if (_nullValue == value)
+                {
+                    return 0;
+                }
+                return -1;
+            }
+            if ((_nullValue == value) || (null == value))
+            {
+                return 1;
+            }
+
+            return CompareWithFamilies(valueNo1, value);
+        }
+
+
+        private int CompareTo(object valueNo1, object valueNo2)
+        {
+            if (valueNo1 == null)
+                return -1;
+            if (valueNo2 == null)
+                return 1;
+            if (valueNo1 == valueNo2)
+                return 0;
+            if (valueNo1 == _nullValue)
+                return -1;
+            if (valueNo2 == _nullValue)
+                return 1;
+
+            if (valueNo1 is IComparable)
+            {
+                try
+                {
+                    return ((IComparable)valueNo1).CompareTo(valueNo2);
+                }
+                catch (ArgumentException e)
+                {
+                    ExceptionBuilder.TraceExceptionWithoutRethrow(e);
+                }
+            }
+            return CompareWithFamilies(valueNo1, valueNo2);
+        }
+
+        private int CompareWithFamilies(object valueNo1, object valueNo2)
+        {
+            Families Family1 = GetFamily(valueNo1.GetType());
+            Families Family2 = GetFamily(valueNo2.GetType());
+            if (Family1 < Family2)
+                return -1;
+            else
+                if (Family1 > Family2)
+                return 1;
+            else
+            {
+                switch (Family1)
+                {
+                    case Families.BOOLEAN:
+                        valueNo1 = Convert.ToBoolean(valueNo1, FormatProvider);
+                        valueNo2 = Convert.ToBoolean(valueNo2, FormatProvider);
+                        break;
+                    case Families.DATETIME:
+                        valueNo1 = Convert.ToDateTime(valueNo1, FormatProvider);
+                        valueNo2 = Convert.ToDateTime(valueNo1, FormatProvider);
+                        break;
+                    case Families.NUMBER:
+                        valueNo1 = Convert.ToDouble(valueNo1, FormatProvider);
+                        valueNo2 = Convert.ToDouble(valueNo2, FormatProvider);
+                        break;
+                    case Families.ARRAY:
+                        {
+                            Array arr1 = (Array)valueNo1;
+                            Array arr2 = (Array)valueNo2;
+                            if (arr1.Length > arr2.Length)
+                                return 1;
+                            else if (arr1.Length < arr2.Length)
+                                return -1;
+                            else
+                            { // same number of elements
+                                for (int i = 0; i < arr1.Length; i++)
+                                {
+                                    int c = CompareTo(arr1.GetValue(i), arr2.GetValue(i));
+                                    if (c != 0)
+                                        return c;
+                                }
+                            }
+                            return 0;
+                        }
+                    default:
+                        valueNo1 = valueNo1.ToString();
+                        valueNo2 = valueNo2.ToString();
+                        break;
+                }
+                return ((IComparable)valueNo1).CompareTo(valueNo2);
+            }
+        }
+
+        public override void Copy(int recordNo1, int recordNo2)
+        {
+            _values[recordNo2] = _values[recordNo1];
+        }
+
+        public override object Get(int recordNo)
+        {
+            object value = _values[recordNo];
+            if (null != value)
+            {
+                return value;
+            }
+            return _nullValue;
+        }
+
+        private Families GetFamily(Type dataType)
+        {
+            switch (Type.GetTypeCode(dataType))
+            {
+                case TypeCode.Boolean: return Families.BOOLEAN;
+                case TypeCode.Char: return Families.STRING;
+                case TypeCode.SByte: return Families.STRING;
+                case TypeCode.Byte: return Families.STRING;
+                case TypeCode.Int16: return Families.NUMBER;
+                case TypeCode.UInt16: return Families.NUMBER;
+                case TypeCode.Int32: return Families.NUMBER;
+                case TypeCode.UInt32: return Families.NUMBER;
+                case TypeCode.Int64: return Families.NUMBER;
+                case TypeCode.UInt64: return Families.NUMBER;
+                case TypeCode.Single: return Families.NUMBER;
+                case TypeCode.Double: return Families.NUMBER;
+                case TypeCode.Decimal: return Families.NUMBER;
+                case TypeCode.DateTime: return Families.DATETIME;
+                case TypeCode.String: return Families.STRING;
+                default:
+                    if (typeof(TimeSpan) == dataType)
+                    {
+                        return Families.DATETIME;
+                    }
+                    else if (dataType.IsArray)
+                    {
+                        return Families.ARRAY;
+                    }
+                    else
+                    {
+                        return Families.STRING;
+                    }
+            }
+        }
+
+        public override bool IsNull(int record)
+        {
+            return (null == _values[record]);
+        }
+
+        public override void Set(int recordNo, object value)
+        {
+            Debug.Assert(null != value, "null value");
+            if (_nullValue == value)
+            {
+                _values[recordNo] = null;
+            }
+            else if (_dataType == typeof(object) || _dataType.IsInstanceOfType(value))
+            {
+                _values[recordNo] = value;
+            }
+            else
+            {
+                Type valType = value.GetType();
+                if (_dataType == typeof(Guid) && valType == typeof(string))
+                {
+                    _values[recordNo] = new Guid((string)value);
+                }
+                else if (_dataType == typeof(byte[]))
+                {
+                    if (valType == typeof(bool))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((bool)value);
+                    }
+                    else if (valType == typeof(char))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((char)value);
+                    }
+                    else if (valType == typeof(short))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((short)value);
+                    }
+                    else if (valType == typeof(int))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((int)value);
+                    }
+                    else if (valType == typeof(long))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((long)value);
+                    }
+                    else if (valType == typeof(ushort))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((ushort)value);
+                    }
+                    else if (valType == typeof(uint))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((uint)value);
+                    }
+                    else if (valType == typeof(ulong))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((ulong)value);
+                    }
+                    else if (valType == typeof(float))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((float)value);
+                    }
+                    else if (valType == typeof(double))
+                    {
+                        _values[recordNo] = BitConverter.GetBytes((double)value);
+                    }
+                    else
+                    {
+                        throw ExceptionBuilder.StorageSetFailed();
+                    }
+                }
+                else
+                {
+                    throw ExceptionBuilder.StorageSetFailed();
+                }
+            }
+        }
+
+        public override void SetCapacity(int capacity)
+        {
+            object[] newValues = new object[capacity];
+            if (_values != null)
+            {
+                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+            }
+            _values = newValues;
+        }
+
+        // Prevent inlining so that reflection calls are not moved to caller that may be in a different assembly that may have a different grant set.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public override object ConvertXmlToObject(string s)
+        {
+            Type type = _dataType; // real type of objects in this column
+
+            if (type == typeof(byte[]))
+            {
+                return Convert.FromBase64String(s);
+            }
+            if (type == typeof(Type))
+            {
+                return Type.GetType(s);
+            }
+            if (type == typeof(Guid))
+            {
+                return (new Guid(s));
+            }
+            if (type == typeof(Uri))
+            {
+                return (new Uri(s));
+            }
+
+
+            if (_implementsIXmlSerializable)
+            {
+                object Obj = System.Activator.CreateInstance(_dataType, true);
+                StringReader strReader = new StringReader(s);
+                using (XmlTextReader xmlTextReader = new XmlTextReader(strReader))
+                {
+                    ((IXmlSerializable)Obj).ReadXml(xmlTextReader);
+                }
+                return Obj;
+            }
+
+            StringReader strreader = new StringReader(s);
+            XmlSerializer deserializerWithOutRootAttribute = ObjectStorage.GetXmlSerializer(type);
+            return (deserializerWithOutRootAttribute.Deserialize(strreader));
+        }
+
+        // Prevent inlining so that reflection calls are not moved to caller that may be in a different assembly that may have a different grant set.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public override object ConvertXmlToObject(XmlReader xmlReader, XmlRootAttribute xmlAttrib)
+        {
+            object retValue = null;
+            bool isBaseCLRType = false;
+            bool legacyUDT = false; // in 1.0 and 1.1 we used to call ToString on CDT obj. so if we have the same case
+            // we need to handle the case when we have column type as object.
+            if (null == xmlAttrib)
+            { // this means type implements IXmlSerializable
+                Type type = null;
+                string typeName = xmlReader.GetAttribute(Keywords.MSD_INSTANCETYPE, Keywords.MSDNS);
+                if (typeName == null || typeName.Length == 0)
+                { // No CDT polumorphism
+                    string xsdTypeName = xmlReader.GetAttribute(Keywords.TYPE, Keywords.XSINS); // this xsd type: Base type polymorphism
+                    if (null != xsdTypeName && xsdTypeName.Length > 0)
+                    {
+                        string[] _typename = xsdTypeName.Split(':');
+                        if (_typename.Length == 2)
+                        { // split will return aray of size 1 if ":" is not there
+                            if (xmlReader.LookupNamespace(_typename[0]) == Keywords.XSDNS)
+                            {
+                                xsdTypeName = _typename[1]; // trim the prefix and just continue with
+                            }
+                        } // for other case, let say we have two ':' in type, the we throws (as old behavior)
+                        type = XSDSchema.XsdtoClr(xsdTypeName);
+                        isBaseCLRType = true;
+                    }
+                    else if (_dataType == typeof(object))
+                    {// there is no Keywords.MSD_INSTANCETYPE and no Keywords.TYPE
+                        legacyUDT = true;             // see if our type is object
+                    }
+                }
+
+                if (legacyUDT)
+                { // if Everett UDT, just read it and return string
+                    retValue = xmlReader.ReadString();
+                }
+                else
+                {
+                    if (typeName == Keywords.TYPEINSTANCE)
+                    {
+                        retValue = Type.GetType(xmlReader.ReadString());
+                        xmlReader.Read(); // need to move to next node
+                    }
+                    else
+                    {
+                        if (null == type)
+                        {
+                            type = (typeName == null) ? _dataType : DataStorage.GetType(typeName);
+                        }
+
+                        if (type == typeof(char) || type == typeof(Guid))
+                        { //msdata:char and msdata:guid imply base types.
+                            isBaseCLRType = true;
+                        }
+
+                        if (type == typeof(object))
+                            throw ExceptionBuilder.CanNotDeserializeObjectType();
+                        if (!isBaseCLRType)
+                        {
+                            retValue = System.Activator.CreateInstance(type, true);
+                            Debug.Assert(xmlReader is DataTextReader, "Invalid DataTextReader is being passed to customer");
+                            ((IXmlSerializable)retValue).ReadXml(xmlReader);
+                        }
+                        else
+                        {  // Process Base CLR type
+                           // for Element Node, if it is Empty, ReadString does not move to End Element; we need to move it
+                            if (type == typeof(string) && xmlReader.NodeType == XmlNodeType.Element && xmlReader.IsEmptyElement)
+                            {
+                                retValue = string.Empty;
+                            }
+                            else
+                            {
+                                retValue = xmlReader.ReadString();
+                                if (type != typeof(byte[]))
+                                {
+                                    retValue = SqlConvert.ChangeTypeForXML(retValue, type);
+                                }
+                                else
+                                {
+                                    retValue = Convert.FromBase64String(retValue.ToString());
+                                }
+                            }
+                            xmlReader.Read();
+                        }
+                    }
+                }
+            }
+            else
+            {
+                XmlSerializer deserializerWithRootAttribute = ObjectStorage.GetXmlSerializer(_dataType, xmlAttrib);
+                retValue = deserializerWithRootAttribute.Deserialize(xmlReader);
+            }
+            return retValue;
+        }
+
+        public override string ConvertObjectToXml(object value)
+        {
+            if ((value == null) || (value == _nullValue))// this case won't happen,  this is added in case if code in xml saver changes
+                return string.Empty;
+
+            Type type = _dataType;
+            if (type == typeof(byte[]) || (type == typeof(object) && (value is byte[])))
+            {
+                return Convert.ToBase64String((byte[])value);
+            }
+            if ((type == typeof(Type)) || ((type == typeof(object)) && (value is Type)))
+            {
+                return ((Type)value).AssemblyQualifiedName;
+            }
+
+            if (!IsTypeCustomType(value.GetType()))
+            { // Guid and Type had TypeCode.Object
+                return (string)SqlConvert.ChangeTypeForXML(value, typeof(string));
+            }
+
+            if (Type.GetTypeCode(value.GetType()) != TypeCode.Object)
+            {
+                return value.ToString();
+            }
+
+            StringWriter strwriter = new StringWriter(FormatProvider);
+            if (_implementsIXmlSerializable)
+            {
+                using (XmlTextWriter xmlTextWriter = new XmlTextWriter(strwriter))
+                {
+                    ((IXmlSerializable)value).WriteXml(xmlTextWriter);
+                }
+                return (strwriter.ToString());
+            }
+
+            XmlSerializer serializerWithOutRootAttribute = ObjectStorage.GetXmlSerializer(value.GetType());
+            serializerWithOutRootAttribute.Serialize(strwriter, value);
+            return strwriter.ToString();
+        }
+
+        public override void ConvertObjectToXml(object value, XmlWriter xmlWriter, XmlRootAttribute xmlAttrib)
+        {
+            if (null == xmlAttrib)
+            { // implements IXmlSerializable
+                Debug.Assert(xmlWriter is DataTextWriter, "Invalid DataTextWriter is being passed to customer");
+                ((IXmlSerializable)value).WriteXml(xmlWriter);
+            }
+            else
+            {
+                XmlSerializer serializerWithRootAttribute = ObjectStorage.GetXmlSerializer(value.GetType(), xmlAttrib);
+                serializerWithRootAttribute.Serialize(xmlWriter, value);
+            }
+        }
+
+        protected override object GetEmptyStorage(int recordCount)
+        {
+            return new object[recordCount];
+        }
+
+        protected override void CopyValue(int record, object store, BitArray nullbits, int storeIndex)
+        {
+            object[] typedStore = (object[])store;
+            typedStore[storeIndex] = _values[record];
+            bool isNull = IsNull(record);
+            nullbits.Set(storeIndex, isNull);
+
+            if (!isNull && (typedStore[storeIndex] is DateTime))
+            {
+                DateTime dt = (DateTime)typedStore[storeIndex];
+                if (dt.Kind == DateTimeKind.Local)
+                {
+                    typedStore[storeIndex] = DateTime.SpecifyKind(dt.ToUniversalTime(), DateTimeKind.Local);
+                }
+            }
+        }
+
+        protected override void SetStorage(object store, BitArray nullbits)
+        {
+            _values = (object[])store;
+            for (int i = 0; i < _values.Length; i++)
+            {
+                if (_values[i] is DateTime)
+                {
+                    DateTime dt = (DateTime)_values[i];
+                    if (dt.Kind == DateTimeKind.Local)
+                    {
+                        _values[i] = (DateTime.SpecifyKind(dt, DateTimeKind.Utc)).ToLocalTime();
+                    }
+                }
+            }
+        }
+
+        private static readonly object s_tempAssemblyCacheLock = new object();
+        private static Dictionary<KeyValuePair<Type, XmlRootAttribute>, XmlSerializer> s_tempAssemblyCache;
+        private static readonly XmlSerializerFactory s_serializerFactory = new XmlSerializerFactory();
+
+        /// <summary>
+        /// throw an InvalidOperationException if type implements IDynamicMetaObjectProvider and not IXmlSerializable
+        /// because XmlSerializerFactory will only serialize the type's declared properties, not its dynamic properties
+        /// </summary>
+        /// <param name="type">type to test for IDynamicMetaObjectProvider</param>
+        /// <exception cref="InvalidOperationException">DataSet will not serialize types that implement IDynamicMetaObjectProvider but do not also implement IXmlSerializable</exception>
+        /// <remarks>IDynamicMetaObjectProvider was introduced in .Net Framework V4.0 into System.Core</remarks>
+        internal static void VerifyIDynamicMetaObjectProvider(Type type)
+        {
+            if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type) &&
+               !typeof(IXmlSerializable).IsAssignableFrom(type))
+            {
+                throw ADP.InvalidOperation(SR.Xml_DynamicWithoutXmlSerializable);
+            }
+        }
+
+        internal static XmlSerializer GetXmlSerializer(Type type)
+        {
+            // prevent writing an instance which implements IDynamicMetaObjectProvider and not IXmlSerializable
+            // the check here prevents the instance data from being written
+            VerifyIDynamicMetaObjectProvider(type);
+
+            // use factory which caches XmlSerializer as necessary
+            XmlSerializer serializer = s_serializerFactory.CreateSerializer(type);
+            return serializer;
+        }
+
+        internal static XmlSerializer GetXmlSerializer(Type type, XmlRootAttribute attribute)
+        {
+            XmlSerializer serializer = null;
+            KeyValuePair<Type, XmlRootAttribute> key = new KeyValuePair<Type, XmlRootAttribute>(type, attribute);
+
+            // _tempAssemblyCache is a readonly instance, lock on write to copy & add then replace the original instance.
+            Dictionary<KeyValuePair<Type, XmlRootAttribute>, XmlSerializer> cache = s_tempAssemblyCache;
+            if ((null == cache) || !cache.TryGetValue(key, out serializer))
+            {   // not in cache, try again with lock because it may need to grow
+                lock (s_tempAssemblyCacheLock)
+                {
+                    cache = s_tempAssemblyCache;
+                    if ((null == cache) || !cache.TryGetValue(key, out serializer))
+                    {
+                        // prevent writing an instance which implements IDynamicMetaObjectProvider and not IXmlSerializable
+                        // the check here prevents the instance data from being written
+                        VerifyIDynamicMetaObjectProvider(type);
+
+                        // if still not in cache, make cache larger and add new XmlSerializer
+                        if (null != cache)
+                        {   // create larger cache, because dictionary is not reader/writer safe
+                            // copy cache so that all readers don't take lock - only potential new writers
+                            // same logic used by DbConnectionFactory
+                            Dictionary<KeyValuePair<Type, XmlRootAttribute>, XmlSerializer> tmp =
+                                new Dictionary<KeyValuePair<Type, XmlRootAttribute>, XmlSerializer>(
+                                    1 + cache.Count, TempAssemblyComparer.s_default);
+                            foreach (KeyValuePair<KeyValuePair<Type, XmlRootAttribute>, XmlSerializer> entry in cache)
+                            {   // copy contents from old cache to new cache
+                                tmp.Add(entry.Key, entry.Value);
+                            }
+                            cache = tmp;
+                        }
+                        else
+                        {   // initial creation of cache
+                            cache = new Dictionary<KeyValuePair<Type, XmlRootAttribute>, XmlSerializer>(
+                                TempAssemblyComparer.s_default);
+                        }
+
+                        // attribute is modifiable - but usuage from XmlSaver & XmlDataLoader & XmlDiffLoader 
+                        // the instances are not modified, but to be safe - copy the XmlRootAttribute before caching
+                        key = new KeyValuePair<Type, XmlRootAttribute>(type, new XmlRootAttribute());
+                        key.Value.ElementName = attribute.ElementName;
+                        key.Value.Namespace = attribute.Namespace;
+                        key.Value.DataType = attribute.DataType;
+                        key.Value.IsNullable = attribute.IsNullable;
+
+                        serializer = s_serializerFactory.CreateSerializer(type, attribute);
+                        cache.Add(key, serializer);
+                        s_tempAssemblyCache = cache;
+                    }
+                }
+            }
+            return serializer;
+        }
+
+        private class TempAssemblyComparer : IEqualityComparer<KeyValuePair<Type, XmlRootAttribute>>
+        {
+            internal static readonly IEqualityComparer<KeyValuePair<Type, XmlRootAttribute>> s_default = new TempAssemblyComparer();
+
+            private TempAssemblyComparer() { }
+
+            public bool Equals(KeyValuePair<Type, XmlRootAttribute> x, KeyValuePair<Type, XmlRootAttribute> y)
+            {
+                return ((x.Key == y.Key) &&                                         // same type
+                        (((x.Value == null) && (y.Value == null)) ||                // XmlRootAttribute both null
+                         ((x.Value != null) && (y.Value != null) &&                 // XmlRootAttribute both with value
+                          (x.Value.ElementName == y.Value.ElementName) &&           // all attribute elements are equal
+                          (x.Value.Namespace == y.Value.Namespace) &&
+                          (x.Value.DataType == y.Value.DataType) &&
+                          (x.Value.IsNullable == y.Value.IsNullable))));
+            }
+
+            public int GetHashCode(KeyValuePair<Type, XmlRootAttribute> obj)
+            {
+                return unchecked(obj.Key.GetHashCode() + obj.Value.ElementName.GetHashCode());
+            }
+        }
+    }
+}
+

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -406,6 +406,9 @@ namespace System.Data.Common
 
                         if (type == typeof(object))
                             throw ExceptionBuilder.CanNotDeserializeObjectType();
+
+                        TypeLimiter.EnsureTypeIsAllowed(type);
+
                         if (!isBaseCLRType)
                         {
                             retValue = System.Activator.CreateInstance(type, true);

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataColumn.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataColumn.cs
@@ -1,0 +1,2057 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml;
+using System.Data.Common;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Data.SqlTypes;
+using System.Xml.Serialization;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Threading;
+using System.Numerics;
+using System.Reflection;
+using System.Collections;
+
+namespace System.Data
+{
+    /// <summary>
+    /// Represents one column of data in a <see cref='System.Data.DataTable'/>.
+    /// </summary>
+    [ToolboxItem(false)]
+    [DesignTimeVisible(false)]
+    [DefaultProperty(nameof(ColumnName))]
+    public class DataColumn : MarshalByValueComponent
+    {
+        private bool _allowNull = true;
+        private string _caption = null;
+        private string _columnName = null;
+        private Type _dataType = null;
+        private StorageType _storageType;
+        internal object _defaultValue = DBNull.Value; // DefaultValue Converter
+        private DataSetDateTime _dateTimeMode = DataSetDateTime.UnspecifiedLocal;
+        private DataExpression _expression = null;
+        private int _maxLength = -1;
+        private int _ordinal = -1;
+        private bool _readOnly = false;
+        internal Index _sortIndex = null;
+        internal DataTable _table = null;
+        private bool _unique = false;
+        internal MappingType _columnMapping = MappingType.Element;
+        internal int _hashCode;
+
+        internal int _errors;
+        private bool _isSqlType = false;
+        private bool _implementsINullable = false;
+        private bool _implementsIChangeTracking = false;
+        private bool _implementsIRevertibleChangeTracking = false;
+        private bool _implementsIXMLSerializable = false;
+
+        private bool _defaultValueIsNull = true;
+
+        internal List<DataColumn> _dependentColumns = null; // list of columns whose expression consume values from this column
+        internal PropertyCollection _extendedProperties = null;
+
+        private DataStorage _storage;
+
+        /// <summary>represents current value to return, usage pattern is .get_Current then MoveAfter</summary>
+        private AutoIncrementValue _autoInc;
+
+        // The _columnClass member is the class for the unfoliated virtual nodes in the XML.
+        internal string _columnUri = null;
+        private string _columnPrefix = string.Empty;
+        internal string _encodedColumnName = null;
+
+        internal SimpleType _simpleType = null;
+
+        private static int s_objectTypeCount;
+        private readonly int _objectID = Interlocked.Increment(ref s_objectTypeCount);
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref='System.Data.DataColumn'/>
+        /// class.
+        /// </summary>
+        public DataColumn() : this(null, typeof(string), null, MappingType.Element)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DataColumn'/> class
+        /// using the specified column name.
+        /// </summary>
+        public DataColumn(string columnName) : this(columnName, typeof(string), null, MappingType.Element)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DataColumn'/> class
+        /// using the specified column name and data type.
+        /// </summary>
+        public DataColumn(string columnName, Type dataType) : this(columnName, dataType, null, MappingType.Element)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance
+        /// of the <see cref='System.Data.DataColumn'/> class
+        /// using the specified name, data type, and expression.
+        /// </summary>
+        public DataColumn(string columnName, Type dataType, string expr) : this(columnName, dataType, expr, MappingType.Element)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DataColumn'/> class
+        /// using
+        /// the specified name, data type, expression, and value that determines whether the
+        /// column is an attribute.
+        /// </summary>
+        public DataColumn(string columnName, Type dataType, string expr, MappingType type)
+        {
+            GC.SuppressFinalize(this);
+            DataCommonEventSource.Log.Trace("<ds.DataColumn.DataColumn|API> {0}, columnName='{1}', expr='{2}', type={3}", ObjectID, columnName, expr, type);
+
+            if (dataType == null)
+            {
+                throw ExceptionBuilder.ArgumentNull(nameof(dataType));
+            }
+
+            StorageType typeCode = DataStorage.GetStorageType(dataType);
+            if (DataStorage.ImplementsINullableValue(typeCode, dataType))
+            {
+                throw ExceptionBuilder.ColumnTypeNotSupported();
+            }
+            _columnName = columnName ?? string.Empty;
+
+            SimpleType stype = SimpleType.CreateSimpleType(typeCode, dataType);
+            if (null != stype)
+            {
+                SimpleType = stype;
+            }
+            UpdateColumnType(dataType, typeCode);
+
+            if (!string.IsNullOrEmpty(expr)) // its a performance hit to set Expression to the empty str when we know it will come out null
+            {
+                Expression = expr;
+            }
+
+            _columnMapping = type;
+        }
+
+        private void UpdateColumnType(Type type, StorageType typeCode)
+        {
+            _dataType = type;
+            _storageType = typeCode;
+            if (StorageType.DateTime != typeCode)
+            {
+                // revert _dateTimeMode back to default, when column type is changed
+                _dateTimeMode = DataSetDateTime.UnspecifiedLocal;
+            }
+
+            DataStorage.ImplementsInterfaces(
+                                typeCode, type,
+                                out _isSqlType,
+                                out _implementsINullable,
+                                out _implementsIXMLSerializable,
+                                out _implementsIChangeTracking,
+                                out _implementsIRevertibleChangeTracking);
+
+            if (!_isSqlType && _implementsINullable)
+            {
+                SqlUdtStorage.GetStaticNullForUdtType(type);
+            }
+        }
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether null
+        /// values are
+        /// allowed in this column for rows belonging to the table.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool AllowDBNull
+        {
+            get { return _allowNull; }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataColumn.set_AllowDBNull|API> {0}, {1}", ObjectID, value);
+                try
+                {
+                    if (_allowNull != value)
+                    {
+                        if (_table != null)
+                        {
+                            if (!value && _table.EnforceConstraints)
+                            {
+                                CheckNotAllowNull();
+                            }
+                        }
+                        _allowNull = value;
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the column automatically increments the value of the column for new
+        /// rows added to the table.
+        /// </summary>
+        [DefaultValue(false)]
+        [RefreshProperties(RefreshProperties.All)]
+        public bool AutoIncrement
+        {
+            get { return ((null != _autoInc) && (_autoInc.Auto)); }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_AutoIncrement|API> {0}, {1}", ObjectID, value);
+                if (AutoIncrement != value)
+                {
+                    if (value)
+                    {
+                        if (_expression != null)
+                        {
+                            throw ExceptionBuilder.AutoIncrementAndExpression();
+                        }
+
+                        if (!DefaultValueIsNull)
+                        {
+                            throw ExceptionBuilder.AutoIncrementAndDefaultValue();
+                        }
+
+                        if (!IsAutoIncrementType(DataType))
+                        {
+                            if (HasData)
+                            {
+                                throw ExceptionBuilder.AutoIncrementCannotSetIfHasData(DataType.Name);
+                            }
+
+                            DataType = typeof(int);
+                        }
+                    }
+
+                    AutoInc.Auto = value;
+                }
+            }
+        }
+
+        internal object AutoIncrementCurrent
+        {
+            get { return ((null != _autoInc) ? _autoInc.Current : AutoIncrementSeed); }
+            set
+            {
+                if ((BigInteger)AutoIncrementSeed != BigIntegerStorage.ConvertToBigInteger(value, FormatProvider))
+                {
+                    AutoInc.SetCurrent(value, FormatProvider);
+                }
+            }
+        }
+
+        internal AutoIncrementValue AutoInc =>
+            (_autoInc ?? (_autoInc = ((DataType == typeof(BigInteger)) ?
+                (AutoIncrementValue)new AutoIncrementBigInteger() :
+                new AutoIncrementInt64())));
+
+
+        /// <summary>
+        /// Gets or sets the starting value for a column that has its
+        /// <see cref='System.Data.DataColumn.AutoIncrement'/> property set to <see langword='true'/>.
+        /// </summary>
+        [DefaultValue((long)0)]
+        public long AutoIncrementSeed
+        {
+            get { return ((null != _autoInc) ? _autoInc.Seed : 0L); }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_AutoIncrementSeed|API> {0}, {1}", ObjectID, value);
+                if (AutoIncrementSeed != value)
+                {
+                    AutoInc.Seed = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the increment used by a column with its <see cref='System.Data.DataColumn.AutoIncrement'/>
+        /// property set to <see langword='true'/>
+        /// </summary>
+        [DefaultValue((long)1)]
+        public long AutoIncrementStep
+        {
+            get { return ((null != _autoInc) ? _autoInc.Step : 1L); }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_AutoIncrementStep|API> {0}, {1}", ObjectID, value);
+                if (AutoIncrementStep != value)
+                {
+                    AutoInc.Step = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets
+        /// the caption for this column.
+        /// </summary>
+        public string Caption
+        {
+            get { return (_caption != null) ? _caption : _columnName; }
+            set
+            {
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
+                if (_caption == null || string.Compare(_caption, value, true, Locale) != 0)
+                {
+                    _caption = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resets the <see cref='System.Data.DataColumn.Caption'/> property to its previous value, or
+        /// to <see langword='null'/> .
+        /// </summary>
+        private void ResetCaption()
+        {
+            if (_caption != null)
+            {
+                _caption = null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref='System.Data.DataColumn.Caption'/> has been explicitly set.
+        /// </summary>
+        private bool ShouldSerializeCaption() => _caption != null;
+
+        /// <summary>
+        /// Gets or sets the name of the column within the <see cref='System.Data.DataColumnCollection'/>.
+        /// </summary>
+        [RefreshProperties(RefreshProperties.All)]
+        [DefaultValue("")]
+        public string ColumnName
+        {
+            get { return _columnName; }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataColumn.set_ColumnName|API> {0}, '{1}'", ObjectID, value);
+                try
+                {
+                    if (value == null)
+                    {
+                        value = string.Empty;
+                    }
+
+                    if (string.Compare(_columnName, value, true, Locale) != 0)
+                    {
+                        if (_table != null)
+                        {
+                            if (value.Length == 0)
+                            {
+                                throw ExceptionBuilder.ColumnNameRequired();
+                            }
+
+                            _table.Columns.RegisterColumnName(value, this);
+                            if (_columnName.Length != 0)
+                            {
+                                _table.Columns.UnregisterName(_columnName);
+                            }
+                        }
+
+                        RaisePropertyChanging(nameof(ColumnName));
+                        _columnName = value;
+                        _encodedColumnName = null;
+                        if (_table != null)
+                        {
+                            _table.Columns.OnColumnPropertyChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, this));
+                        }
+                    }
+                    else if (_columnName != value)
+                    {
+                        RaisePropertyChanging(nameof(ColumnName));
+                        _columnName = value;
+                        _encodedColumnName = null;
+                        if (_table != null)
+                        {
+                            _table.Columns.OnColumnPropertyChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, this));
+                        }
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        internal string EncodedColumnName
+        {
+            get
+            {
+                if (_encodedColumnName == null)
+                {
+                    _encodedColumnName = XmlConvert.EncodeLocalName(ColumnName);
+                }
+
+                Debug.Assert(!string.IsNullOrEmpty(_encodedColumnName));
+                return _encodedColumnName;
+            }
+        }
+
+        internal IFormatProvider FormatProvider =>
+            // used for formating/parsing not comparing
+            ((null != _table) ? _table.FormatProvider : CultureInfo.CurrentCulture);
+
+        internal CultureInfo Locale =>
+            // used for comparing not formating/parsing
+            ((null != _table) ? _table.Locale : CultureInfo.CurrentCulture);
+
+        internal int ObjectID => _objectID;
+
+        [DefaultValue("")]
+        public string Prefix
+        {
+            get { return _columnPrefix; }
+            set
+            {
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_Prefix|API> {0}, '{1}'", ObjectID, value);
+
+                if ((XmlConvert.DecodeName(value) == value) && (XmlConvert.EncodeName(value) != value))
+                {
+                    throw ExceptionBuilder.InvalidPrefix(value);
+                }
+
+                _columnPrefix = value;
+            }
+        }
+
+        // Return the field value as a string. If the field value is NULL, then NULL is return.
+        // If the column type is string and it's value is empty, then the empty string is returned.
+        // If the column type is not string, or the column type is string and the value is not empty string, then a non-empty string is returned
+        // This method does not throw any formatting exceptions, since we can always format the field value to a string.
+        internal string GetColumnValueAsString(DataRow row, DataRowVersion version)
+        {
+            object objValue = this[row.GetRecordFromVersion(version)];
+
+            if (DataStorage.IsObjectNull(objValue))
+            {
+                return null;
+            }
+
+            string value = ConvertObjectToXml(objValue);
+            Debug.Assert(value != null);
+            return value;
+        }
+
+        /// <summary>
+        /// Whether this column computes values.
+        /// </summary>
+        internal bool Computed => _expression != null;
+
+        /// <summary>
+        /// The internal expression object that computes the values.
+        /// </summary>
+        internal DataExpression DataExpression => _expression;
+
+        /// <summary>
+        /// The type of data stored in the column.
+        /// </summary>
+        [DefaultValue(typeof(string))]
+        [RefreshProperties(RefreshProperties.All)]
+        [TypeConverter(typeof(ColumnTypeConverter))]
+        public Type DataType
+        {
+            get { return _dataType; }
+            set
+            {
+                if (_dataType != value)
+                {
+                    if (HasData)
+                    {
+                        throw ExceptionBuilder.CantChangeDataType();
+                    }
+                    if (value == null)
+                    {
+                        throw ExceptionBuilder.NullDataType();
+                    }
+                    StorageType typeCode = DataStorage.GetStorageType(value);
+                    if (DataStorage.ImplementsINullableValue(typeCode, value))
+                    {
+                        throw ExceptionBuilder.ColumnTypeNotSupported();
+                    }
+                    if (_table != null && IsInRelation())
+                    {
+                        throw ExceptionBuilder.ColumnsTypeMismatch();
+                    }
+                    if (typeCode == StorageType.BigInteger && _expression != null)
+                    {
+                        throw ExprException.UnsupportedDataType(value);
+                    }
+
+                    // If the DefualtValue is different from the Column DataType, we will coerce the value to the DataType
+                    if (!DefaultValueIsNull)
+                    {
+                        try
+                        {
+                            if (_defaultValue is BigInteger)
+                            {
+                                _defaultValue = BigIntegerStorage.ConvertFromBigInteger((BigInteger)_defaultValue, value, FormatProvider);
+                            }
+                            else if (typeof(BigInteger) == value)
+                            {
+                                _defaultValue = BigIntegerStorage.ConvertToBigInteger(_defaultValue, FormatProvider);
+                            }
+                            else if (typeof(string) == value)
+                            {
+                                // since string types can be null in value! DO NOT REMOVE THIS CHECK
+                                _defaultValue = DefaultValue.ToString();
+                            }
+                            else if (typeof(SqlString) == value)
+                            {
+                                // since string types can be null in value! DO NOT REMOVE THIS CHECK
+                                _defaultValue = SqlConvert.ConvertToSqlString(DefaultValue);
+                            }
+                            else if (typeof(object) != value)
+                            {
+                                DefaultValue = SqlConvert.ChangeTypeForDefaultValue(DefaultValue, value, FormatProvider);
+                            }
+                        }
+                        catch (InvalidCastException ex)
+                        {
+                            throw ExceptionBuilder.DefaultValueDataType(ColumnName, DefaultValue.GetType(), value, ex);
+                        }
+                        catch (FormatException ex)
+                        {
+                            throw ExceptionBuilder.DefaultValueDataType(ColumnName, DefaultValue.GetType(), value, ex);
+                        }
+                    }
+
+                    if (ColumnMapping == MappingType.SimpleContent)
+                    {
+                        if (value == typeof(char))
+                        {
+                            throw ExceptionBuilder.CannotSetSimpleContentType(ColumnName, value);
+                        }
+                    }
+
+                    SimpleType = SimpleType.CreateSimpleType(typeCode, value);
+                    if (StorageType.String == typeCode)
+                    {
+                        _maxLength = -1;
+                    }
+
+                    UpdateColumnType(value, typeCode);
+                    XmlDataType = null;
+
+                    if (AutoIncrement)
+                    {
+                        if (!IsAutoIncrementType(value))
+                        {
+                            AutoIncrement = false;
+                        }
+
+                        if (null != _autoInc)
+                        {
+                            // if you already have data you can't change the data type
+                            // if you don't have data - you wouldn't have incremented AutoIncrementCurrent.
+                            AutoIncrementValue inc = _autoInc;
+                            _autoInc = null;
+                            AutoInc.Auto = inc.Auto; // recreate with correct datatype
+                            AutoInc.Seed = inc.Seed;
+                            AutoInc.Step = inc.Step;
+                            if (_autoInc.DataType == inc.DataType)
+                            {
+                                _autoInc.Current = inc.Current;
+                            }
+                            else if (inc.DataType == typeof(long))
+                            {
+                                AutoInc.Current = (BigInteger)(long)inc.Current;
+                            }
+                            else
+                            {
+                                AutoInc.Current = checked((long)(BigInteger)inc.Current);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [DefaultValue(DataSetDateTime.UnspecifiedLocal)]
+        [RefreshProperties(RefreshProperties.All)]
+        public DataSetDateTime DateTimeMode
+        {
+            get { return _dateTimeMode; }
+            set
+            {
+                if (_dateTimeMode != value)
+                {
+                    if (DataType != typeof(DateTime) && value != DataSetDateTime.UnspecifiedLocal)
+                    {
+                        //Check for column being DateTime. If the column is not DateTime make sure the value that is being is only the default[UnspecifiedLocal].
+                        throw ExceptionBuilder.CannotSetDateTimeModeForNonDateTimeColumns();
+                    }
+                    switch (value)
+                    {
+                        case DataSetDateTime.Utc:
+                        case DataSetDateTime.Local:
+                            if (HasData)
+                            {
+                                throw ExceptionBuilder.CantChangeDateTimeMode(_dateTimeMode, value);
+                            }
+                            break;
+                        case DataSetDateTime.Unspecified:
+                        case DataSetDateTime.UnspecifiedLocal:
+                            if (_dateTimeMode == DataSetDateTime.Unspecified || _dateTimeMode == DataSetDateTime.UnspecifiedLocal)
+                            {
+                                break;
+                            }
+                            if (HasData)
+                            {
+                                throw ExceptionBuilder.CantChangeDateTimeMode(_dateTimeMode, value);
+                            }
+                            break;
+                        default:
+                            throw ExceptionBuilder.InvalidDateTimeMode(value);
+                    }
+                    _dateTimeMode = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the default value for the column when creating new rows.
+        /// </summary>
+        [TypeConverter(typeof(DefaultValueTypeConverter))]
+        public object DefaultValue
+        {
+            get
+            {
+                Debug.Assert(_defaultValue != null, "It should not have been set to null.");
+                if (_defaultValue == DBNull.Value && _implementsINullable)
+                {
+                    // for perf I dont access property
+                    if (_storage != null)
+                    {
+                        _defaultValue = _storage._nullValue;
+                    }
+                    else if (_isSqlType)
+                    {
+                        _defaultValue = SqlConvert.ChangeTypeForDefaultValue(_defaultValue, _dataType, FormatProvider);
+                    }
+                    else if (_implementsINullable)
+                    {
+                        PropertyInfo propInfo = _dataType.GetProperty("Null", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        if (propInfo != null)
+                        {
+                            _defaultValue = propInfo.GetValue(null, null);
+                        }
+                    }
+                }
+
+                return _defaultValue;
+            }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_DefaultValue|API> {0}", ObjectID);
+                if (_defaultValue == null || !DefaultValue.Equals(value))
+                {
+                    if (AutoIncrement)
+                    {
+                        throw ExceptionBuilder.DefaultValueAndAutoIncrement();
+                    }
+
+                    object newDefaultValue = (value == null) ? DBNull.Value : value;
+                    if (newDefaultValue != DBNull.Value && DataType != typeof(object))
+                    {
+                        // If the DefualtValue is different from the Column DataType, we will coerce the value to the DataType
+                        try
+                        {
+                            newDefaultValue = SqlConvert.ChangeTypeForDefaultValue(newDefaultValue, DataType, FormatProvider);
+                        }
+                        catch (InvalidCastException ex)
+                        {
+                            throw ExceptionBuilder.DefaultValueColumnDataType(ColumnName, newDefaultValue.GetType(), DataType, ex);
+                        }
+                    }
+                    _defaultValue = newDefaultValue;
+                    _defaultValueIsNull = ((newDefaultValue == DBNull.Value) || (ImplementsINullable && DataStorage.IsObjectSqlNull(newDefaultValue))) ? true : false;
+                }
+            }
+        }
+
+        internal bool DefaultValueIsNull => _defaultValueIsNull;
+
+        internal void BindExpression() => DataExpression.Bind(_table);
+
+        /// <summary>
+        /// Gets or sets the expression used to either filter rows, calculate the column's
+        /// value, or create an aggregate column.
+        /// </summary>
+        [RefreshProperties(RefreshProperties.All)]
+        [DefaultValue("")]
+        public string Expression
+        {
+            get { return (_expression == null ? "" : _expression.Expression); }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataColumn.set_Expression|API> {0}, '{1}'", ObjectID, value);
+
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
+                try
+                {
+                    DataExpression newExpression = null;
+                    if (value.Length > 0)
+                    {
+                        DataExpression testExpression = new DataExpression(_table, value, _dataType);
+                        if (testExpression.HasValue)
+                        {
+                            newExpression = testExpression;
+                        }
+                    }
+
+                    if (_expression == null && newExpression != null)
+                    {
+                        if (AutoIncrement || Unique)
+                        {
+                            throw ExceptionBuilder.ExpressionAndUnique();
+                        }
+
+                        // We need to make sure the column is not involved in any Constriants
+                        if (_table != null)
+                        {
+                            for (int i = 0; i < _table.Constraints.Count; i++)
+                            {
+                                if (_table.Constraints[i].ContainsColumn(this))
+                                {
+                                    throw ExceptionBuilder.ExpressionAndConstraint(this, _table.Constraints[i]);
+                                }
+                            }
+                        }
+
+                        bool oldReadOnly = ReadOnly;
+                        try
+                        {
+                            ReadOnly = true;
+                        }
+                        catch (ReadOnlyException e)
+                        {
+                            ExceptionBuilder.TraceExceptionForCapture(e);
+                            ReadOnly = oldReadOnly;
+                            throw ExceptionBuilder.ExpressionAndReadOnly();
+                        }
+                    }
+
+                    // re-calculate the evaluation queue
+                    if (_table != null)
+                    {
+                        if (newExpression != null && newExpression.DependsOn(this))
+                        {
+                            throw ExceptionBuilder.ExpressionCircular();
+                        }
+
+                        HandleDependentColumnList(_expression, newExpression);
+                        //hold onto oldExpression in case of error applying new Expression.
+                        DataExpression oldExpression = _expression;
+                        _expression = newExpression;
+
+                        // because the column is attached to a table we need to re-calc values
+                        try
+                        {
+                            if (newExpression == null)
+                            {
+                                for (int i = 0; i < _table.RecordCapacity; i++)
+                                {
+                                    InitializeRecord(i);
+                                }
+                            }
+                            else
+                            {
+                                _table.EvaluateExpressions(this);
+                            }
+
+                            _table.ResetInternalIndexes(this);
+                            _table.EvaluateDependentExpressions(this);
+                        }
+                        catch (Exception e1) when (ADP.IsCatchableExceptionType(e1))
+                        {
+                            ExceptionBuilder.TraceExceptionForCapture(e1);
+                            try
+                            {
+                                // in the case of error we need to set the column expression to the old value
+                                _expression = oldExpression;
+                                HandleDependentColumnList(newExpression, _expression);
+                                if (oldExpression == null)
+                                {
+                                    for (int i = 0; i < _table.RecordCapacity; i++)
+                                    {
+                                        InitializeRecord(i);
+                                    }
+                                }
+                                else
+                                {
+                                    _table.EvaluateExpressions(this);
+                                }
+                                _table.ResetInternalIndexes(this);
+                                _table.EvaluateDependentExpressions(this);
+                            }
+                            catch (Exception e2) when (ADP.IsCatchableExceptionType(e2))
+                            {
+                                ExceptionBuilder.TraceExceptionWithoutRethrow(e2);
+                            }
+                            throw;
+                        }
+                    }
+                    else
+                    {
+                        //if column is not attached to a table, just set.
+                        _expression = newExpression;
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection of custom user information.
+        /// </summary>
+        [Browsable(false)]
+        public PropertyCollection ExtendedProperties => _extendedProperties ?? (_extendedProperties = new PropertyCollection());
+
+        /// <summary>
+        /// Indicates whether this column is now storing data.
+        /// </summary>
+        internal bool HasData => _storage != null;
+
+        internal bool ImplementsINullable => _implementsINullable;
+
+        internal bool ImplementsIChangeTracking => _implementsIChangeTracking;
+
+        internal bool ImplementsIRevertibleChangeTracking => _implementsIRevertibleChangeTracking;
+
+        internal bool IsCloneable
+        {
+            get
+            {
+                Debug.Assert(null != _storage, "no storage");
+                return _storage._isCloneable;
+            }
+        }
+
+        internal bool IsStringType
+        {
+            get
+            {
+                Debug.Assert(null != _storage, "no storage");
+                return _storage._isStringType;
+            }
+        }
+
+        internal bool IsValueType
+        {
+            get
+            {
+                Debug.Assert(null != _storage, "no storage");
+                return _storage._isValueType;
+            }
+        }
+
+        internal bool IsSqlType => _isSqlType;
+
+        private void SetMaxLengthSimpleType()
+        {
+            if (_simpleType != null)
+            {
+                Debug.Assert(_simpleType.CanHaveMaxLength(), "expected simpleType to be string");
+
+                _simpleType.MaxLength = _maxLength;
+
+                // check if we reset the simpleType back to plain string
+                if (_simpleType.IsPlainString())
+                {
+                    _simpleType = null;
+                }
+                else
+                {
+                    // Named Simple Type's Name should not be null
+                    if (_simpleType.Name != null && XmlDataType != null)
+                    {
+                        // if MaxLength is changed, we need to make  namedsimpletype annonymous simpletype
+                        _simpleType.ConvertToAnnonymousSimpleType();
+                        XmlDataType = null;
+                    }
+                }
+            }
+            else if (-1 < _maxLength)
+            {
+                SimpleType = SimpleType.CreateLimitedStringType(_maxLength);
+            }
+        }
+
+        [DefaultValue(-1)]
+        public int MaxLength
+        {
+            get { return _maxLength; }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataColumn.set_MaxLength|API> {0}, {1}", ObjectID, value);
+                try
+                {
+                    if (_maxLength != value)
+                    {
+                        if (ColumnMapping == MappingType.SimpleContent)
+                        {
+                            throw ExceptionBuilder.CannotSetMaxLength2(this);
+                        }
+                        if ((DataType != typeof(string)) && (DataType != typeof(SqlString)))
+                        {
+                            throw ExceptionBuilder.HasToBeStringType(this);
+                        }
+                        int oldValue = _maxLength;
+                        _maxLength = Math.Max(value, -1);
+
+                        if (((oldValue < 0) || (value < oldValue)) && (null != _table) && _table.EnforceConstraints)
+                        {
+                            if (!CheckMaxLength())
+                            {
+                                _maxLength = oldValue;
+                                throw ExceptionBuilder.CannotSetMaxLength(this, value);
+                            }
+                        }
+                        SetMaxLengthSimpleType();
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        public string Namespace
+        {
+            get
+            {
+                if (_columnUri == null)
+                {
+                    if (Table != null && _columnMapping != MappingType.Attribute)
+                    {
+                        return Table.Namespace;
+                    }
+                    return string.Empty;
+                }
+                return _columnUri;
+            }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_Namespace|API> {0}, '{1}'", ObjectID, value);
+
+                if (_columnUri != value)
+                {
+                    if (_columnMapping != MappingType.SimpleContent)
+                    {
+                        RaisePropertyChanging(nameof(Namespace));
+                        _columnUri = value;
+                    }
+                    else if (value != Namespace)
+                    {
+                        throw ExceptionBuilder.CannotChangeNamespace(ColumnName);
+                    }
+                }
+            }
+        }
+
+        private bool ShouldSerializeNamespace() => _columnUri != null;
+
+        private void ResetNamespace() => Namespace = null;
+
+        /// <summary>
+        /// Gets the position of the column in the <see cref='System.Data.DataColumnCollection'/>
+        /// collection.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int Ordinal => _ordinal;
+
+        public void SetOrdinal(int ordinal)
+        {
+            if (_ordinal == -1)
+            {
+                throw ExceptionBuilder.ColumnNotInAnyTable();
+            }
+
+            if (_ordinal != ordinal)
+            {
+                _table.Columns.MoveTo(this, ordinal);
+            }
+        }
+
+        internal void SetOrdinalInternal(int ordinal)
+        {
+            if (_ordinal != ordinal)
+            {
+                if (Unique && _ordinal != -1 && ordinal == -1)
+                {
+                    UniqueConstraint key = _table.Constraints.FindKeyConstraint(this);
+                    if (key != null)
+                    {
+                        _table.Constraints.Remove(key);
+                    }
+                }
+
+                if ((null != _sortIndex) && (-1 == ordinal))
+                {
+                    Debug.Assert(2 <= _sortIndex.RefCount, "bad sortIndex refcount");
+                    _sortIndex.RemoveRef();
+                    _sortIndex.RemoveRef(); // second should remove it from index collection
+                    _sortIndex = null;
+                }
+
+                int originalOrdinal = _ordinal;
+                _ordinal = ordinal;
+                if (originalOrdinal == -1 && _ordinal != -1)
+                {
+                    if (Unique)
+                    {
+                        UniqueConstraint key = new UniqueConstraint(this);
+                        _table.Constraints.Add(key);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value
+        /// indicating whether the column allows changes once a row has been added to the table.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool ReadOnly
+        {
+            get { return _readOnly; }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_ReadOnly|API> {0}, {1}", ObjectID, value);
+                if (_readOnly != value)
+                {
+                    if (!value && _expression != null)
+                    {
+                        throw ExceptionBuilder.ReadOnlyAndExpression();
+                    }
+                    _readOnly = value;
+                }
+            }
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)] // don't have debugger view expand this
+        private Index SortIndex
+        {
+            get
+            {
+                if (_sortIndex == null)
+                {
+                    var indexDesc = new IndexField[] { new IndexField(this, false) };
+                    _sortIndex = _table.GetIndex(indexDesc, DataViewRowState.CurrentRows, null);
+                    _sortIndex.AddRef();
+                }
+                return _sortIndex;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref='System.Data.DataTable'/> to which the column belongs to.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public DataTable Table => _table;
+
+        /// <summary>
+        /// Internal mechanism for changing the table pointer.
+        /// </summary>
+        internal void SetTable(DataTable table)
+        {
+            if (_table != table)
+            {
+                if (Computed)
+                {
+                    if ((table == null) || (!table.fInitInProgress && ((table.DataSet == null) || (!table.DataSet._fIsSchemaLoading && !table.DataSet._fInitInProgress))))
+                    {
+                        // We need to re-bind all expression columns.
+                        DataExpression.Bind(table);
+                    }
+                }
+
+                if (Unique && _table != null)
+                {
+                    UniqueConstraint constraint = table.Constraints.FindKeyConstraint(this);
+                    if (constraint != null)
+                    {
+                        table.Constraints.CanRemove(constraint, true);
+                    }
+                }
+                _table = table;
+                _storage = null; // empty out storage for reuse.
+            }
+        }
+
+        private DataRow GetDataRow(int index) => _table._recordManager[index];
+
+        /// <summary>
+        /// This is how data is pushed in and out of the column.
+        /// </summary>
+        internal object this[int record]
+        {
+            get
+            {
+                _table._recordManager.VerifyRecord(record);
+                Debug.Assert(null != _storage, "null storage");
+                return _storage.Get(record);
+            }
+            set
+            {
+                try
+                {
+                    _table._recordManager.VerifyRecord(record);
+                    Debug.Assert(null != _storage, "no storage");
+                    Debug.Assert(null != value, "setting null, expecting dbnull");
+                    _storage.Set(record, value);
+                    Debug.Assert(null != _table, "storage with no DataTable on column");
+                }
+                catch (Exception e)
+                {
+                    ExceptionBuilder.TraceExceptionForCapture(e);
+                    throw ExceptionBuilder.SetFailed(value, this, DataType, e);
+                }
+
+                if (AutoIncrement)
+                {
+                    if (!_storage.IsNull(record))
+                    {
+                        AutoInc.SetCurrentAndIncrement(_storage.Get(record));
+                    }
+                }
+                if (Computed)
+                {
+                    // if and only if it is Expression column, we will cache LastChangedColumn, otherwise DO NOT
+                    DataRow dr = GetDataRow(record);
+                    if (dr != null)
+                    {
+                        // at initialization time (datatable.NewRow(), we would fill the storage with default value, but at that time we won't have datarow)
+                        dr.LastChangedColumn = this;
+                    }
+                }
+            }
+        }
+
+        internal void InitializeRecord(int record)
+        {
+            Debug.Assert(null != _storage, "no storage");
+            _storage.Set(record, DefaultValue);
+        }
+
+        internal void SetValue(int record, object value)
+        {
+            // just silently set the value
+            try
+            {
+                Debug.Assert(null != value, "setting null, expecting dbnull");
+                Debug.Assert(null != _table, "storage with no DataTable on column");
+                Debug.Assert(null != _storage, "no storage");
+                _storage.Set(record, value);
+            }
+            catch (Exception e)
+            {
+                ExceptionBuilder.TraceExceptionForCapture(e);
+                throw ExceptionBuilder.SetFailed(value, this, DataType, e);
+            }
+
+            DataRow dr = GetDataRow(record);
+            if (dr != null)
+            {  // at initialization time (datatable.NewRow(), we would fill the storage with default value, but at that time we won't have datarow)
+                dr.LastChangedColumn = this;
+            }
+        }
+
+        internal void FreeRecord(int record)
+        {
+            Debug.Assert(null != _storage, "no storage");
+            _storage.Set(record, _storage._nullValue);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the values in each row of the column must be unique.
+        /// </summary>
+        [DefaultValue(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool Unique
+        {
+            get { return _unique; }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataColumn.set_Unique|API> {0}, {1}", ObjectID, value);
+                try
+                {
+                    if (_unique != value)
+                    {
+                        if (value && _expression != null)
+                        {
+                            throw ExceptionBuilder.UniqueAndExpression();
+                        }
+
+                        UniqueConstraint oldConstraint = null;
+                        if (_table != null)
+                        {
+                            if (value)
+                            {
+                                CheckUnique();
+                            }
+                            else
+                            {
+                                for (IEnumerator e = Table.Constraints.GetEnumerator(); e.MoveNext();)
+                                {
+                                    UniqueConstraint o = (e.Current as UniqueConstraint);
+                                    if ((null != o) && (o.ColumnsReference.Length == 1) && (o.ColumnsReference[0] == this))
+                                        oldConstraint = o;
+                                }
+                                Debug.Assert(oldConstraint != null, "Should have found a column to remove from the collection.");
+                                _table.Constraints.CanRemove(oldConstraint, true);
+                            }
+                        }
+
+                        _unique = value;
+
+                        if (_table != null)
+                        {
+                            if (value)
+                            {
+                                // This should not fail due to a duplicate constraint. unique would have
+                                // already been true if there was an existed UniqueConstraint for this column
+
+                                UniqueConstraint constraint = new UniqueConstraint(this);
+                                Debug.Assert(_table.Constraints.FindKeyConstraint(this) == null, "Should not be a duplication constraint in collection");
+                                _table.Constraints.Add(constraint);
+                            }
+                            else
+                            {
+                                _table.Constraints.Remove(oldConstraint);
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+
+        internal void InternalUnique(bool value) => _unique = value;
+
+        internal string XmlDataType { get; set; } = string.Empty; // The type specified in dt:type attribute
+
+        internal SimpleType SimpleType
+        {
+            get { return _simpleType; }
+            set
+            {
+                _simpleType = value;
+
+                // there is a change, since we are supporting hierarchy(bacause of Names Simple Type) old check (just one leel base check) is wrong
+                if (value != null && value.CanHaveMaxLength())
+                {
+                    _maxLength = _simpleType.MaxLength;// this is temp solution, since we dont let simple content to have
+                }
+
+                //maxlength set but for simple type we want to set it, after coming to decision about it , we should
+                // use MaxLength property
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref='System.Data.MappingType'/> of the column.
+        /// </summary>
+        [DefaultValue(MappingType.Element)]
+        public virtual MappingType ColumnMapping
+        {
+            get { return _columnMapping; }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataColumn.set_ColumnMapping|API> {0}, {1}", ObjectID, value);
+                if (value != _columnMapping)
+                {
+                    if (value == MappingType.SimpleContent && _table != null)
+                    {
+                        int threshold = 0;
+                        if (_columnMapping == MappingType.Element)
+                        {
+                            threshold = 1;
+                        }
+                        if (_dataType == typeof(char))
+                        {
+                            throw ExceptionBuilder.CannotSetSimpleContent(ColumnName, _dataType);
+                        }
+
+                        if (_table.XmlText != null && _table.XmlText != this)
+                        {
+                            throw ExceptionBuilder.CannotAddColumn3();
+                        }
+                        if (_table.ElementColumnCount > threshold)
+                        {
+                            throw ExceptionBuilder.CannotAddColumn4(ColumnName);
+                        }
+                    }
+
+                    RaisePropertyChanging(nameof(ColumnMapping));
+
+                    if (_table != null)
+                    {
+                        if (_columnMapping == MappingType.SimpleContent)
+                        {
+                            _table._xmlText = null;
+                        }
+
+                        if (value == MappingType.Element)
+                        {
+                            _table.ElementColumnCount++;
+                        }
+                        else if (_columnMapping == MappingType.Element)
+                        {
+                            _table.ElementColumnCount--;
+                        }
+                    }
+
+                    _columnMapping = value;
+                    if (value == MappingType.SimpleContent)
+                    {
+                        _columnUri = null;
+                        if (_table != null)
+                        {
+                            _table.XmlText = this;
+                        }
+                        SimpleType = null;
+                    }
+                }
+            }
+        }
+
+        internal event PropertyChangedEventHandler PropertyChanging;
+
+        internal void CheckColumnConstraint(DataRow row, DataRowAction action)
+        {
+            if (_table.UpdatingCurrent(row, action))
+            {
+                CheckNullable(row);
+                CheckMaxLength(row);
+            }
+        }
+
+        internal bool CheckMaxLength()
+        {
+            if ((0 <= _maxLength) && (null != Table) && (0 < Table.Rows.Count))
+            {
+                Debug.Assert(IsStringType, "not a String or SqlString column");
+                foreach (DataRow dr in Table.Rows)
+                {
+                    if (dr.HasVersion(DataRowVersion.Current))
+                    {
+                        if (_maxLength < GetStringLength(dr.GetCurrentRecordNo()))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        internal void CheckMaxLength(DataRow dr)
+        {
+            if (0 <= _maxLength)
+            {
+                Debug.Assert(IsStringType, "not a String or SqlString column");
+                if (_maxLength < GetStringLength(dr.GetDefaultRecord()))
+                {
+                    throw ExceptionBuilder.LongerThanMaxLength(this);
+                }
+            }
+        }
+
+        protected internal void CheckNotAllowNull()
+        {
+            if (_storage == null)
+            {
+                return;
+            }
+
+            if (_sortIndex != null)
+            {
+                if (_sortIndex.IsKeyInIndex(_storage._nullValue))
+                {
+                    // here we do use strong typed NULL for Sql types
+                    throw ExceptionBuilder.NullKeyValues(ColumnName);
+                }
+            }
+            else
+            {
+                // since we do not have index, we so sequential search
+                foreach (DataRow dr in _table.Rows)
+                {
+                    if (dr.RowState == DataRowState.Deleted)
+                    {
+                        continue;
+                    }
+
+                    if (!_implementsINullable)
+                    {
+                        if (dr[this] == DBNull.Value)
+                        {
+                            throw ExceptionBuilder.NullKeyValues(ColumnName);
+                        }
+                    }
+                    else
+                    {
+                        if (DataStorage.IsObjectNull(dr[this]))
+                        {
+                            throw ExceptionBuilder.NullKeyValues(ColumnName);
+                        }
+                    }
+                }
+            }
+        }
+
+        internal void CheckNullable(DataRow row)
+        {
+            if (!AllowDBNull)
+            {
+                Debug.Assert(null != _storage, "no storage");
+                if (_storage.IsNull(row.GetDefaultRecord()))
+                {
+                    throw ExceptionBuilder.NullValues(ColumnName);
+                }
+            }
+        }
+
+        protected void CheckUnique()
+        {
+            if (!SortIndex.CheckUnique())
+            {
+                // Throws an exception and the name of any column if its Unique property set to
+                // True and non-unique values are found in the column.
+                throw ExceptionBuilder.NonUniqueValues(ColumnName);
+            }
+        }
+
+        internal int Compare(int record1, int record2)
+        {
+            Debug.Assert(null != _storage, "null storage");
+            return _storage.Compare(record1, record2);
+        }
+
+        internal bool CompareValueTo(int record1, object value, bool checkType)
+        {
+            // this method is used to make sure value and exact type match.
+            int valuesMatch = CompareValueTo(record1, value);
+
+            // if values match according to storage, do extra checks for exact compare
+            if (valuesMatch == 0)
+            {
+                Type leftType = value.GetType();
+                Type rightType = _storage.Get(record1).GetType();
+                // if strings, then do exact character by character check
+                if (leftType == typeof(string) && rightType == typeof(string))
+                {
+                    return string.CompareOrdinal((string)_storage.Get(record1), (string)value) == 0 ? true : false;
+                }
+                // make sure same type
+                else if (leftType == rightType)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal int CompareValueTo(int record1, object value)
+        {
+            Debug.Assert(null != _storage, "null storage");
+            return _storage.CompareValueTo(record1, value);
+        }
+
+        internal object ConvertValue(object value)
+        {
+            Debug.Assert(null != _storage, "null storage");
+            return _storage.ConvertValue(value);
+        }
+
+        internal void Copy(int srcRecordNo, int dstRecordNo)
+        {
+            Debug.Assert(null != _storage, "null storage");
+            _storage.Copy(srcRecordNo, dstRecordNo);
+        }
+
+        // Prevent inlining so that reflection calls are not moved to caller that may be in a different assembly that may have a different grant set.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal DataColumn Clone()
+        {
+            DataColumn clone = (DataColumn)Activator.CreateInstance(GetType());
+
+            clone.SimpleType = SimpleType;
+
+            clone._allowNull = _allowNull;
+            if (null != _autoInc)
+            {
+                clone._autoInc = _autoInc.Clone();
+            }
+            clone._caption = _caption;
+            clone.ColumnName = ColumnName;
+            clone._columnUri = _columnUri;
+            clone._columnPrefix = _columnPrefix;
+            clone.DataType = DataType;
+            clone._defaultValue = _defaultValue;
+            clone._defaultValueIsNull = ((_defaultValue == DBNull.Value) || (clone.ImplementsINullable && DataStorage.IsObjectSqlNull(_defaultValue))) ? true : false;
+            clone._columnMapping = _columnMapping;// clone column Mapping since we dont let MaxLength to be set throu API
+            clone._readOnly = _readOnly;
+            clone.MaxLength = MaxLength;
+            clone.XmlDataType = XmlDataType;
+            clone._dateTimeMode = _dateTimeMode;
+
+            // so if we have set it, we should continue preserving the information
+
+            // ...Extended Properties
+            if (_extendedProperties != null)
+            {
+                foreach (object key in _extendedProperties.Keys)
+                {
+                    clone.ExtendedProperties[key] = _extendedProperties[key];
+                }
+            }
+
+            return clone;
+        }
+
+        /// <summary>
+        /// Finds a relation that this column is the sole child of or null.
+        /// </summary>
+        internal DataRelation FindParentRelation()
+        {
+            var parentRelations = new DataRelation[Table.ParentRelations.Count];
+            Table.ParentRelations.CopyTo(parentRelations, 0);
+
+            for (int i = 0; i < parentRelations.Length; i++)
+            {
+                DataRelation relation = parentRelations[i];
+                DataKey key = relation.ChildKey;
+                if (key.ColumnsReference.Length == 1 && key.ColumnsReference[0] == this)
+                {
+                    return relation;
+                }
+            }
+
+            return null;
+        }
+
+
+        internal object GetAggregateValue(int[] records, AggregateType kind)
+        {
+            if (_storage == null)
+            {
+                return kind == AggregateType.Count ? (object)0 : DBNull.Value;
+            }
+            return _storage.Aggregate(records, kind);
+        }
+
+        private int GetStringLength(int record)
+        {
+            Debug.Assert(null != _storage, "no storage");
+            return _storage.GetStringLength(record);
+        }
+
+        internal void Init(int record)
+        {
+            if (AutoIncrement)
+            {
+                object value = _autoInc.Current;
+                _autoInc.MoveAfter();
+                Debug.Assert(null != _storage, "no storage");
+                _storage.Set(record, value);
+            }
+            else
+            {
+                this[record] = _defaultValue;
+            }
+        }
+
+        internal static bool IsAutoIncrementType(Type dataType) =>
+            dataType == typeof(int) ||
+            dataType == typeof(long) ||
+            dataType == typeof(short) ||
+            dataType == typeof(decimal) ||
+            dataType == typeof(BigInteger) ||
+            dataType == typeof(SqlInt32) ||
+            dataType == typeof(SqlInt64) ||
+            dataType == typeof(SqlInt16) ||
+            dataType == typeof(SqlDecimal);
+
+        private bool IsColumnMappingValid(StorageType typeCode, MappingType mapping) =>
+            !((mapping != MappingType.Element) && DataStorage.IsTypeCustomType(typeCode));
+
+        internal bool IsCustomType => _storage != null ?
+            _storage._isCustomDefinedType :
+            DataStorage.IsTypeCustomType(DataType);
+
+        internal bool IsValueCustomTypeInstance(object value) =>
+            // if instance is not a storage supported type (built in or SQL types)
+            (DataStorage.IsTypeCustomType(value.GetType()) && !(value is Type));
+
+        internal bool ImplementsIXMLSerializable => _implementsIXMLSerializable;
+
+        internal bool IsNull(int record)
+        {
+            Debug.Assert(null != _storage, "no storage");
+            return _storage.IsNull(record);
+        }
+
+        /// <summary>
+        /// Returns true if this column is a part of a Parent or Child key for a relation.
+        /// </summary>
+        internal bool IsInRelation()
+        {
+            DataKey key;
+            DataRelationCollection rels = _table.ParentRelations;
+
+            Debug.Assert(rels != null, "Invalid ParentRelations");
+            for (int i = 0; i < rels.Count; i++)
+            {
+                key = rels[i].ChildKey;
+                Debug.Assert(key.HasValue, "Invalid child key (null)");
+                if (key.ContainsColumn(this))
+                {
+                    return true;
+                }
+            }
+
+            rels = _table.ChildRelations;
+            Debug.Assert(rels != null, "Invalid ChildRelations");
+            for (int i = 0; i < rels.Count; i++)
+            {
+                key = rels[i].ParentKey;
+                Debug.Assert(key.HasValue, "Invalid parent key (null)");
+                if (key.ContainsColumn(this))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal bool IsMaxLengthViolated()
+        {
+            if (MaxLength < 0)
+                return true;
+
+            bool error = false;
+            object value;
+            string errorText = null;
+
+            foreach (DataRow dr in Table.Rows)
+            {
+                if (dr.HasVersion(DataRowVersion.Current))
+                {
+                    value = dr[this];
+                    if (!_isSqlType)
+                    {
+                        if (value != null && value != DBNull.Value && ((string)value).Length > MaxLength)
+                        {
+                            if (errorText == null)
+                            {
+                                errorText = ExceptionBuilder.MaxLengthViolationText(ColumnName);
+                            }
+                            dr.RowError = errorText;
+                            dr.SetColumnError(this, errorText);
+                            error = true;
+                        }
+                    }
+                    else
+                    {
+                        if (!DataStorage.IsObjectNull(value) && ((SqlString)value).Value.Length > MaxLength)
+                        {
+                            if (errorText == null)
+                            {
+                                errorText = ExceptionBuilder.MaxLengthViolationText(ColumnName);
+                            }
+                            dr.RowError = errorText;
+                            dr.SetColumnError(this, errorText);
+                            error = true;
+                        }
+                    }
+                }
+            }
+            return error;
+        }
+
+        internal bool IsNotAllowDBNullViolated()
+        {
+            Index index = SortIndex;
+            DataRow[] rows = index.GetRows(index.FindRecords(DBNull.Value));
+            for (int i = 0; i < rows.Length; i++)
+            {
+                string errorText = ExceptionBuilder.NotAllowDBNullViolationText(ColumnName);
+                rows[i].RowError = errorText;
+                rows[i].SetColumnError(this, errorText);
+            }
+            return (rows.Length > 0);
+        }
+
+        internal void FinishInitInProgress()
+        {
+            if (Computed)
+                BindExpression();
+        }
+
+        protected virtual void OnPropertyChanging(PropertyChangedEventArgs pcevent)
+        {
+            PropertyChanging?.Invoke(this, pcevent);
+        }
+
+        protected internal void RaisePropertyChanging(string name)
+        {
+            OnPropertyChanging(new PropertyChangedEventArgs(name));
+        }
+
+        private void InsureStorage()
+        {
+            if (_storage == null)
+            {
+                _storage = DataStorage.CreateStorage(this, _dataType, _storageType);
+            }
+        }
+
+        internal void SetCapacity(int capacity)
+        {
+            InsureStorage();
+            _storage.SetCapacity(capacity);
+        }
+
+        private bool ShouldSerializeDefaultValue() => !DefaultValueIsNull;
+
+        internal void OnSetDataSet() { }
+
+        // Returns the <see cref='System.Data.DataColumn.Expression'/> of the column, if one exists.
+        public override string ToString() => _expression == null ?
+            ColumnName :
+            ColumnName + " + " + Expression;
+
+        internal object ConvertXmlToObject(string s)
+        {
+            Debug.Assert(s != null, "Caller is resposible for missing element/attribute case");
+            InsureStorage();
+            return _storage.ConvertXmlToObject(s);
+        }
+
+        internal object ConvertXmlToObject(XmlReader xmlReader, XmlRootAttribute xmlAttrib)
+        {
+            InsureStorage();
+            return _storage.ConvertXmlToObject(xmlReader, xmlAttrib);
+        }
+
+
+        internal string ConvertObjectToXml(object value)
+        {
+            Debug.Assert(value != null && (value != DBNull.Value), "Caller is resposible for checking on DBNull");
+            InsureStorage();
+            return _storage.ConvertObjectToXml(value);
+        }
+
+        internal void ConvertObjectToXml(object value, XmlWriter xmlWriter, XmlRootAttribute xmlAttrib)
+        {
+            Debug.Assert(value != null && (value != DBNull.Value), "Caller is resposible for checking on DBNull");
+            InsureStorage();
+            _storage.ConvertObjectToXml(value, xmlWriter, xmlAttrib);
+        }
+
+        internal object GetEmptyColumnStore(int recordCount)
+        {
+            InsureStorage();
+            return _storage.GetEmptyStorageInternal(recordCount);
+        }
+
+        internal void CopyValueIntoStore(int record, object store, BitArray nullbits, int storeIndex)
+        {
+            Debug.Assert(null != _storage, "no storage");
+            _storage.CopyValueInternal(record, store, nullbits, storeIndex);
+        }
+
+        internal void SetStorage(object store, BitArray nullbits)
+        {
+            InsureStorage();
+            _storage.SetStorageInternal(store, nullbits);
+        }
+
+        internal void AddDependentColumn(DataColumn expressionColumn)
+        {
+            if (_dependentColumns == null)
+            {
+                _dependentColumns = new List<DataColumn>();
+            }
+
+            Debug.Assert(!_dependentColumns.Contains(expressionColumn), "duplicate column - expected to be unique");
+            _dependentColumns.Add(expressionColumn);
+            _table.AddDependentColumn(expressionColumn);
+        }
+
+        internal void RemoveDependentColumn(DataColumn expressionColumn)
+        {
+            if (_dependentColumns != null && _dependentColumns.Contains(expressionColumn))
+            {
+                _dependentColumns.Remove(expressionColumn);
+            }
+            _table.RemoveDependentColumn(expressionColumn);
+        }
+
+        internal void HandleDependentColumnList(DataExpression oldExpression, DataExpression newExpression)
+        {
+            DataColumn[] dependency;
+
+            // remove this column from the dependentColumn list of the columns this column depends on.
+            if (oldExpression != null)
+            {
+                dependency = oldExpression.GetDependency();
+                foreach (DataColumn col in dependency)
+                {
+                    Debug.Assert(null != col, "null datacolumn in expression dependencies");
+                    col.RemoveDependentColumn(this);
+                    if (col._table != _table)
+                    {
+                        _table.RemoveDependentColumn(this);
+                    }
+                }
+                _table.RemoveDependentColumn(this);
+            }
+
+            if (newExpression != null)
+            {
+                // get the list of columns that this expression depends on
+                dependency = newExpression.GetDependency();
+                // add this column to dependent column list of each column this column depends on
+                foreach (DataColumn col in dependency)
+                {
+                    col.AddDependentColumn(this);
+                    if (col._table != _table)
+                    {
+                        _table.AddDependentColumn(this);
+                    }
+                }
+                _table.AddDependentColumn(this);
+            }
+        }
+    }
+
+    internal abstract class AutoIncrementValue
+    {
+        internal bool Auto { get; set; }
+        internal abstract object Current { get; set; }
+        internal abstract long Seed { get; set; }
+        internal abstract long Step { get; set; }
+        internal abstract Type DataType { get; }
+
+        internal abstract void SetCurrent(object value, IFormatProvider formatProvider);
+        internal abstract void SetCurrentAndIncrement(object value);
+        internal abstract void MoveAfter();
+
+        internal AutoIncrementValue Clone()
+        {
+            AutoIncrementValue clone = (this is AutoIncrementInt64) ? new AutoIncrementInt64() : (AutoIncrementValue)new AutoIncrementBigInteger();
+            clone.Auto = Auto;
+            clone.Seed = Seed;
+            clone.Step = Step;
+            clone.Current = Current;
+            return clone;
+        }
+    }
+
+    /// <summary>the auto stepped value with Int64 representation</summary>
+    /// <remarks>use unchecked behavior</remarks>
+    internal sealed class AutoIncrementInt64 : AutoIncrementValue
+    {
+        /// <summary>the last returned auto incremented value</summary>
+        private long _current;
+
+        /// <summary>the initial value use to set current</summary>
+        private long _seed;
+
+        /// <summary>the value by which to offset the next value</summary>
+        private long _step = 1;
+
+        /// <summary>Gets and sets the current auto incremented value to use</summary>
+        internal override object Current
+        {
+            get { return _current; }
+            set { _current = (long)value; }
+        }
+
+        internal override Type DataType => typeof(long);
+
+        /// <summary>Get and sets the initial seed value.</summary>
+        internal override long Seed
+        {
+            get { return _seed; }
+            set
+            {
+                if ((_current == _seed) || BoundaryCheck(value))
+                {
+                    _current = value;
+                }
+                _seed = value;
+            }
+        }
+
+        /// <summary>Get and sets the stepping value.</summary>
+        /// <exception cref="ArugmentException">if value is 0</exception>
+        internal override long Step
+        {
+            get { return _step; }
+            set
+            {
+                if (0 == value)
+                {
+                    throw ExceptionBuilder.AutoIncrementSeed();
+                }
+                if (_step != value)
+                {
+                    if (_current != Seed)
+                    {
+                        _current = unchecked(_current - _step + value);
+                    }
+                    _step = value;
+                }
+            }
+        }
+
+        internal override void MoveAfter()
+        {
+            _current = unchecked(_current + _step);
+        }
+
+        internal override void SetCurrent(object value, IFormatProvider formatProvider)
+        {
+            _current = Convert.ToInt64(value, formatProvider);
+        }
+
+        internal override void SetCurrentAndIncrement(object value)
+        {
+            Debug.Assert(null != value && DataColumn.IsAutoIncrementType(value.GetType()) && !(value is BigInteger), "unexpected value for autoincrement");
+            long v = (long)SqlConvert.ChangeType2(value, StorageType.Int64, typeof(long), CultureInfo.InvariantCulture);
+            if (BoundaryCheck(v))
+            {
+                _current = unchecked(v + _step);
+            }
+        }
+
+        private bool BoundaryCheck(BigInteger value) =>
+            ((_step < 0) && (value <= _current)) || ((0 < _step) && (_current <= value));
+    }
+
+    /// <summary>the auto stepped value with BigInteger representation</summary>
+    internal sealed class AutoIncrementBigInteger : AutoIncrementValue
+    {
+        /// <summary>the current auto incremented value to use</summary>
+        private BigInteger _current;
+
+        /// <summary>the initial value use to set current</summary>
+        private long _seed;
+
+        /// <summary>the value by which to offset the next value</summary>
+        private BigInteger _step = 1;
+
+        /// <summary>Gets and sets the current auto incremented value to use</summary>
+        internal override object Current
+        {
+            get { return _current; }
+            set { _current = (BigInteger)value; }
+        }
+
+        internal override Type DataType => typeof(BigInteger);
+
+        /// <summary>Get and sets the initial seed value.</summary>
+        internal override long Seed
+        {
+            get { return _seed; }
+            set
+            {
+                if ((_current == _seed) || BoundaryCheck(value))
+                {
+                    _current = value;
+                }
+                _seed = value;
+            }
+        }
+
+        /// <summary>Get and sets the stepping value.</summary>
+        /// <exception cref="ArugmentException">if value is 0</exception>
+        internal override long Step
+        {
+            get { return (long)_step; }
+            set
+            {
+                if (0 == value)
+                {
+                    throw ExceptionBuilder.AutoIncrementSeed();
+                }
+                if (_step != value)
+                {
+                    if (_current != Seed)
+                    {
+                        _current = checked(_current - _step + value);
+                    }
+                    _step = value;
+                }
+            }
+        }
+
+        internal override void MoveAfter()
+        {
+            _current = checked(_current + _step);
+        }
+
+        internal override void SetCurrent(object value, IFormatProvider formatProvider)
+        {
+            _current = BigIntegerStorage.ConvertToBigInteger(value, formatProvider);
+        }
+
+        internal override void SetCurrentAndIncrement(object value)
+        {
+            BigInteger v = (BigInteger)value;
+            if (BoundaryCheck(v))
+            {
+                _current = v + _step;
+            }
+        }
+
+        private bool BoundaryCheck(BigInteger value) =>
+           ((_step < 0) && (value <= _current)) || ((0 < _step) && (_current <= value));
+    }
+}

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataColumn.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataColumn.cs
@@ -143,6 +143,7 @@ namespace System.Data
 
         private void UpdateColumnType(Type type, StorageType typeCode)
         {
+            TypeLimiter.EnsureTypeIsAllowed(type);
             _dataType = type;
             _storageType = typeCode;
             if (StorageType.DateTime != typeCode)

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataException.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataException.cs
@@ -1,0 +1,746 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.Serialization;
+
+namespace System.Data
+{
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class DataException : SystemException
+    {
+        protected DataException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public DataException() : base(SR.DataSet_DefaultDataException)
+        {
+            HResult = HResults.Data;
+        }
+
+        public DataException(string s) : base(s)
+        {
+            HResult = HResults.Data;
+        }
+
+        public DataException(string s, Exception innerException) : base(s, innerException) { }
+    };
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class ConstraintException : DataException
+    {
+        protected ConstraintException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public ConstraintException() : base(SR.DataSet_DefaultConstraintException)
+        {
+            HResult = HResults.DataConstraint;
+        }
+
+        public ConstraintException(string s) : base(s)
+        {
+            HResult = HResults.DataConstraint;
+        }
+
+        public ConstraintException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataConstraint;
+        }
+    }
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class DeletedRowInaccessibleException : DataException
+    {
+        protected DeletedRowInaccessibleException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DeletedRowInaccessibleException'/> class.
+        /// </summary>
+        public DeletedRowInaccessibleException() : base(SR.DataSet_DefaultDeletedRowInaccessibleException)
+        {
+            HResult = HResults.DataDeletedRowInaccessible;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DeletedRowInaccessibleException'/> class with the specified string.
+        /// </summary>
+        public DeletedRowInaccessibleException(string s) : base(s)
+        {
+            HResult = HResults.DataDeletedRowInaccessible;
+        }
+
+        public DeletedRowInaccessibleException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataDeletedRowInaccessible;
+        }
+    }
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class DuplicateNameException : DataException
+    {
+        protected DuplicateNameException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public DuplicateNameException() : base(SR.DataSet_DefaultDuplicateNameException)
+        {
+            HResult = HResults.DataDuplicateName;
+        }
+
+        public DuplicateNameException(string s) : base(s)
+        {
+            HResult = HResults.DataDuplicateName;
+        }
+
+        public DuplicateNameException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataDuplicateName;
+        }
+    }
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class InRowChangingEventException : DataException
+    {
+        protected InRowChangingEventException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public InRowChangingEventException() : base(SR.DataSet_DefaultInRowChangingEventException)
+        {
+            HResult = HResults.DataInRowChangingEvent;
+        }
+
+        public InRowChangingEventException(string s) : base(s)
+        {
+            HResult = HResults.DataInRowChangingEvent;
+        }
+
+        public InRowChangingEventException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataInRowChangingEvent;
+        }
+    }
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class InvalidConstraintException : DataException
+    {
+        protected InvalidConstraintException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public InvalidConstraintException() : base(SR.DataSet_DefaultInvalidConstraintException)
+        {
+            HResult = HResults.DataInvalidConstraint;
+        }
+
+        public InvalidConstraintException(string s) : base(s)
+        {
+            HResult = HResults.DataInvalidConstraint;
+        }
+
+        public InvalidConstraintException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataInvalidConstraint;
+        }
+    }
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class MissingPrimaryKeyException : DataException
+    {
+        protected MissingPrimaryKeyException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public MissingPrimaryKeyException() : base(SR.DataSet_DefaultMissingPrimaryKeyException)
+        {
+            HResult = HResults.DataMissingPrimaryKey;
+        }
+
+        public MissingPrimaryKeyException(string s) : base(s)
+        {
+            HResult = HResults.DataMissingPrimaryKey;
+        }
+
+        public MissingPrimaryKeyException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataMissingPrimaryKey;
+        }
+    }
+    
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class NoNullAllowedException : DataException
+    {
+        protected NoNullAllowedException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public NoNullAllowedException() : base(SR.DataSet_DefaultNoNullAllowedException)
+        {
+            HResult = HResults.DataNoNullAllowed;
+        }
+
+        public NoNullAllowedException(string s) : base(s)
+        {
+            HResult = HResults.DataNoNullAllowed;
+        }
+
+        public NoNullAllowedException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataNoNullAllowed;
+        }
+    }
+    
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class ReadOnlyException : DataException
+    {
+        protected ReadOnlyException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public ReadOnlyException() : base(SR.DataSet_DefaultReadOnlyException)
+        {
+            HResult = HResults.DataReadOnly;
+        }
+
+        public ReadOnlyException(string s) : base(s)
+        {
+            HResult = HResults.DataReadOnly;
+        }
+
+        public ReadOnlyException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataReadOnly;
+        }
+    }
+    
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class RowNotInTableException : DataException
+    {
+        protected RowNotInTableException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public RowNotInTableException() : base(SR.DataSet_DefaultRowNotInTableException)
+        {
+            HResult = HResults.DataRowNotInTable;
+        }
+
+        public RowNotInTableException(string s) : base(s)
+        {
+            HResult = HResults.DataRowNotInTable;
+        }
+
+        public RowNotInTableException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataRowNotInTable;
+        }
+    }
+
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class VersionNotFoundException : DataException
+    {
+        protected VersionNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public VersionNotFoundException() : base(SR.DataSet_DefaultVersionNotFoundException)
+        {
+            HResult = HResults.DataVersionNotFound;
+        }
+
+        public VersionNotFoundException(string s) : base(s)
+        {
+            HResult = HResults.DataVersionNotFound;
+        }
+
+        public VersionNotFoundException(string message, Exception innerException) : base(message, innerException)
+        {
+            HResult = HResults.DataVersionNotFound;
+        }
+    }
+
+    internal static class ExceptionBuilder
+    {
+        // The class defines the exceptions that are specific to the DataSet.
+        // The class contains functions that take the proper informational variables and then construct
+        // the appropriate exception with an error string obtained from the resource Data.txt.
+        // The exception is then returned to the caller, so that the caller may then throw from its
+        // location so that the catcher of the exception will have the appropriate call stack.
+        // This class is used so that there will be compile time checking of error messages.
+        // The resource Data.txt will ensure proper string text based on the appropriate locale.
+
+        // this method accepts BID format as an argument, this attribute allows FXCopBid rule to validate calls to it
+        private static void TraceException(string trace, Exception e)
+        {
+            Debug.Assert(null != e, "TraceException: null Exception");
+            if (e != null)
+            {
+                DataCommonEventSource.Log.Trace(trace, e);
+            }
+        }
+
+        internal static Exception TraceExceptionAsReturnValue(Exception e)
+        {
+            TraceException("<comm.ADP.TraceException|ERR|THROW> '{0}'", e);
+            return e;
+        }
+
+        internal static Exception TraceExceptionForCapture(Exception e)
+        {
+            TraceException("<comm.ADP.TraceException|ERR|CATCH> '{0}'", e);
+            return e;
+        }
+
+        internal static Exception TraceExceptionWithoutRethrow(Exception e)
+        {
+            TraceException("<comm.ADP.TraceException|ERR|CATCH> '{0}'", e);
+            return e;
+        }
+
+        internal static Exception _Argument(string error) => TraceExceptionAsReturnValue(new ArgumentException(error));
+        internal static Exception _Argument(string paramName, string error) => TraceExceptionAsReturnValue(new ArgumentException(error));
+        internal static Exception _Argument(string error, Exception innerException) => TraceExceptionAsReturnValue(new ArgumentException(error, innerException));
+        private static Exception _ArgumentNull(string paramName, string msg) => TraceExceptionAsReturnValue(new ArgumentNullException(paramName, msg));
+        internal static Exception _ArgumentOutOfRange(string paramName, string msg) => TraceExceptionAsReturnValue(new ArgumentOutOfRangeException(paramName, msg));
+        private static Exception _IndexOutOfRange(string error) => TraceExceptionAsReturnValue(new IndexOutOfRangeException(error));
+        private static Exception _InvalidOperation(string error) => TraceExceptionAsReturnValue(new InvalidOperationException(error));
+        private static Exception _InvalidEnumArgumentException(string error) => TraceExceptionAsReturnValue(new InvalidEnumArgumentException(error));
+        private static Exception _InvalidEnumArgumentException<T>(T value) => _InvalidEnumArgumentException(SR.Format(SR.ADP_InvalidEnumerationValue, typeof(T).Name, value.ToString()));
+
+        //
+        // System.Data exceptions
+        //
+
+        private static void ThrowDataException(string error, Exception innerException)
+        {
+            throw TraceExceptionAsReturnValue(new DataException(error, innerException));
+        }
+
+        private static Exception _Data(string error) => TraceExceptionAsReturnValue(new DataException(error));
+        private static Exception _Constraint(string error) => TraceExceptionAsReturnValue(new ConstraintException(error));
+        private static Exception _InvalidConstraint(string error) => TraceExceptionAsReturnValue(new InvalidConstraintException(error));
+        private static Exception _DeletedRowInaccessible(string error) => TraceExceptionAsReturnValue(new DeletedRowInaccessibleException(error));
+        private static Exception _DuplicateName(string error) => TraceExceptionAsReturnValue(new DuplicateNameException(error));
+        private static Exception _InRowChangingEvent(string error) => TraceExceptionAsReturnValue(new InRowChangingEventException(error));
+        private static Exception _MissingPrimaryKey(string error) => TraceExceptionAsReturnValue(new MissingPrimaryKeyException(error));
+        private static Exception _NoNullAllowed(string error) => TraceExceptionAsReturnValue(new NoNullAllowedException(error));
+
+        private static Exception _ReadOnly(string error) => TraceExceptionAsReturnValue(new ReadOnlyException(error));
+        private static Exception _RowNotInTable(string error) => TraceExceptionAsReturnValue(new RowNotInTableException(error));
+        private static Exception _VersionNotFound(string error) => TraceExceptionAsReturnValue(new VersionNotFoundException(error));
+
+        public static Exception ArgumentNull(string paramName) => _ArgumentNull(paramName, SR.Format(SR.Data_ArgumentNull, paramName));
+        public static Exception ArgumentOutOfRange(string paramName) => _ArgumentOutOfRange(paramName, SR.Format(SR.Data_ArgumentOutOfRange, paramName));
+        public static Exception BadObjectPropertyAccess(string error) => _InvalidOperation(SR.Format(SR.DataConstraint_BadObjectPropertyAccess, error));
+        public static Exception ArgumentContainsNull(string paramName) => _Argument(paramName, SR.Format(SR.Data_ArgumentContainsNull, paramName));
+
+
+        //
+        // Collections
+        //
+
+        public static Exception CannotModifyCollection() => _Argument(SR.Data_CannotModifyCollection);
+        public static Exception CaseInsensitiveNameConflict(string name) => _Argument(SR.Format(SR.Data_CaseInsensitiveNameConflict, name));
+        public static Exception NamespaceNameConflict(string name) => _Argument(SR.Format(SR.Data_NamespaceNameConflict, name));
+        public static Exception InvalidOffsetLength() => _Argument(SR.Data_InvalidOffsetLength);
+
+        //
+        // DataColumnCollection
+        //
+
+        public static Exception ColumnNotInTheTable(string column, string table) => _Argument(SR.Format(SR.DataColumn_NotInTheTable, column, table));
+        public static Exception ColumnNotInAnyTable() => _Argument(SR.DataColumn_NotInAnyTable);
+        public static Exception ColumnOutOfRange(int index) => _IndexOutOfRange(SR.Format(SR.DataColumns_OutOfRange, (index).ToString(CultureInfo.InvariantCulture)));
+        public static Exception ColumnOutOfRange(string column) => _IndexOutOfRange(SR.Format(SR.DataColumns_OutOfRange, column));
+        public static Exception CannotAddColumn1(string column) => _Argument(SR.Format(SR.DataColumns_Add1, column));
+        public static Exception CannotAddColumn2(string column) => _Argument(SR.Format(SR.DataColumns_Add2, column));
+        public static Exception CannotAddColumn3() => _Argument(SR.DataColumns_Add3);
+        public static Exception CannotAddColumn4(string column) => _Argument(SR.Format(SR.DataColumns_Add4, column));
+        public static Exception CannotAddDuplicate(string column) => _DuplicateName(SR.Format(SR.DataColumns_AddDuplicate, column));
+        public static Exception CannotAddDuplicate2(string table) => _DuplicateName(SR.Format(SR.DataColumns_AddDuplicate2, table));
+        public static Exception CannotAddDuplicate3(string table) => _DuplicateName(SR.Format(SR.DataColumns_AddDuplicate3, table));
+        public static Exception CannotRemoveColumn() => _Argument(SR.DataColumns_Remove);
+        public static Exception CannotRemovePrimaryKey() => _Argument(SR.DataColumns_RemovePrimaryKey);
+        public static Exception CannotRemoveChildKey(string relation) => _Argument(SR.Format(SR.DataColumns_RemoveChildKey, relation));
+        public static Exception CannotRemoveConstraint(string constraint, string table) => _Argument(SR.Format(SR.DataColumns_RemoveConstraint, constraint, table));
+        public static Exception CannotRemoveExpression(string column, string expression) => _Argument(SR.Format(SR.DataColumns_RemoveExpression, column, expression));
+        public static Exception ColumnNotInTheUnderlyingTable(string column, string table) => _Argument(SR.Format(SR.DataColumn_NotInTheUnderlyingTable, column, table));
+        public static Exception InvalidOrdinal(string name, int ordinal) => _ArgumentOutOfRange(name, SR.Format(SR.DataColumn_OrdinalExceedMaximun, (ordinal).ToString(CultureInfo.InvariantCulture)));
+
+        //
+        // _Constraint and ConstrainsCollection
+        //
+
+        public static Exception AddPrimaryKeyConstraint() => _Argument(SR.DataConstraint_AddPrimaryKeyConstraint);
+        public static Exception NoConstraintName() => _Argument(SR.DataConstraint_NoName);
+        public static Exception ConstraintViolation(string constraint) => _Constraint(SR.Format(SR.DataConstraint_Violation, constraint));
+        public static Exception ConstraintNotInTheTable(string constraint) => _Argument(SR.Format(SR.DataConstraint_NotInTheTable, constraint));
+
+        public static string KeysToString(object[] keys)
+        {
+            string values = string.Empty;
+            for (int i = 0; i < keys.Length; i++)
+            {
+                values += Convert.ToString(keys[i], null) + (i < keys.Length - 1 ? ", " : string.Empty);
+            }
+            return values;
+        }
+
+        public static string UniqueConstraintViolationText(DataColumn[] columns, object[] values)
+        {
+            if (columns.Length > 1)
+            {
+                string columnNames = string.Empty;
+                for (int i = 0; i < columns.Length; i++)
+                {
+                    columnNames += columns[i].ColumnName + (i < columns.Length - 1 ? ", " : "");
+                }
+                return SR.Format(SR.DataConstraint_ViolationValue, columnNames, KeysToString(values));
+            }
+            else
+            {
+                return SR.Format(SR.DataConstraint_ViolationValue, columns[0].ColumnName, Convert.ToString(values[0], null));
+            }
+        }
+
+        public static Exception ConstraintViolation(DataColumn[] columns, object[] values) => _Constraint(UniqueConstraintViolationText(columns, values));
+        public static Exception ConstraintOutOfRange(int index) => _IndexOutOfRange(SR.Format(SR.DataConstraint_OutOfRange, (index).ToString(CultureInfo.InvariantCulture)));
+        public static Exception DuplicateConstraint(string constraint) => _Data(SR.Format(SR.DataConstraint_Duplicate, constraint));
+        public static Exception DuplicateConstraintName(string constraint) => _DuplicateName(SR.Format(SR.DataConstraint_DuplicateName, constraint));
+        public static Exception NeededForForeignKeyConstraint(UniqueConstraint key, ForeignKeyConstraint fk) => _Argument(SR.Format(SR.DataConstraint_NeededForForeignKeyConstraint, key.ConstraintName, fk.ConstraintName));
+        public static Exception UniqueConstraintViolation() => _Argument(SR.DataConstraint_UniqueViolation);
+        public static Exception ConstraintForeignTable() => _Argument(SR.DataConstraint_ForeignTable);
+        public static Exception ConstraintParentValues() => _Argument(SR.DataConstraint_ParentValues);
+        public static Exception ConstraintAddFailed(DataTable table) => _InvalidConstraint(SR.Format(SR.DataConstraint_AddFailed, table.TableName));
+        public static Exception ConstraintRemoveFailed() => _Argument(SR.DataConstraint_RemoveFailed);
+        public static Exception FailedCascadeDelete(string constraint) => _InvalidConstraint(SR.Format(SR.DataConstraint_CascadeDelete, constraint));
+        public static Exception FailedCascadeUpdate(string constraint) => _InvalidConstraint(SR.Format(SR.DataConstraint_CascadeUpdate, constraint));
+        public static Exception FailedClearParentTable(string table, string constraint, string childTable) => _InvalidConstraint(SR.Format(SR.DataConstraint_ClearParentTable, table, constraint, childTable));
+        public static Exception ForeignKeyViolation(string constraint, object[] keys) => _InvalidConstraint(SR.Format(SR.DataConstraint_ForeignKeyViolation, constraint, KeysToString(keys)));
+        public static Exception RemoveParentRow(ForeignKeyConstraint constraint) => _InvalidConstraint(SR.Format(SR.DataConstraint_RemoveParentRow, constraint.ConstraintName));
+        public static string MaxLengthViolationText(string columnName) => SR.Format(SR.DataColumn_ExceedMaxLength, columnName);
+        public static string NotAllowDBNullViolationText(string columnName) => SR.Format(SR.DataColumn_NotAllowDBNull, columnName);
+        public static Exception CantAddConstraintToMultipleNestedTable(string tableName) => _Argument(SR.Format(SR.DataConstraint_CantAddConstraintToMultipleNestedTable, tableName));
+
+        //
+        // DataColumn Set Properties conflicts
+        //
+
+        public static Exception AutoIncrementAndExpression() => _Argument(SR.DataColumn_AutoIncrementAndExpression);
+        public static Exception AutoIncrementAndDefaultValue() => _Argument(SR.DataColumn_AutoIncrementAndDefaultValue);
+        public static Exception AutoIncrementSeed() => _Argument(SR.DataColumn_AutoIncrementSeed);
+        public static Exception CantChangeDataType() => _Argument(SR.DataColumn_ChangeDataType);
+        public static Exception NullDataType() => _Argument(SR.DataColumn_NullDataType);
+        public static Exception ColumnNameRequired() => _Argument(SR.DataColumn_NameRequired);
+        public static Exception DefaultValueAndAutoIncrement() => _Argument(SR.DataColumn_DefaultValueAndAutoIncrement);
+        public static Exception DefaultValueDataType(string column, Type defaultType, Type columnType, Exception inner) =>
+            column.Length == 0 ?
+                _Argument(SR.Format(SR.DataColumn_DefaultValueDataType1, defaultType.FullName, columnType.FullName), inner) :
+                _Argument(SR.Format(SR.DataColumn_DefaultValueDataType, column, defaultType.FullName, columnType.FullName), inner);
+
+        public static Exception DefaultValueColumnDataType(string column, Type defaultType, Type columnType, Exception inner) => _Argument(SR.Format(SR.DataColumn_DefaultValueColumnDataType, column, defaultType.FullName, columnType.FullName), inner);
+        public static Exception ExpressionAndUnique() => _Argument(SR.DataColumn_ExpressionAndUnique);
+        public static Exception ExpressionAndReadOnly() => _Argument(SR.DataColumn_ExpressionAndReadOnly);
+        public static Exception ExpressionAndConstraint(DataColumn column, Constraint constraint) => _Argument(SR.Format(SR.DataColumn_ExpressionAndConstraint, column.ColumnName, constraint.ConstraintName));
+        public static Exception ExpressionInConstraint(DataColumn column) => _Argument(SR.Format(SR.DataColumn_ExpressionInConstraint, column.ColumnName));
+        public static Exception ExpressionCircular() => _Argument(SR.DataColumn_ExpressionCircular);
+        public static Exception NonUniqueValues(string column) => _InvalidConstraint(SR.Format(SR.DataColumn_NonUniqueValues, column));
+        public static Exception NullKeyValues(string column) => _Data(SR.Format(SR.DataColumn_NullKeyValues, column));
+        public static Exception NullValues(string column) => _NoNullAllowed(SR.Format(SR.DataColumn_NullValues, column));
+        public static Exception ReadOnlyAndExpression() => _ReadOnly(SR.DataColumn_ReadOnlyAndExpression);
+        public static Exception ReadOnly(string column) => _ReadOnly(SR.Format(SR.DataColumn_ReadOnly, column));
+        public static Exception UniqueAndExpression() => _Argument(SR.DataColumn_UniqueAndExpression);
+        public static Exception SetFailed(object value, DataColumn column, Type type, Exception innerException) => _Argument(innerException.Message + SR.Format(SR.DataColumn_SetFailed, value.ToString(), column.ColumnName, type.Name), innerException);
+        public static Exception CannotSetToNull(DataColumn column) => _Argument(SR.Format(SR.DataColumn_CannotSetToNull, column.ColumnName));
+        public static Exception LongerThanMaxLength(DataColumn column) => _Argument(SR.Format(SR.DataColumn_LongerThanMaxLength, column.ColumnName));
+        public static Exception CannotSetMaxLength(DataColumn column, int value) => _Argument(SR.Format(SR.DataColumn_CannotSetMaxLength, column.ColumnName, value.ToString(CultureInfo.InvariantCulture)));
+        public static Exception CannotSetMaxLength2(DataColumn column) => _Argument(SR.Format(SR.DataColumn_CannotSetMaxLength2, column.ColumnName));
+        public static Exception CannotSetSimpleContentType(string columnName, Type type) => _Argument(SR.Format(SR.DataColumn_CannotSimpleContentType, columnName, type));
+        public static Exception CannotSetSimpleContent(string columnName, Type type) => _Argument(SR.Format(SR.DataColumn_CannotSimpleContent, columnName, type));
+        public static Exception CannotChangeNamespace(string columnName) => _Argument(SR.Format(SR.DataColumn_CannotChangeNamespace, columnName));
+        public static Exception HasToBeStringType(DataColumn column) => _Argument(SR.Format(SR.DataColumn_HasToBeStringType, column.ColumnName));
+        public static Exception AutoIncrementCannotSetIfHasData(string typeName) => _Argument(SR.Format(SR.DataColumn_AutoIncrementCannotSetIfHasData, typeName));
+        public static Exception INullableUDTwithoutStaticNull(string typeName) => _Argument(SR.Format(SR.DataColumn_INullableUDTwithoutStaticNull, typeName));
+        public static Exception IComparableNotImplemented(string typeName) => _Data(SR.Format(SR.DataStorage_IComparableNotDefined, typeName));
+        public static Exception UDTImplementsIChangeTrackingButnotIRevertible(string typeName) => _InvalidOperation(SR.Format(SR.DataColumn_UDTImplementsIChangeTrackingButnotIRevertible, typeName));
+        public static Exception SetAddedAndModifiedCalledOnnonUnchanged() => _InvalidOperation(SR.DataColumn_SetAddedAndModifiedCalledOnNonUnchanged);
+        public static Exception InvalidDataColumnMapping(Type type) => _Argument(SR.Format(SR.DataColumn_InvalidDataColumnMapping, type.AssemblyQualifiedName));
+        public static Exception CannotSetDateTimeModeForNonDateTimeColumns() => _InvalidOperation(SR.DataColumn_CannotSetDateTimeModeForNonDateTimeColumns);
+        public static Exception InvalidDateTimeMode(DataSetDateTime mode) => _InvalidEnumArgumentException(mode);
+        public static Exception CantChangeDateTimeMode(DataSetDateTime oldValue, DataSetDateTime newValue) => _InvalidOperation(SR.Format(SR.DataColumn_DateTimeMode, oldValue.ToString(), newValue.ToString()));
+        public static Exception ColumnTypeNotSupported() => Common.ADP.NotSupported(SR.DataColumn_NullableTypesNotSupported);
+
+        //
+        // DataView
+        //
+
+        public static Exception SetFailed(string name) => _Data(SR.Format(SR.DataView_SetFailed, name));
+        public static Exception SetDataSetFailed() => _Data(SR.DataView_SetDataSetFailed);
+        public static Exception SetRowStateFilter() => _Data(SR.DataView_SetRowStateFilter);
+        public static Exception CanNotSetDataSet() => _Data(SR.DataView_CanNotSetDataSet);
+        public static Exception CanNotUseDataViewManager() => _Data(SR.DataView_CanNotUseDataViewManager);
+        public static Exception CanNotSetTable() => _Data(SR.DataView_CanNotSetTable);
+        public static Exception CanNotUse() => _Data(SR.DataView_CanNotUse);
+        public static Exception CanNotBindTable() => _Data(SR.DataView_CanNotBindTable);
+        public static Exception SetTable() => _Data(SR.DataView_SetTable);
+        public static Exception SetIListObject() => _Argument(SR.DataView_SetIListObject);
+        public static Exception AddNewNotAllowNull() => _Data(SR.DataView_AddNewNotAllowNull);
+        public static Exception NotOpen() => _Data(SR.DataView_NotOpen);
+        public static Exception CreateChildView() => _Argument(SR.DataView_CreateChildView);
+        public static Exception CanNotDelete() => _Data(SR.DataView_CanNotDelete);
+        public static Exception CanNotEdit() => _Data(SR.DataView_CanNotEdit);
+        public static Exception GetElementIndex(int index) => _IndexOutOfRange(SR.Format(SR.DataView_GetElementIndex, (index).ToString(CultureInfo.InvariantCulture)));
+        public static Exception AddExternalObject() => _Argument(SR.DataView_AddExternalObject);
+        public static Exception CanNotClear() => _Argument(SR.DataView_CanNotClear);
+        public static Exception InsertExternalObject() => _Argument(SR.DataView_InsertExternalObject);
+        public static Exception RemoveExternalObject() => _Argument(SR.DataView_RemoveExternalObject);
+        public static Exception PropertyNotFound(string property, string table) => _Argument(SR.Format(SR.DataROWView_PropertyNotFound, property, table));
+        public static Exception ColumnToSortIsOutOfRange(string column) => _Argument(SR.Format(SR.DataColumns_OutOfRange, column));
+
+        //
+        // Keys
+        //
+
+        public static Exception KeyTableMismatch() => _InvalidConstraint(SR.DataKey_TableMismatch);
+        public static Exception KeyNoColumns() => _InvalidConstraint(SR.DataKey_NoColumns);
+        public static Exception KeyTooManyColumns(int cols) => _InvalidConstraint(SR.Format(SR.DataKey_TooManyColumns, (cols).ToString(CultureInfo.InvariantCulture)));
+        public static Exception KeyDuplicateColumns(string columnName) => _InvalidConstraint(SR.Format(SR.DataKey_DuplicateColumns, columnName));
+
+        //
+        // Relations, constraints
+        //
+
+        public static Exception RelationDataSetMismatch() => _InvalidConstraint(SR.DataRelation_DataSetMismatch);
+        public static Exception NoRelationName() => _Argument(SR.DataRelation_NoName);
+        public static Exception ColumnsTypeMismatch() => _InvalidConstraint(SR.DataRelation_ColumnsTypeMismatch);
+        public static Exception KeyLengthMismatch() => _Argument(SR.DataRelation_KeyLengthMismatch);
+        public static Exception KeyLengthZero() => _Argument(SR.DataRelation_KeyZeroLength);
+        public static Exception ForeignRelation() => _Argument(SR.DataRelation_ForeignDataSet);
+        public static Exception KeyColumnsIdentical() => _InvalidConstraint(SR.DataRelation_KeyColumnsIdentical);
+        public static Exception RelationForeignTable(string t1, string t2) => _InvalidConstraint(SR.Format(SR.DataRelation_ForeignTable, t1, t2));
+        public static Exception GetParentRowTableMismatch(string t1, string t2) => _InvalidConstraint(SR.Format(SR.DataRelation_GetParentRowTableMismatch, t1, t2));
+        public static Exception SetParentRowTableMismatch(string t1, string t2) => _InvalidConstraint(SR.Format(SR.DataRelation_SetParentRowTableMismatch, t1, t2));
+        public static Exception RelationForeignRow() => _Argument(SR.DataRelation_ForeignRow);
+        public static Exception RelationNestedReadOnly() => _Argument(SR.DataRelation_RelationNestedReadOnly);
+        public static Exception TableCantBeNestedInTwoTables(string tableName) => _Argument(SR.Format(SR.DataRelation_TableCantBeNestedInTwoTables, tableName));
+        public static Exception LoopInNestedRelations(string tableName) => _Argument(SR.Format(SR.DataRelation_LoopInNestedRelations, tableName));
+        public static Exception RelationDoesNotExist() => _Argument(SR.DataRelation_DoesNotExist);
+        public static Exception ParentRowNotInTheDataSet() => _Argument(SR.DataRow_ParentRowNotInTheDataSet);
+        public static Exception ParentOrChildColumnsDoNotHaveDataSet() => _InvalidConstraint(SR.DataRelation_ParentOrChildColumnsDoNotHaveDataSet);
+        public static Exception InValidNestedRelation(string childTableName) => _InvalidOperation(SR.Format(SR.DataRelation_InValidNestedRelation, childTableName));
+        public static Exception InvalidParentNamespaceinNestedRelation(string childTableName) => _InvalidOperation(SR.Format(SR.DataRelation_InValidNamespaceInNestedRelation, childTableName));
+
+        //
+        // Rows
+        //
+
+        public static Exception RowNotInTheDataSet() => _Argument(SR.DataRow_NotInTheDataSet);
+        public static Exception RowNotInTheTable() => _RowNotInTable(SR.DataRow_NotInTheTable);
+        public static Exception EditInRowChanging() => _InRowChangingEvent(SR.DataRow_EditInRowChanging);
+        public static Exception EndEditInRowChanging() => _InRowChangingEvent(SR.DataRow_EndEditInRowChanging);
+        public static Exception BeginEditInRowChanging() => _InRowChangingEvent(SR.DataRow_BeginEditInRowChanging);
+        public static Exception CancelEditInRowChanging() => _InRowChangingEvent(SR.DataRow_CancelEditInRowChanging);
+        public static Exception DeleteInRowDeleting() => _InRowChangingEvent(SR.DataRow_DeleteInRowDeleting);
+        public static Exception ValueArrayLength() => _Argument(SR.DataRow_ValuesArrayLength);
+        public static Exception NoCurrentData() => _VersionNotFound(SR.DataRow_NoCurrentData);
+        public static Exception NoOriginalData() => _VersionNotFound(SR.DataRow_NoOriginalData);
+        public static Exception NoProposedData() => _VersionNotFound(SR.DataRow_NoProposedData);
+        public static Exception RowRemovedFromTheTable() => _RowNotInTable(SR.DataRow_RemovedFromTheTable);
+        public static Exception DeletedRowInaccessible() => _DeletedRowInaccessible(SR.DataRow_DeletedRowInaccessible);
+        public static Exception RowAlreadyDeleted() => _DeletedRowInaccessible(SR.DataRow_AlreadyDeleted);
+        public static Exception RowEmpty() => _Argument(SR.DataRow_Empty);
+        public static Exception InvalidRowVersion() => _Data(SR.DataRow_InvalidVersion);
+        public static Exception RowOutOfRange() => _IndexOutOfRange(SR.DataRow_RowOutOfRange);
+        public static Exception RowOutOfRange(int index) => _IndexOutOfRange(SR.Format(SR.DataRow_OutOfRange, (index).ToString(CultureInfo.InvariantCulture)));
+        public static Exception RowInsertOutOfRange(int index) => _IndexOutOfRange(SR.Format(SR.DataRow_RowInsertOutOfRange, (index).ToString(CultureInfo.InvariantCulture)));
+        public static Exception RowInsertTwice(int index, string tableName) => _IndexOutOfRange(SR.Format(SR.DataRow_RowInsertTwice, (index).ToString(CultureInfo.InvariantCulture), tableName));
+        public static Exception RowInsertMissing(string tableName) => _IndexOutOfRange(SR.Format(SR.DataRow_RowInsertMissing, tableName));
+        public static Exception RowAlreadyRemoved() => _Data(SR.DataRow_AlreadyRemoved);
+        public static Exception MultipleParents() => _Data(SR.DataRow_MultipleParents);
+        public static Exception InvalidRowState(DataRowState state) => _InvalidEnumArgumentException<DataRowState>(state);
+        public static Exception InvalidRowBitPattern() => _Argument(SR.DataRow_InvalidRowBitPattern);
+
+        //
+        // DataSet
+        //
+
+        internal static Exception SetDataSetNameToEmpty() => _Argument(SR.DataSet_SetNameToEmpty);
+        internal static Exception SetDataSetNameConflicting(string name) => _Argument(SR.Format(SR.DataSet_SetDataSetNameConflicting, name));
+        public static Exception DataSetUnsupportedSchema(string ns) => _Argument(SR.Format(SR.DataSet_UnsupportedSchema, ns));
+        public static Exception MergeMissingDefinition(string obj) => _Argument(SR.Format(SR.DataMerge_MissingDefinition, obj));
+        public static Exception TablesInDifferentSets() => _Argument(SR.DataRelation_TablesInDifferentSets);
+        public static Exception RelationAlreadyExists() => _Argument(SR.DataRelation_AlreadyExists);
+        public static Exception RowAlreadyInOtherCollection() => _Argument(SR.DataRow_AlreadyInOtherCollection);
+        public static Exception RowAlreadyInTheCollection() => _Argument(SR.DataRow_AlreadyInTheCollection);
+        public static Exception TableMissingPrimaryKey() => _MissingPrimaryKey(SR.DataTable_MissingPrimaryKey);
+        public static Exception RecordStateRange() => _Argument(SR.DataIndex_RecordStateRange);
+        public static Exception IndexKeyLength(int length, int keyLength) => length == 0 ?
+            _Argument(SR.DataIndex_FindWithoutSortOrder) :
+            _Argument(SR.Format(SR.DataIndex_KeyLength, (length).ToString(CultureInfo.InvariantCulture), (keyLength).ToString(CultureInfo.InvariantCulture)));
+        public static Exception RemovePrimaryKey(DataTable table) => table.TableName.Length == 0 ?
+            _Argument(SR.DataKey_RemovePrimaryKey) :
+            _Argument(SR.Format(SR.DataKey_RemovePrimaryKey1, table.TableName));
+        public static Exception RelationAlreadyInOtherDataSet() => _Argument(SR.DataRelation_AlreadyInOtherDataSet);
+        public static Exception RelationAlreadyInTheDataSet() => _Argument(SR.DataRelation_AlreadyInTheDataSet);
+        public static Exception RelationNotInTheDataSet(string relation) => _Argument(SR.Format(SR.DataRelation_NotInTheDataSet, relation));
+        public static Exception RelationOutOfRange(object index) => _IndexOutOfRange(SR.Format(SR.DataRelation_OutOfRange, Convert.ToString(index, null)));
+        public static Exception DuplicateRelation(string relation) => _DuplicateName(SR.Format(SR.DataRelation_DuplicateName, relation));
+        public static Exception RelationTableNull() => _Argument(SR.DataRelation_TableNull);
+        public static Exception RelationDataSetNull() => _Argument(SR.DataRelation_TableNull);
+        public static Exception RelationTableWasRemoved() => _Argument(SR.DataRelation_TableWasRemoved);
+        public static Exception ParentTableMismatch() => _Argument(SR.DataRelation_ParentTableMismatch);
+        public static Exception ChildTableMismatch() => _Argument(SR.DataRelation_ChildTableMismatch);
+        public static Exception EnforceConstraint() => _Constraint(SR.Data_EnforceConstraints);
+        public static Exception CaseLocaleMismatch() => _Argument(SR.DataRelation_CaseLocaleMismatch);
+        public static Exception CannotChangeCaseLocale() => CannotChangeCaseLocale(null);
+        public static Exception CannotChangeCaseLocale(Exception innerException) => _Argument(SR.DataSet_CannotChangeCaseLocale, innerException);
+        public static Exception CannotChangeSchemaSerializationMode() => _InvalidOperation(SR.DataSet_CannotChangeSchemaSerializationMode);
+        public static Exception InvalidSchemaSerializationMode(Type enumType, string mode) => _InvalidEnumArgumentException(SR.Format(SR.ADP_InvalidEnumerationValue, enumType.Name, mode));
+        public static Exception InvalidRemotingFormat(SerializationFormat mode) => _InvalidEnumArgumentException<SerializationFormat>(mode);
+
+        //
+        // DataTable and DataTableCollection
+        //
+        public static Exception TableForeignPrimaryKey() => _Argument(SR.DataTable_ForeignPrimaryKey);
+        public static Exception TableCannotAddToSimpleContent() => _Argument(SR.DataTable_CannotAddToSimpleContent);
+        public static Exception NoTableName() => _Argument(SR.DataTable_NoName);
+        public static Exception MultipleTextOnlyColumns() => _Argument(SR.DataTable_MultipleSimpleContentColumns);
+        public static Exception InvalidSortString(string sort) => _Argument(SR.Format(SR.DataTable_InvalidSortString, sort));
+        public static Exception DuplicateTableName(string table) => _DuplicateName(SR.Format(SR.DataTable_DuplicateName, table));
+        public static Exception DuplicateTableName2(string table, string ns) => _DuplicateName(SR.Format(SR.DataTable_DuplicateName2, table, ns));
+        public static Exception SelfnestedDatasetConflictingName(string table) => _DuplicateName(SR.Format(SR.DataTable_SelfnestedDatasetConflictingName, table));
+        public static Exception DatasetConflictingName(string table) => _DuplicateName(SR.Format(SR.DataTable_DatasetConflictingName, table));
+        public static Exception TableAlreadyInOtherDataSet() => _Argument(SR.DataTable_AlreadyInOtherDataSet);
+        public static Exception TableAlreadyInTheDataSet() => _Argument(SR.DataTable_AlreadyInTheDataSet);
+        public static Exception TableOutOfRange(int index) => _IndexOutOfRange(SR.Format(SR.DataTable_OutOfRange, (index).ToString(CultureInfo.InvariantCulture)));
+        public static Exception TableNotInTheDataSet(string table) => _Argument(SR.Format(SR.DataTable_NotInTheDataSet, table));
+        public static Exception TableInRelation() => _Argument(SR.DataTable_InRelation);
+        public static Exception TableInConstraint(DataTable table, Constraint constraint) => _Argument(SR.Format(SR.DataTable_InConstraint, table.TableName, constraint.ConstraintName));
+        public static Exception CanNotSerializeDataTableHierarchy() => _InvalidOperation(SR.DataTable_CanNotSerializeDataTableHierarchy);
+        public static Exception CanNotRemoteDataTable() => _InvalidOperation(SR.DataTable_CanNotRemoteDataTable);
+        public static Exception CanNotSetRemotingFormat() => _Argument(SR.DataTable_CanNotSetRemotingFormat);
+        public static Exception CanNotSerializeDataTableWithEmptyName() => _InvalidOperation(SR.DataTable_CanNotSerializeDataTableWithEmptyName);
+        public static Exception TableNotFound(string tableName) => _Argument(SR.Format(SR.DataTable_TableNotFound, tableName));
+
+
+        //
+        // Storage
+        //
+        public static Exception AggregateException(AggregateType aggregateType, Type type) => _Data(SR.Format(SR.DataStorage_AggregateException, aggregateType.ToString(), type.Name));
+        public static Exception InvalidStorageType(TypeCode typecode) => _Data(SR.Format(SR.DataStorage_InvalidStorageType, typecode.ToString()));
+        public static Exception RangeArgument(int min, int max) => _Argument(SR.Format(SR.Range_Argument, (min).ToString(CultureInfo.InvariantCulture), (max).ToString(CultureInfo.InvariantCulture)));
+        public static Exception NullRange() => _Data(SR.Range_NullRange);
+        public static Exception NegativeMinimumCapacity() => _Argument(SR.RecordManager_MinimumCapacity);
+        public static Exception ProblematicChars(char charValue) => _Argument(SR.Format(SR.DataStorage_ProblematicChars, "0x" + ((ushort)charValue).ToString("X", CultureInfo.InvariantCulture)));
+        public static Exception StorageSetFailed() => _Argument(SR.DataStorage_SetInvalidDataType);
+
+
+        //
+        // XML schema
+        //
+        public static Exception SimpleTypeNotSupported() => _Data(SR.Xml_SimpleTypeNotSupported);
+        public static Exception MissingAttribute(string attribute) => MissingAttribute(string.Empty, attribute);
+        public static Exception MissingAttribute(string element, string attribute) => _Data(SR.Format(SR.Xml_MissingAttribute, element, attribute));
+        public static Exception InvalidAttributeValue(string name, string value) => _Data(SR.Format(SR.Xml_ValueOutOfRange, name, value));
+        public static Exception AttributeValues(string name, string value1, string value2) => _Data(SR.Format(SR.Xml_AttributeValues, name, value1, value2));
+        public static Exception ElementTypeNotFound(string name) => _Data(SR.Format(SR.Xml_ElementTypeNotFound, name));
+        public static Exception RelationParentNameMissing(string rel) => _Data(SR.Format(SR.Xml_RelationParentNameMissing, rel));
+        public static Exception RelationChildNameMissing(string rel) => _Data(SR.Format(SR.Xml_RelationChildNameMissing, rel));
+        public static Exception RelationTableKeyMissing(string rel) => _Data(SR.Format(SR.Xml_RelationTableKeyMissing, rel));
+        public static Exception RelationChildKeyMissing(string rel) => _Data(SR.Format(SR.Xml_RelationChildKeyMissing, rel));
+        public static Exception UndefinedDatatype(string name) => _Data(SR.Format(SR.Xml_UndefinedDatatype, name));
+        public static Exception DatatypeNotDefined() => _Data(SR.Xml_DatatypeNotDefined);
+        public static Exception MismatchKeyLength() => _Data(SR.Xml_MismatchKeyLength);
+        public static Exception InvalidField(string name) => _Data(SR.Format(SR.Xml_InvalidField, name));
+        public static Exception InvalidSelector(string name) => _Data(SR.Format(SR.Xml_InvalidSelector, name));
+        public static Exception CircularComplexType(string name) => _Data(SR.Format(SR.Xml_CircularComplexType, name));
+        public static Exception CannotInstantiateAbstract(string name) => _Data(SR.Format(SR.Xml_CannotInstantiateAbstract, name));
+        public static Exception InvalidKey(string name) => _Data(SR.Format(SR.Xml_InvalidKey, name));
+        public static Exception DiffgramMissingTable(string name) => _Data(SR.Format(SR.Xml_MissingTable, name));
+        public static Exception DiffgramMissingSQL() => _Data(SR.Xml_MissingSQL);
+        public static Exception DuplicateConstraintRead(string str) => _Data(SR.Format(SR.Xml_DuplicateConstraint, str));
+        public static Exception ColumnTypeConflict(string name) => _Data(SR.Format(SR.Xml_ColumnConflict, name));
+        public static Exception CannotConvert(string name, string type) => _Data(SR.Format(SR.Xml_CannotConvert, name, type));
+        public static Exception MissingRefer(string name) => _Data(SR.Format(SR.Xml_MissingRefer, Keywords.REFER, Keywords.XSD_KEYREF, name));
+        public static Exception InvalidPrefix(string name) => _Data(SR.Format(SR.Xml_InvalidPrefix, name));
+        public static Exception CanNotDeserializeObjectType() => _InvalidOperation(SR.Xml_CanNotDeserializeObjectType);
+        public static Exception IsDataSetAttributeMissingInSchema() => _Data(SR.Xml_IsDataSetAttributeMissingInSchema);
+        public static Exception TooManyIsDataSetAtributeInSchema() => _Data(SR.Xml_TooManyIsDataSetAtributeInSchema);
+
+        // XML save
+        public static Exception NestedCircular(string name) => _Data(SR.Format(SR.Xml_NestedCircular, name));
+        public static Exception MultipleParentRows(string tableQName) => _Data(SR.Format(SR.Xml_MultipleParentRows, tableQName));
+        public static Exception PolymorphismNotSupported(string typeName) => _InvalidOperation(SR.Format(SR.Xml_PolymorphismNotSupported, typeName));
+        public static Exception DataTableInferenceNotSupported() => _InvalidOperation(SR.Xml_DataTableInferenceNotSupported);
+
+        /// <summary>throw DataException for multitarget failure</summary>
+        internal static void ThrowMultipleTargetConverter(Exception innerException)
+        {
+            string res = (null != innerException) ? SR.Xml_MultipleTargetConverterError : SR.Xml_MultipleTargetConverterEmpty;
+            ThrowDataException(res, innerException);
+        }
+
+        // Merge
+        public static Exception DuplicateDeclaration(string name) => _Data(SR.Format(SR.Xml_MergeDuplicateDeclaration, name));
+
+        //Read Xml data
+        public static Exception FoundEntity() => _Data(SR.Xml_FoundEntity);
+        public static Exception MergeFailed(string name) => _Data(name);
+
+        // SqlConvert
+        public static Exception ConvertFailed(Type type1, Type type2) => _Data(SR.Format(SR.SqlConvert_ConvertFailed, type1.FullName, type2.FullName));
+
+        // DataTableReader
+        public static Exception InvalidDataTableReader(string tableName) => _InvalidOperation(SR.Format(SR.DataTableReader_InvalidDataTableReader, tableName));
+        public static Exception DataTableReaderSchemaIsInvalid(string tableName) => _InvalidOperation(SR.Format(SR.DataTableReader_SchemaInvalidDataTableReader, tableName));
+        public static Exception CannotCreateDataReaderOnEmptyDataSet() => _Argument(SR.DataTableReader_CannotCreateDataReaderOnEmptyDataSet);
+        public static Exception DataTableReaderArgumentIsEmpty() => _Argument(SR.DataTableReader_DataTableReaderArgumentIsEmpty);
+        public static Exception ArgumentContainsNullValue() => _Argument(SR.DataTableReader_ArgumentContainsNullValue);
+        public static Exception InvalidCurrentRowInDataTableReader() => _DeletedRowInaccessible(SR.DataTableReader_InvalidRowInDataTableReader);
+        public static Exception EmptyDataTableReader(string tableName) => _DeletedRowInaccessible(SR.Format(SR.DataTableReader_DataTableCleared, tableName));
+        internal static Exception InvalidDuplicateNamedSimpleTypeDelaration(string stName, string errorStr) => _Argument(SR.Format(SR.NamedSimpleType_InvalidDuplicateNamedSimpleTypeDelaration, stName, errorStr));
+
+        // RbTree
+        internal static Exception InternalRBTreeError(RBTreeError internalError) => _InvalidOperation(SR.Format(SR.RbTree_InvalidState, (int)internalError));
+        public static Exception EnumeratorModified() => _InvalidOperation(SR.RbTree_EnumerationBroken);
+    }
+}

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataException.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataException.cs
@@ -372,6 +372,7 @@ namespace System.Data
         public static Exception ArgumentOutOfRange(string paramName) => _ArgumentOutOfRange(paramName, SR.Format(SR.Data_ArgumentOutOfRange, paramName));
         public static Exception BadObjectPropertyAccess(string error) => _InvalidOperation(SR.Format(SR.DataConstraint_BadObjectPropertyAccess, error));
         public static Exception ArgumentContainsNull(string paramName) => _Argument(paramName, SR.Format(SR.Data_ArgumentContainsNull, paramName));
+        public static Exception TypeNotAllowed(Type type) => _InvalidOperation(SR.Format(SR.Data_TypeNotAllowed, type.AssemblyQualifiedName));
 
 
         //

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataSet.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataSet.cs
@@ -1,0 +1,3543 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace System.Data
+{
+    /// <summary>
+    /// Represents an in-memory cache of data.
+    /// </summary>
+    [DefaultProperty(nameof(DataSetName))]
+    [Serializable]
+    [XmlSchemaProvider(nameof(GetDataSetSchema))]
+    [XmlRoot(nameof(DataSet))]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#else
+    [System.ComponentModel.ToolboxItemAttribute("Microsoft.VSDesigner.Data.VS.DataSetToolboxItem, Microsoft.VSDesigner, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+#endif
+    public class DataSet : MarshalByValueComponent, IListSource, IXmlSerializable, ISupportInitializeNotification, ISerializable
+    {
+        private const string KEY_XMLSCHEMA = "XmlSchema";
+        private const string KEY_XMLDIFFGRAM = "XmlDiffGram";
+
+        private DataViewManager _defaultViewManager;
+
+        // Public Collections
+        private readonly DataTableCollection _tableCollection;
+        private readonly DataRelationCollection _relationCollection;
+        internal PropertyCollection _extendedProperties = null;
+        private string _dataSetName = "NewDataSet";
+        private string _datasetPrefix = string.Empty;
+        internal string _namespaceURI = string.Empty;
+        private bool _enforceConstraints = true;
+
+        // globalization stuff
+        private bool _caseSensitive;
+        private CultureInfo _culture;
+        private bool _cultureUserSet;
+
+        // Internal definitions
+        internal bool _fInReadXml = false;
+        internal bool _fInLoadDiffgram = false;
+        internal bool _fTopLevelTable = false;
+        internal bool _fInitInProgress = false;
+        internal bool _fEnableCascading = true;
+        internal bool _fIsSchemaLoading = false;
+        private bool _fBoundToDocument;        // for XmlDataDocument
+
+        internal string _mainTableName = string.Empty;
+
+        //default remoting format is XML
+        private SerializationFormat _remotingFormat = SerializationFormat.Xml;
+
+        private object _defaultViewManagerLock = new object();
+
+        private static int s_objectTypeCount; // Bid counter
+        private readonly int _objectID = Interlocked.Increment(ref s_objectTypeCount);
+        private static XmlSchemaComplexType s_schemaTypeForWSDL = null;
+
+        internal bool _useDataSetSchemaOnly; // UseDataSetSchemaOnly  , for YUKON
+        internal bool _udtIsWrapped; // if UDT is wrapped , for YUKON
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DataSet'/> class.
+        /// </summary>
+        public DataSet()
+        {
+            GC.SuppressFinalize(this);
+            DataCommonEventSource.Log.Trace("<ds.DataSet.DataSet|API> {0}", ObjectID); // others will call this constr
+
+            // Set default locale
+            _tableCollection = new DataTableCollection(this);
+            _relationCollection = new DataRelationCollection.DataSetRelationCollection(this);
+            _culture = CultureInfo.CurrentCulture; // Set default locale
+        }
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref='System.Data.DataSet'/>
+        /// class with the given name.
+        /// </summary>
+        public DataSet(string dataSetName) : this()
+        {
+            DataSetName = dataSetName;
+        }
+
+        [DefaultValue(SerializationFormat.Xml)]
+        public SerializationFormat RemotingFormat
+        {
+            get { return _remotingFormat; }
+            set
+            {
+                if (value != SerializationFormat.Binary && value != SerializationFormat.Xml)
+                {
+                    throw ExceptionBuilder.InvalidRemotingFormat(value);
+                }
+                _remotingFormat = value;
+                // this property is inherited to DataTable from DataSet.So we set this value to DataTable also
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    Tables[i].RemotingFormat = value;
+                }
+            }
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public virtual SchemaSerializationMode SchemaSerializationMode
+        {
+            //Typed DataSet calls into this
+            get { return SchemaSerializationMode.IncludeSchema; }
+            set
+            {
+                if (value != SchemaSerializationMode.IncludeSchema)
+                {
+                    throw ExceptionBuilder.CannotChangeSchemaSerializationMode();
+                }
+            }
+        }
+
+        // Check whether the stream is binary serialized.
+        // 'static' function that consumes SerializationInfo
+        protected bool IsBinarySerialized(SerializationInfo info, StreamingContext context)
+        {
+            // mainly for typed DS
+            // our default remoting format is XML
+            SerializationFormat remotingFormat = SerializationFormat.Xml;
+            SerializationInfoEnumerator e = info.GetEnumerator();
+
+            while (e.MoveNext())
+            {
+                if (e.Name == "DataSet.RemotingFormat")
+                {
+                    //DataSet.RemotingFormat does not exist in V1/V1.1 versions
+                    remotingFormat = (SerializationFormat)e.Value;
+                    break;
+                }
+            }
+
+            return (remotingFormat == SerializationFormat.Binary);
+        }
+
+        // Should Schema be included during Serialization
+        // 'static' function that consumes SerializationInfo
+        protected SchemaSerializationMode DetermineSchemaSerializationMode(SerializationInfo info, StreamingContext context)
+        {
+            //Typed DataSet calls into this
+            SchemaSerializationMode schemaSerializationMode = SchemaSerializationMode.IncludeSchema;
+            SerializationInfoEnumerator e = info.GetEnumerator();
+
+            while (e.MoveNext())
+            {
+                if (e.Name == "SchemaSerializationMode.DataSet")
+                { //SchemaSerializationMode.DataSet does not exist in V1/V1.1 versions
+                    schemaSerializationMode = (SchemaSerializationMode)e.Value;
+                    break;
+                }
+            }
+            return schemaSerializationMode;
+        }
+
+        protected SchemaSerializationMode DetermineSchemaSerializationMode(XmlReader reader)
+        {
+            //Typed DataSet calls into this
+            SchemaSerializationMode schemaSerializationMode = SchemaSerializationMode.IncludeSchema;
+            reader.MoveToContent();
+            if (reader.NodeType == XmlNodeType.Element)
+            {
+                if (reader.HasAttributes)
+                {
+                    string attribValue = reader.GetAttribute(Keywords.MSD_SCHEMASERIALIZATIONMODE, Keywords.MSDNS);
+                    if (string.Equals(attribValue, Keywords.MSD_EXCLUDESCHEMA, StringComparison.OrdinalIgnoreCase))
+                    {
+                        schemaSerializationMode = SchemaSerializationMode.ExcludeSchema;
+                    }
+                    else if (string.Equals(attribValue, Keywords.MSD_INCLUDESCHEMA, StringComparison.OrdinalIgnoreCase))
+                    {
+                        schemaSerializationMode = SchemaSerializationMode.IncludeSchema;
+                    }
+                    else if (attribValue != null)
+                    {
+                        // if attrib does not exist, then don't throw
+                        throw ExceptionBuilder.InvalidSchemaSerializationMode(typeof(SchemaSerializationMode), attribValue);
+                    }
+                }
+            }
+            return schemaSerializationMode;
+        }
+
+
+        // Deserialize all the tables data of the dataset from binary/xml stream.
+        // 'instance' method that consumes SerializationInfo
+        protected void GetSerializationData(SerializationInfo info, StreamingContext context)
+        {
+            // mainly for typed DS
+            SerializationFormat remotingFormat = SerializationFormat.Xml;
+            SerializationInfoEnumerator e = info.GetEnumerator();
+
+            while (e.MoveNext())
+            {
+                if (e.Name == "DataSet.RemotingFormat")
+                { //DataSet.RemotingFormat does not exist in V1/V1.1 versions
+                    remotingFormat = (SerializationFormat)e.Value;
+                    break;
+                }
+            }
+
+            DeserializeDataSetData(info, context, remotingFormat);
+        }
+
+
+        // Deserialize all the tables schema and data of the dataset from binary/xml stream.
+        protected DataSet(SerializationInfo info, StreamingContext context) : this(info, context, true)
+        {
+        }
+
+        protected DataSet(SerializationInfo info, StreamingContext context, bool ConstructSchema) : this()
+        {
+            SerializationFormat remotingFormat = SerializationFormat.Xml;
+            SchemaSerializationMode schemaSerializationMode = SchemaSerializationMode.IncludeSchema;
+            SerializationInfoEnumerator e = info.GetEnumerator();
+
+            while (e.MoveNext())
+            {
+                switch (e.Name)
+                {
+                    case "DataSet.RemotingFormat": //DataSet.RemotingFormat does not exist in V1/V1.1 versions
+                        remotingFormat = (SerializationFormat)e.Value;
+                        break;
+                    case "SchemaSerializationMode.DataSet": //SchemaSerializationMode.DataSet does not exist in V1/V1.1 versions
+                        schemaSerializationMode = (SchemaSerializationMode)e.Value;
+                        break;
+                }
+            }
+
+            if (schemaSerializationMode == SchemaSerializationMode.ExcludeSchema)
+            {
+                InitializeDerivedDataSet();
+            }
+
+            // adding back this check will fix typed dataset XML remoting, but we have to fix case that 
+            // a class inherits from DataSet and just relies on DataSet to deserialize (see SQL BU DT 374717)
+            // to fix that case also, we need to add a flag and add it to below check so return (no-op) will be 
+            // conditional (flag needs to be set in TypedDataSet
+            if (remotingFormat == SerializationFormat.Xml && !ConstructSchema)
+            {
+                return; //For typed dataset xml remoting, this is a no-op
+            }
+
+            DeserializeDataSet(info, context, remotingFormat, schemaSerializationMode);
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            SerializationFormat remotingFormat = RemotingFormat;
+            SerializeDataSet(info, context, remotingFormat);
+        }
+
+        // Deserialize all the tables data of the dataset from binary/xml stream.
+        protected virtual void InitializeDerivedDataSet() { }
+
+        // Serialize all the tables.
+        private void SerializeDataSet(SerializationInfo info, StreamingContext context, SerializationFormat remotingFormat)
+        {
+            Debug.Assert(info != null);
+            info.AddValue("DataSet.RemotingVersion", new Version(2, 0));
+
+            // SqlHotFix 299, SerializationFormat enumeration types don't exist in V1.1 SP1
+            if (SerializationFormat.Xml != remotingFormat)
+            {
+                info.AddValue("DataSet.RemotingFormat", remotingFormat);
+            }
+
+            // SqlHotFix 299, SchemaSerializationMode enumeration types don't exist in V1.1 SP1
+            if (SchemaSerializationMode.IncludeSchema != SchemaSerializationMode)
+            {
+                //SkipSchemaDuringSerialization
+                info.AddValue("SchemaSerializationMode.DataSet", SchemaSerializationMode);
+            }
+
+            if (remotingFormat != SerializationFormat.Xml)
+            {
+                if (SchemaSerializationMode == SchemaSerializationMode.IncludeSchema)
+                {
+                    //DataSet public state properties
+                    SerializeDataSetProperties(info, context);
+
+                    //Tables Count
+                    info.AddValue("DataSet.Tables.Count", Tables.Count);
+
+                    //Tables, Columns, Rows
+                    for (int i = 0; i < Tables.Count; i++)
+                    {
+                        BinaryFormatter bf = new BinaryFormatter(null, new StreamingContext(context.State, false));
+                        MemoryStream memStream = new MemoryStream();
+                        bf.Serialize(memStream, Tables[i]);
+                        memStream.Position = 0;
+                        info.AddValue(string.Format(CultureInfo.InvariantCulture, "DataSet.Tables_{0}", i), memStream.GetBuffer());
+                    }
+
+                    //Constraints
+                    for (int i = 0; i < Tables.Count; i++)
+                    {
+                        Tables[i].SerializeConstraints(info, context, i, true);
+                    }
+
+                    //Relations
+                    SerializeRelations(info, context);
+
+                    //Expression Columns
+                    for (int i = 0; i < Tables.Count; i++)
+                    {
+                        Tables[i].SerializeExpressionColumns(info, context, i);
+                    }
+                }
+                else
+                {
+                    //Serialize  DataSet public properties.
+                    SerializeDataSetProperties(info, context);
+                }
+
+                //Rows
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    Tables[i].SerializeTableData(info, context, i);
+                }
+            }
+            else
+            {
+                // old behaviour
+                string strSchema = GetXmlSchemaForRemoting(null);
+
+                string strData = null;
+                info.AddValue(KEY_XMLSCHEMA, strSchema);
+
+                StringBuilder strBuilder = new StringBuilder(EstimatedXmlStringSize() * 2);
+                StringWriter strWriter = new StringWriter(strBuilder, CultureInfo.InvariantCulture);
+                XmlTextWriter w = new XmlTextWriter(strWriter);
+                WriteXml(w, XmlWriteMode.DiffGram);
+                strData = strWriter.ToString();
+                info.AddValue(KEY_XMLDIFFGRAM, strData);
+            }
+        }
+
+        // Deserialize all the tables - marked internal so that DataTable can call into this
+        internal void DeserializeDataSet(SerializationInfo info, StreamingContext context, SerializationFormat remotingFormat, SchemaSerializationMode schemaSerializationMode)
+        {
+            // deserialize schema
+            DeserializeDataSetSchema(info, context, remotingFormat, schemaSerializationMode);
+            // deserialize data
+            DeserializeDataSetData(info, context, remotingFormat);
+        }
+
+        // Deserialize schema.
+        private void DeserializeDataSetSchema(SerializationInfo info, StreamingContext context, SerializationFormat remotingFormat, SchemaSerializationMode schemaSerializationMode)
+        {
+            if (remotingFormat != SerializationFormat.Xml)
+            {
+                if (schemaSerializationMode == SchemaSerializationMode.IncludeSchema)
+                {
+                    //DataSet public state properties
+                    DeserializeDataSetProperties(info, context);
+
+                    //Tables Count
+                    int tableCount = info.GetInt32("DataSet.Tables.Count");
+
+                    //Tables, Columns, Rows
+                    for (int i = 0; i < tableCount; i++)
+                    {
+                        byte[] buffer = (byte[])info.GetValue(string.Format(CultureInfo.InvariantCulture, "DataSet.Tables_{0}", i), typeof(byte[]));
+                        MemoryStream memStream = new MemoryStream(buffer);
+                        memStream.Position = 0;
+                        BinaryFormatter bf = new BinaryFormatter(null, new StreamingContext(context.State, false));
+                        DataTable dt = (DataTable)bf.Deserialize(memStream);
+                        Tables.Add(dt);
+                    }
+
+                    //Constraints
+                    for (int i = 0; i < tableCount; i++)
+                    {
+                        Tables[i].DeserializeConstraints(info, context,  /* table index */i,  /* serialize all constraints */ true); //
+                    }
+
+                    //Relations
+                    DeserializeRelations(info, context);
+
+                    //Expression Columns
+                    for (int i = 0; i < tableCount; i++)
+                    {
+                        Tables[i].DeserializeExpressionColumns(info, context, i);
+                    }
+                }
+                else
+                {
+                    //DeSerialize DataSet public properties.[Locale, CaseSensitive and EnforceConstraints]
+                    DeserializeDataSetProperties(info, context);
+                }
+            }
+            else
+            {
+                string strSchema = (string)info.GetValue(KEY_XMLSCHEMA, typeof(string));
+
+                if (strSchema != null)
+                {
+                    ReadXmlSchema(new XmlTextReader(new StringReader(strSchema)), true);
+                }
+            }
+        }
+
+        // Deserialize all  data.
+        private void DeserializeDataSetData(SerializationInfo info, StreamingContext context, SerializationFormat remotingFormat)
+        {
+            if (remotingFormat != SerializationFormat.Xml)
+            {
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    Tables[i].DeserializeTableData(info, context, i);
+                }
+            }
+            else
+            {
+                string strData = (string)info.GetValue(KEY_XMLDIFFGRAM, typeof(string));
+
+                if (strData != null)
+                {
+                    ReadXml(new XmlTextReader(new StringReader(strData)), XmlReadMode.DiffGram);
+                }
+            }
+        }
+
+        // Serialize just the dataset properties
+        private void SerializeDataSetProperties(SerializationInfo info, StreamingContext context)
+        {
+            //DataSet basic properties
+            info.AddValue("DataSet.DataSetName", DataSetName);
+            info.AddValue("DataSet.Namespace", Namespace);
+            info.AddValue("DataSet.Prefix", Prefix);
+
+            //DataSet runtime properties
+            info.AddValue("DataSet.CaseSensitive", CaseSensitive);
+            info.AddValue("DataSet.LocaleLCID", Locale.LCID);
+            info.AddValue("DataSet.EnforceConstraints", EnforceConstraints);
+
+            //ExtendedProperties
+            info.AddValue("DataSet.ExtendedProperties", ExtendedProperties);
+        }
+
+        // DeSerialize dataset properties
+        private void DeserializeDataSetProperties(SerializationInfo info, StreamingContext context)
+        {
+            //DataSet basic properties
+            _dataSetName = info.GetString("DataSet.DataSetName");
+            _namespaceURI = info.GetString("DataSet.Namespace");
+            _datasetPrefix = info.GetString("DataSet.Prefix");
+
+            //DataSet runtime properties
+            _caseSensitive = info.GetBoolean("DataSet.CaseSensitive");
+            int lcid = (int)info.GetValue("DataSet.LocaleLCID", typeof(int));
+            _culture = new CultureInfo(lcid);
+            _cultureUserSet = true;
+            _enforceConstraints = info.GetBoolean("DataSet.EnforceConstraints");
+
+            //ExtendedProperties
+            _extendedProperties = (PropertyCollection)info.GetValue("DataSet.ExtendedProperties", typeof(PropertyCollection));
+        }
+
+        // Gets relation info from the dataset.
+        // ***Schema for Serializing ArrayList of Relations***
+        // Relations -> [relationName]->[parentTableIndex, parentcolumnIndexes]->[childTableIndex, childColumnIndexes]->[Nested]->[extendedProperties]
+        private void SerializeRelations(SerializationInfo info, StreamingContext context)
+        {
+            ArrayList relationList = new ArrayList();
+
+            foreach (DataRelation rel in Relations)
+            {
+                int[] parentInfo = new int[rel.ParentColumns.Length + 1];
+
+                parentInfo[0] = Tables.IndexOf(rel.ParentTable);
+                for (int j = 1; j < parentInfo.Length; j++)
+                {
+                    parentInfo[j] = rel.ParentColumns[j - 1].Ordinal;
+                }
+
+                int[] childInfo = new int[rel.ChildColumns.Length + 1];
+                childInfo[0] = Tables.IndexOf(rel.ChildTable);
+                for (int j = 1; j < childInfo.Length; j++)
+                {
+                    childInfo[j] = rel.ChildColumns[j - 1].Ordinal;
+                }
+
+                ArrayList list = new ArrayList();
+                list.Add(rel.RelationName);
+                list.Add(parentInfo);
+                list.Add(childInfo);
+                list.Add(rel.Nested);
+                list.Add(rel._extendedProperties);
+
+                relationList.Add(list);
+            }
+            info.AddValue("DataSet.Relations", relationList);
+        }
+
+        // Adds relations to the dataset.
+        // ***Schema for Serializing ArrayList of Relations***
+        // Relations -> [relationName]->[parentTableIndex, parentcolumnIndexes]->[childTableIndex, childColumnIndexes]->[Nested]->[extendedProperties]
+        private void DeserializeRelations(SerializationInfo info, StreamingContext context)
+        {
+            ArrayList relationList = (ArrayList)info.GetValue("DataSet.Relations", typeof(ArrayList));
+
+            foreach (ArrayList list in relationList)
+            {
+                string relationName = (string)list[0];
+                int[] parentInfo = (int[])list[1];
+                int[] childInfo = (int[])list[2];
+                bool isNested = (bool)list[3];
+                PropertyCollection extendedProperties = (PropertyCollection)list[4];
+
+                //ParentKey Columns.
+                DataColumn[] parentkeyColumns = new DataColumn[parentInfo.Length - 1];
+                for (int i = 0; i < parentkeyColumns.Length; i++)
+                {
+                    parentkeyColumns[i] = Tables[parentInfo[0]].Columns[parentInfo[i + 1]];
+                }
+
+                //ChildKey Columns.
+                DataColumn[] childkeyColumns = new DataColumn[childInfo.Length - 1];
+                for (int i = 0; i < childkeyColumns.Length; i++)
+                {
+                    childkeyColumns[i] = Tables[childInfo[0]].Columns[childInfo[i + 1]];
+                }
+
+                //Create the Relation, without any constraints[Assumption: The constraints are added earlier than the relations]
+                DataRelation rel = new DataRelation(relationName, parentkeyColumns, childkeyColumns, false);
+                rel.CheckMultipleNested = false; // disable the check for multiple nested parent
+                rel.Nested = isNested;
+                rel._extendedProperties = extendedProperties;
+
+                Relations.Add(rel);
+                rel.CheckMultipleNested = true; // enable the check for multiple nested parent
+            }
+        }
+
+        internal void FailedEnableConstraints()
+        {
+            EnforceConstraints = false;
+            throw ExceptionBuilder.EnforceConstraint();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether string
+        /// comparisons within <see cref='System.Data.DataTable'/>
+        /// objects are case-sensitive.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool CaseSensitive
+        {
+            get { return _caseSensitive; }
+            set
+            {
+                if (_caseSensitive != value)
+                {
+                    bool oldValue = _caseSensitive;
+                    _caseSensitive = value;
+
+                    if (!ValidateCaseConstraint())
+                    {
+                        _caseSensitive = oldValue;
+                        throw ExceptionBuilder.CannotChangeCaseLocale();
+                    }
+
+                    foreach (DataTable table in Tables)
+                    {
+                        table.SetCaseSensitiveValue(value, false, true);
+                    }
+                }
+            }
+        }
+
+        bool IListSource.ContainsListCollection => true;
+
+        /// <summary>
+        /// Gets a custom view of the data contained by the <see cref='System.Data.DataSet'/> , one
+        /// that allows filtering, searching, and navigating through the custom data view.
+        /// </summary>
+        [Browsable(false)]
+        public DataViewManager DefaultViewManager
+        {
+            get
+            {
+                if (_defaultViewManager == null)
+                {
+                    lock (_defaultViewManagerLock)
+                    {
+                        if (_defaultViewManager == null)
+                        {
+                            _defaultViewManager = new DataViewManager(this, true);
+                        }
+                    }
+                }
+                return _defaultViewManager;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether constraint rules are followed when
+        /// attempting any update operation.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool EnforceConstraints
+        {
+            get { return _enforceConstraints; }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.set_EnforceConstraints|API> {0}, {1}", ObjectID, value);
+                try
+                {
+                    if (_enforceConstraints != value)
+                    {
+                        if (value)
+                        {
+                            EnableConstraints();
+                        }
+                        _enforceConstraints = value;
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        internal void RestoreEnforceConstraints(bool value)
+        {
+            _enforceConstraints = value;
+        }
+
+        internal void EnableConstraints()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.EnableConstraints|INFO> {0}", ObjectID);
+            try
+            {
+                bool errors = false;
+                for (ConstraintEnumerator constraints = new ConstraintEnumerator(this); constraints.GetNext();)
+                {
+                    Constraint constraint = constraints.GetConstraint();
+                    errors |= constraint.IsConstraintViolated();
+                }
+
+                foreach (DataTable table in Tables)
+                {
+                    foreach (DataColumn column in table.Columns)
+                    {
+                        if (!column.AllowDBNull)
+                        {
+                            errors |= column.IsNotAllowDBNullViolated();
+                        }
+                        if (column.MaxLength >= 0)
+                        {
+                            errors |= column.IsMaxLengthViolated();
+                        }
+                    }
+                }
+
+                if (errors)
+                {
+                    FailedEnableConstraints();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of this <see cref='System.Data.DataSet'/> .
+        /// </summary>
+        [DefaultValue("")]
+        public string DataSetName
+        {
+            get { return _dataSetName; }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataSet.set_DataSetName|API> {0}, '{1}'", ObjectID, value);
+                if (value != _dataSetName)
+                {
+                    if (value == null || value.Length == 0)
+                    {
+                        throw ExceptionBuilder.SetDataSetNameToEmpty();
+                    }
+
+                    DataTable conflicting = Tables[value, Namespace];
+                    if ((conflicting != null) && (!conflicting._fNestedInDataset))
+                    {
+                        throw ExceptionBuilder.SetDataSetNameConflicting(value);
+                    }
+
+                    RaisePropertyChanging(nameof(DataSetName));
+                    _dataSetName = value;
+                }
+            }
+        }
+
+        [DefaultValue("")]
+        public string Namespace
+        {
+            get { return _namespaceURI; }
+            set
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataSet.set_Namespace|API> {0}, '{1}'", ObjectID, value);
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
+                if (value != _namespaceURI)
+                {
+                    RaisePropertyChanging(nameof(Namespace));
+                    foreach (DataTable dt in Tables)
+                    {
+                        if (dt._tableNamespace != null)
+                        {
+                            continue;
+                        }
+
+                        if ((dt.NestedParentRelations.Length == 0) ||
+                            (dt.NestedParentRelations.Length == 1 && dt.NestedParentRelations[0].ChildTable == dt))
+                        {
+                            if (Tables.Contains(dt.TableName, value, false, true))
+                            {
+                                throw ExceptionBuilder.DuplicateTableName2(dt.TableName, value);
+                            }
+                            dt.CheckCascadingNamespaceConflict(value);
+                            dt.DoRaiseNamespaceChange();
+                        }
+                    }
+                    _namespaceURI = value;
+
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        _datasetPrefix = string.Empty;
+                    }
+                }
+            }
+        }
+
+        [DefaultValue("")]
+        public string Prefix
+        {
+            get { return _datasetPrefix; }
+            set
+            {
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+
+                if ((XmlConvert.DecodeName(value) == value) && (XmlConvert.EncodeName(value) != value))
+                {
+                    throw ExceptionBuilder.InvalidPrefix(value);
+                }
+
+                if (value != _datasetPrefix)
+                {
+                    RaisePropertyChanging(nameof(Prefix));
+                    _datasetPrefix = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection of custom user information.
+        /// </summary>
+        [Browsable(false)]
+        public PropertyCollection ExtendedProperties => _extendedProperties ?? (_extendedProperties = new PropertyCollection());
+
+        /// <summary>
+        /// Gets a value indicating whether there are errors in any
+        /// of the rows in any of the tables of this <see cref='System.Data.DataSet'/> .
+        /// </summary>
+        [Browsable(false)]
+        public bool HasErrors
+        {
+            get
+            {
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    if (Tables[i].HasErrors)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        [Browsable(false)]
+        public bool IsInitialized => !_fInitInProgress;
+
+        /// <summary>
+        /// Gets or sets the locale information used to compare strings within the table.
+        /// </summary>
+        public CultureInfo Locale
+        {
+            get
+            {
+                // used for comparing not formating/parsing
+                Debug.Assert(null != _culture, "DataSet.Locale: null culture");
+                return _culture;
+            }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.set_Locale|API> {0}", ObjectID);
+                try
+                {
+                    if (value != null)
+                    {
+                        if (!_culture.Equals(value))
+                        {
+                            SetLocaleValue(value, true);
+                        }
+                        _cultureUserSet = true;
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        internal void SetLocaleValue(CultureInfo value, bool userSet)
+        {
+            bool flag = false;
+            bool exceptionThrown = false;
+            int tableCount = 0;
+
+            CultureInfo oldLocale = _culture;
+            bool oldUserSet = _cultureUserSet;
+
+            try
+            {
+                _culture = value;
+                _cultureUserSet = userSet;
+
+                foreach (DataTable table in Tables)
+                {
+                    if (!table.ShouldSerializeLocale())
+                    {
+                        bool retchk = table.SetLocaleValue(value, false, false);
+                    }
+                }
+
+                flag = ValidateLocaleConstraint();
+                if (flag)
+                {
+                    flag = false;
+                    foreach (DataTable table in Tables)
+                    {
+                        tableCount++;
+                        if (!table.ShouldSerializeLocale())
+                        {
+                            table.SetLocaleValue(value, false, true);
+                        }
+                    }
+                    flag = true;
+                }
+            }
+            catch
+            {
+                exceptionThrown = true;
+                throw;
+            }
+            finally
+            {
+                if (!flag)
+                { // reset old locale if ValidationFailed or exception thrown
+                    _culture = oldLocale;
+                    _cultureUserSet = oldUserSet;
+                    foreach (DataTable table in Tables)
+                    {
+                        if (!table.ShouldSerializeLocale())
+                        {
+                            table.SetLocaleValue(oldLocale, false, false);
+                        }
+                    }
+                    try
+                    {
+                        for (int i = 0; i < tableCount; ++i)
+                        {
+                            if (!Tables[i].ShouldSerializeLocale())
+                            {
+                                Tables[i].SetLocaleValue(oldLocale, false, true);
+                            }
+                        }
+                    }
+                    catch (Exception e) when (ADP.IsCatchableExceptionType(e))
+                    {
+                        ADP.TraceExceptionWithoutRethrow(e);
+                    }
+                    if (!exceptionThrown)
+                    {
+                        throw ExceptionBuilder.CannotChangeCaseLocale(null);
+                    }
+                }
+            }
+        }
+
+        internal bool ShouldSerializeLocale()
+        {
+            // this method is used design-time scenarios via reflection
+            //   by the property grid to show the Locale property in bold or not
+            //   by the code dom for persisting the Locale property or not
+
+            // we always want the locale persisted if set by user or different the current thread
+            // but that logic should by performed by the serializion code
+            return _cultureUserSet;
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override ISite Site
+        {
+            get { return base.Site; }
+            set
+            {
+                ISite oldSite = Site;
+                if (value == null && oldSite != null)
+                {
+                    IContainer cont = oldSite.Container;
+
+                    if (cont != null)
+                    {
+                        for (int i = 0; i < Tables.Count; i++)
+                        {
+                            if (Tables[i].Site != null)
+                            {
+                                cont.Remove(Tables[i]);
+                            }
+                        }
+                    }
+                }
+                base.Site = value;
+            }
+        }
+
+        /// <summary>
+        /// Get the collection of relations that link tables and
+        /// allow navigation from parent tables to child tables.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public DataRelationCollection Relations => _relationCollection;
+
+        /// <summary>
+        /// Indicates whether <see cref='Relations'/> property should be persisted.
+        /// </summary>
+        protected virtual bool ShouldSerializeRelations() => true;
+
+        /// <summary>
+        /// Resets the <see cref='System.Data.DataSet.Relations'/> property to its default state.
+        /// </summary>
+        private void ResetRelations() => Relations.Clear();
+
+        /// <summary>
+        /// Gets the collection of tables contained in the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public DataTableCollection Tables => _tableCollection;
+
+        /// <summary>
+        /// Indicates whether <see cref='System.Data.DataSet.Tables'/> property should be persisted.
+        /// </summary>
+        protected virtual bool ShouldSerializeTables() => true;
+
+        /// <summary>
+        /// Resets the <see cref='System.Data.DataSet.Tables'/> property to its default state.
+        /// </summary>
+        private void ResetTables() => Tables.Clear();
+
+        internal bool FBoundToDocument
+        {
+            get { return _fBoundToDocument; }
+            set { _fBoundToDocument = value; }
+        }
+
+        /// <summary>
+        /// Commits all the changes made to this <see cref='System.Data.DataSet'/> since it was loaded or the last
+        /// time <see cref='System.Data.DataSet.AcceptChanges'/> was called.
+        /// </summary>
+        public void AcceptChanges()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.AcceptChanges|API> {0}", ObjectID);
+            try
+            {
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    Tables[i].AcceptChanges();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal event PropertyChangedEventHandler PropertyChanging;
+
+        /// <summary>
+        /// Occurs when attempting to merge schemas for two tables with the same name.
+        /// </summary>
+        public event MergeFailedEventHandler MergeFailed;
+
+        internal event DataRowCreatedEventHandler DataRowCreated; // Internal for XmlDataDocument only
+        internal event DataSetClearEventhandler ClearFunctionCalled; // Internal for XmlDataDocument only
+
+        public event EventHandler Initialized;
+
+        public void BeginInit()
+        {
+            _fInitInProgress = true;
+        }
+
+        public void EndInit()
+        {
+            Tables.FinishInitCollection();
+            for (int i = 0; i < Tables.Count; i++)
+            {
+                Tables[i].Columns.FinishInitCollection();
+            }
+
+            for (int i = 0; i < Tables.Count; i++)
+            {
+                Tables[i].Constraints.FinishInitConstraints();
+            }
+
+            ((DataRelationCollection.DataSetRelationCollection)Relations).FinishInitRelations();
+
+            _fInitInProgress = false;
+            OnInitialized();
+        }
+
+        /// <summary>
+        /// Clears the <see cref='System.Data.DataSet'/> of any data by removing all rows in all tables.
+        /// </summary>
+        public void Clear()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Clear|API> {0}", ObjectID);
+            try
+            {
+                OnClearFunctionCalled(null);
+                bool fEnforce = EnforceConstraints;
+                EnforceConstraints = false;
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    Tables[i].Clear();
+                }
+                EnforceConstraints = fEnforce;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Clones the structure of the <see cref='System.Data.DataSet'/>, including all <see cref='System.Data.DataTable'/> schemas, relations, and
+        /// constraints.
+        /// </summary>
+        // Prevent inlining so that reflection calls are not moved to caller that may be in a different assembly that may have a different grant set.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public virtual DataSet Clone()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Clone|API> {0}", ObjectID);
+            try
+            {
+                DataSet ds = (DataSet)Activator.CreateInstance(GetType(), true);
+
+                if (ds.Tables.Count > 0)  // To clean up all the schema in strong typed dataset.
+                {
+                    ds.Reset();
+                }
+
+                //copy some original dataset properties
+                ds.DataSetName = DataSetName;
+                ds.CaseSensitive = CaseSensitive;
+                ds._culture = _culture;
+                ds._cultureUserSet = _cultureUserSet;
+                ds.EnforceConstraints = EnforceConstraints;
+                ds.Namespace = Namespace;
+                ds.Prefix = Prefix;
+                ds.RemotingFormat = RemotingFormat;
+                ds._fIsSchemaLoading = true; //delay expression evaluation
+
+                // ...Tables...
+                DataTableCollection tbls = Tables;
+                for (int i = 0; i < tbls.Count; i++)
+                {
+                    DataTable dt = tbls[i].Clone(ds);
+                    dt._tableNamespace = tbls[i].Namespace; // hardcode the namespace for a second to not mess up
+                    // DataRelation cloning.
+                    ds.Tables.Add(dt);
+                }
+
+                // ...Constraints...
+                for (int i = 0; i < tbls.Count; i++)
+                {
+                    ConstraintCollection constraints = tbls[i].Constraints;
+                    for (int j = 0; j < constraints.Count; j++)
+                    {
+                        if (constraints[j] is UniqueConstraint)
+                        {
+                            continue;
+                        }
+
+                        ForeignKeyConstraint foreign = constraints[j] as ForeignKeyConstraint;
+                        if (foreign.Table == foreign.RelatedTable)
+                        {
+                            continue;// we have already added this foreign key in while cloning the datatable
+                        }
+
+                        ds.Tables[i].Constraints.Add(constraints[j].Clone(ds));
+                    }
+                }
+
+                // ...Relations...
+                DataRelationCollection rels = Relations;
+                for (int i = 0; i < rels.Count; i++)
+                {
+                    DataRelation rel = rels[i].Clone(ds);
+                    rel.CheckMultipleNested = false; // disable the check for multiple nested parent
+                    ds.Relations.Add(rel);
+                    rel.CheckMultipleNested = true; // enable the check for multiple nested parent
+                }
+
+                // ...Extended Properties...
+                if (_extendedProperties != null)
+                {
+                    foreach (object key in _extendedProperties.Keys)
+                    {
+                        ds.ExtendedProperties[key] = _extendedProperties[key];
+                    }
+                }
+
+                foreach (DataTable table in Tables)
+                {
+                    foreach (DataColumn col in table.Columns)
+                    {
+                        if (col.Expression.Length != 0)
+                        {
+                            ds.Tables[table.TableName, table.Namespace].Columns[col.ColumnName].Expression = col.Expression;
+                        }
+                    }
+                }
+
+                for (int i = 0; i < tbls.Count; i++)
+                {
+                    ds.Tables[i]._tableNamespace = tbls[i]._tableNamespace; // undo the hardcoding of the namespace
+                }
+
+                ds._fIsSchemaLoading = false; //reactivate column computations
+
+                return ds;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Copies both the structure and data for this <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public DataSet Copy()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Copy|API> {0}", ObjectID);
+            try
+            {
+                DataSet dsNew = Clone();
+                bool fEnforceConstraints = dsNew.EnforceConstraints;
+                dsNew.EnforceConstraints = false;
+                foreach (DataTable table in Tables)
+                {
+                    DataTable destTable = dsNew.Tables[table.TableName, table.Namespace];
+
+                    foreach (DataRow row in table.Rows)
+                    {
+                        table.CopyRow(destTable, row);
+                    }
+                }
+
+                dsNew.EnforceConstraints = fEnforceConstraints;
+
+                return dsNew;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal int EstimatedXmlStringSize()
+        {
+            int bytes = 100;
+            for (int i = 0; i < Tables.Count; i++)
+            {
+                int rowBytes = (Tables[i].TableName.Length + 4) << 2;
+                DataTable table = Tables[i];
+                for (int j = 0; j < table.Columns.Count; j++)
+                {
+                    rowBytes += ((table.Columns[j].ColumnName.Length + 4) << 2);
+                    rowBytes += 20;
+                }
+                bytes += table.Rows.Count * rowBytes;
+            }
+
+            return bytes;
+        }
+
+        /// <summary>
+        /// Returns a copy of the <see cref='System.Data.DataSet'/> that contains all changes made to
+        /// it since it was loaded or <see cref='System.Data.DataSet.AcceptChanges'/> was last called.
+        /// </summary>
+        public DataSet GetChanges() =>
+            GetChanges(DataRowState.Added | DataRowState.Deleted | DataRowState.Modified);
+
+        private struct TableChanges
+        {
+            private BitArray _rowChanges;
+
+            internal TableChanges(int rowCount)
+            {
+                _rowChanges = new BitArray(rowCount);
+                HasChanges = 0;
+            }
+
+            internal int HasChanges { get; set; }
+
+            internal bool this[int index]
+            {
+                get { return _rowChanges[index]; }
+                set
+                {
+                    Debug.Assert(value && !_rowChanges[index], "setting twice or to false");
+                    _rowChanges[index] = value;
+                    HasChanges++;
+                }
+            }
+        }
+
+        public DataSet GetChanges(DataRowState rowStates)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.GetChanges|API> {0}, rowStates={1}", ObjectID, rowStates);
+            try
+            {
+                DataSet dsNew = null;
+                bool fEnforceConstraints = false;
+                if (0 != (rowStates & ~(DataRowState.Added | DataRowState.Deleted | DataRowState.Modified | DataRowState.Unchanged)))
+                {
+                    throw ExceptionBuilder.InvalidRowState(rowStates);
+                }
+
+                // Initialize all the individual table bitmaps.
+                TableChanges[] bitMatrix = new TableChanges[Tables.Count];
+                for (int i = 0; i < bitMatrix.Length; ++i)
+                {
+                    bitMatrix[i] = new TableChanges(Tables[i].Rows.Count);
+                }
+
+                // find all the modified rows and their parents
+                MarkModifiedRows(bitMatrix, rowStates);
+
+                // copy the changes to a cloned table
+                for (int i = 0; i < bitMatrix.Length; ++i)
+                {
+                    Debug.Assert(0 <= bitMatrix[i].HasChanges, "negative change count");
+                    if (0 < bitMatrix[i].HasChanges)
+                    {
+                        if (null == dsNew)
+                        {
+                            dsNew = Clone();
+                            fEnforceConstraints = dsNew.EnforceConstraints;
+                            dsNew.EnforceConstraints = false;
+                        }
+
+                        DataTable table = Tables[i];
+                        DataTable destTable = dsNew.Tables[table.TableName, table.Namespace];
+                        Debug.Assert(bitMatrix[i].HasChanges <= table.Rows.Count, "to many changes");
+
+                        for (int j = 0; 0 < bitMatrix[i].HasChanges; ++j)
+                        {
+                            // Loop through the rows.
+                            if (bitMatrix[i][j])
+                            {
+                                table.CopyRow(destTable, table.Rows[j]);
+                                bitMatrix[i].HasChanges--;
+                            }
+                        }
+                    }
+                }
+
+                if (null != dsNew)
+                {
+                    dsNew.EnforceConstraints = fEnforceConstraints;
+                }
+                return dsNew;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        private void MarkModifiedRows(TableChanges[] bitMatrix, DataRowState rowStates)
+        {
+            // for every table, every row & every relation find the modified rows and for non-deleted rows, their parents
+            for (int tableIndex = 0; tableIndex < bitMatrix.Length; ++tableIndex)
+            {
+                DataRowCollection rows = Tables[tableIndex].Rows;
+                int rowCount = rows.Count;
+
+                for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex)
+                {
+                    DataRow row = rows[rowIndex];
+                    DataRowState rowState = row.RowState;
+                    Debug.Assert(DataRowState.Added == rowState ||
+                                 DataRowState.Deleted == rowState ||
+                                 DataRowState.Modified == rowState ||
+                                 DataRowState.Unchanged == rowState,
+                                 "unexpected DataRowState");
+
+                    // if bit not already set and row is modified
+                    if ((0 != (rowStates & rowState)) && !bitMatrix[tableIndex][rowIndex])
+                    {
+                        bitMatrix[tableIndex][rowIndex] = true;
+
+                        if (DataRowState.Deleted != rowState)
+                        {
+                            MarkRelatedRowsAsModified(bitMatrix, row);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void MarkRelatedRowsAsModified(TableChanges[] bitMatrix, DataRow row)
+        {
+            DataRelationCollection relations = row.Table.ParentRelations;
+            int relationCount = relations.Count;
+            for (int relatedIndex = 0; relatedIndex < relationCount; ++relatedIndex)
+            {
+                DataRow[] relatedRows = row.GetParentRows(relations[relatedIndex], DataRowVersion.Current);
+
+                foreach (DataRow relatedRow in relatedRows)
+                {
+                    int relatedTableIndex = Tables.IndexOf(relatedRow.Table);
+                    int relatedRowIndex = relatedRow.Table.Rows.IndexOf(relatedRow);
+
+                    if (!bitMatrix[relatedTableIndex][relatedRowIndex])
+                    {
+                        bitMatrix[relatedTableIndex][relatedRowIndex] = true;
+
+                        if (DataRowState.Deleted != relatedRow.RowState)
+                        {
+                            // recurse into related rows
+                            MarkRelatedRowsAsModified(bitMatrix, relatedRow);
+                        }
+                    }
+                }
+            }
+        }
+
+        IList IListSource.GetList() => DefaultViewManager;
+
+        internal string GetRemotingDiffGram(DataTable table)
+        {
+            StringWriter strWriter = new StringWriter(CultureInfo.InvariantCulture);
+            XmlTextWriter writer = new XmlTextWriter(strWriter);
+            writer.Formatting = Formatting.Indented;
+            if (strWriter != null)
+            {
+                // Create and save the updates
+                new NewDiffgramGen(table, false).Save(writer, table);
+            }
+
+            return strWriter.ToString();
+        }
+
+        public string GetXml()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.GetXml|API> {0}", ObjectID);
+            try
+            {
+                // StringBuilder strBuilder = new StringBuilder(EstimatedXmlStringSize());
+                // StringWriter strWriter = new StringWriter(strBuilder);
+                StringWriter strWriter = new StringWriter(CultureInfo.InvariantCulture);
+                if (strWriter != null)
+                {
+                    XmlTextWriter w = new XmlTextWriter(strWriter);
+                    w.Formatting = Formatting.Indented;
+                    new XmlDataTreeWriter(this).Save(w, false);
+                }
+                return strWriter.ToString();
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public string GetXmlSchema()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.GetXmlSchema|API> {0}", ObjectID);
+            try
+            {
+                StringWriter strWriter = new StringWriter(CultureInfo.InvariantCulture);
+                XmlTextWriter writer = new XmlTextWriter(strWriter);
+                writer.Formatting = Formatting.Indented;
+                if (strWriter != null)
+                {
+                    (new XmlTreeGen(SchemaFormat.Public)).Save(this, writer);
+                }
+
+                return strWriter.ToString();
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal string GetXmlSchemaForRemoting(DataTable table)
+        {
+            StringWriter strWriter = new StringWriter(CultureInfo.InvariantCulture);
+            XmlTextWriter writer = new XmlTextWriter(strWriter);
+            writer.Formatting = Formatting.Indented;
+            if (strWriter != null)
+            {
+                if (table == null)
+                {
+                    if (SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema)
+                    {
+                        (new XmlTreeGen(SchemaFormat.RemotingSkipSchema)).Save(this, writer);
+                    }
+                    else
+                    {
+                        (new XmlTreeGen(SchemaFormat.Remoting)).Save(this, writer);
+                    }
+                }
+                else
+                {
+                    // no skip schema support for typed datatable
+                    (new XmlTreeGen(SchemaFormat.Remoting)).Save(table, writer);
+                }
+            }
+
+            return strWriter.ToString();
+        }
+
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref='System.Data.DataSet'/> has changes, including new,
+        ///    deleted, or modified rows.
+        /// </summary>
+        public bool HasChanges() => HasChanges(DataRowState.Added | DataRowState.Deleted | DataRowState.Modified);
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref='System.Data.DataSet'/> has changes, including new,
+        ///    deleted, or modified rows, filtered by <see cref='System.Data.DataRowState'/>.
+        /// </summary>
+        public bool HasChanges(DataRowState rowStates)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.HasChanges|API> {0}, rowStates={1}", ObjectID, (int)rowStates);
+            try
+            {
+                const DataRowState allRowStates = DataRowState.Detached | DataRowState.Unchanged | DataRowState.Added | DataRowState.Deleted | DataRowState.Modified;
+
+                if ((rowStates & (~allRowStates)) != 0)
+                {
+                    throw ExceptionBuilder.ArgumentOutOfRange("rowState");
+                }
+
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    DataTable table = Tables[i];
+
+                    for (int j = 0; j < table.Rows.Count; j++)
+                    {
+                        DataRow row = table.Rows[j];
+                        if ((row.RowState & rowStates) != 0)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Infer the XML schema from the specified <see cref='System.IO.TextReader'/> into the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void InferXmlSchema(XmlReader reader, string[] nsArray)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.InferXmlSchema|API> {0}", ObjectID);
+            try
+            {
+                if (reader == null)
+                {
+                    return;
+                }
+
+                XmlDocument xdoc = new XmlDocument();
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    XmlNode node = xdoc.ReadNode(reader);
+                    xdoc.AppendChild(node);
+                }
+                else
+                {
+                    xdoc.Load(reader);
+                }
+
+                if (xdoc.DocumentElement == null)
+                {
+                    return;
+                }
+
+                InferSchema(xdoc, nsArray, XmlReadMode.InferSchema);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Infer the XML schema from the specified <see cref='System.IO.TextReader'/> into the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void InferXmlSchema(Stream stream, string[] nsArray)
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            InferXmlSchema(new XmlTextReader(stream), nsArray);
+        }
+
+        /// <summary>
+        /// Infer the XML schema from the specified <see cref='System.IO.TextReader'/> into the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void InferXmlSchema(TextReader reader, string[] nsArray)
+        {
+            if (reader == null)
+            {
+                return;
+            }
+
+            InferXmlSchema(new XmlTextReader(reader), nsArray);
+        }
+
+        /// <summary>
+        /// Infer the XML schema from the specified file into the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void InferXmlSchema(string fileName, string[] nsArray)
+        {
+            XmlTextReader xr = new XmlTextReader(fileName);
+            try
+            {
+                InferXmlSchema(xr, nsArray);
+            }
+            finally
+            {
+                xr.Close();
+            }
+        }
+
+        /// <summary>
+        /// Reads the XML schema from the specified <see cref='T:System.Xml.XMLReader'/> into the <see cref='System.Data.DataSet'/>
+        /// </summary>
+        public void ReadXmlSchema(XmlReader reader) => ReadXmlSchema(reader, false);
+
+        internal void ReadXmlSchema(XmlReader reader, bool denyResolving)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ReadXmlSchema|INFO> {0}, reader, denyResolving={1}", ObjectID, denyResolving);
+            try
+            {
+                int iCurrentDepth = -1;
+
+                if (reader == null)
+                {
+                    return;
+                }
+
+                if (reader is XmlTextReader)
+                {
+                    ((XmlTextReader)reader).WhitespaceHandling = WhitespaceHandling.None;
+                }
+
+                XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    iCurrentDepth = reader.Depth;
+                }
+
+                reader.MoveToContent();
+
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    // if reader points to the schema load it...
+                    if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                    {
+                        // load XDR schema and exit
+                        ReadXDRSchema(reader);
+                        return;
+                    }
+
+                    if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                    {
+                        // load XSD schema and exit
+                        ReadXSDSchema(reader, denyResolving);
+                        return;
+                    }
+
+                    if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                    {
+                        throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                    }
+
+                    // ... otherwise backup the top node and all its attributes
+                    XmlElement topNode = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                    if (reader.HasAttributes)
+                    {
+                        int attrCount = reader.AttributeCount;
+                        for (int i = 0; i < attrCount; i++)
+                        {
+                            reader.MoveToAttribute(i);
+                            if (reader.NamespaceURI.Equals(Keywords.XSD_XMLNS_NS))
+                            {
+                                topNode.SetAttribute(reader.Name, reader.GetAttribute(i));
+                            }
+                            else
+                            {
+                                XmlAttribute attr = topNode.SetAttributeNode(reader.LocalName, reader.NamespaceURI);
+                                attr.Prefix = reader.Prefix;
+                                attr.Value = reader.GetAttribute(i);
+                            }
+                        }
+                    }
+                    reader.Read();
+
+                    while (MoveToElement(reader, iCurrentDepth))
+                    {
+                        // if reader points to the schema load it...
+                        if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                        {
+                            // load XDR schema and exit
+                            ReadXDRSchema(reader);
+                            return;
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                        {
+                            // load XSD schema and exit
+                            ReadXSDSchema(reader, denyResolving);
+                            return;
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                        {
+                            throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                        }
+
+                        XmlNode node = xdoc.ReadNode(reader);
+                        topNode.AppendChild(node);
+                    }
+
+                    // read the closing tag of the current element
+                    ReadEndElement(reader);
+
+                    // if we are here no schema has been found
+                    xdoc.AppendChild(topNode);
+
+                    // so we InferSchema
+                    InferSchema(xdoc, null, XmlReadMode.Auto);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal bool MoveToElement(XmlReader reader, int depth)
+        {
+            while (!reader.EOF && reader.NodeType != XmlNodeType.EndElement && reader.NodeType != XmlNodeType.Element && reader.Depth > depth)
+            {
+                reader.Read();
+            }
+            return (reader.NodeType == XmlNodeType.Element);
+        }
+
+        private static void MoveToElement(XmlReader reader)
+        {
+            while (!reader.EOF && reader.NodeType != XmlNodeType.EndElement && reader.NodeType != XmlNodeType.Element)
+            {
+                reader.Read();
+            }
+        }
+        internal void ReadEndElement(XmlReader reader)
+        {
+            while (reader.NodeType == XmlNodeType.Whitespace)
+            {
+                reader.Skip();
+            }
+            if (reader.NodeType == XmlNodeType.None)
+            {
+                reader.Skip();
+            }
+            else if (reader.NodeType == XmlNodeType.EndElement)
+            {
+                reader.ReadEndElement();
+            }
+        }
+
+        internal void ReadXSDSchema(XmlReader reader, bool denyResolving)
+        {
+            XmlSchemaSet sSet = new XmlSchemaSet();
+
+            int schemaFragmentCount = 1;
+            //read from current schmema element
+            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+            {
+                if (reader.HasAttributes)
+                {
+                    string attribValue = reader.GetAttribute(Keywords.MSD_FRAGMENTCOUNT, Keywords.MSDNS); // this must not move the position
+                    if (!string.IsNullOrEmpty(attribValue))
+                    {
+                        schemaFragmentCount = int.Parse(attribValue, null);
+                    }
+                }
+            }
+
+            while (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+            {
+                XmlSchema s = XmlSchema.Read(reader, null);
+                sSet.Add(s);
+                //read the end tag
+                ReadEndElement(reader);
+
+                if (--schemaFragmentCount > 0)
+                {
+                    MoveToElement(reader);
+                }
+                while (reader.NodeType == XmlNodeType.Whitespace)
+                {
+                    reader.Skip();
+                }
+            }
+            sSet.Compile();
+            XSDSchema schema = new XSDSchema();
+            schema.LoadSchema(sSet, this);
+        }
+
+        internal void ReadXDRSchema(XmlReader reader)
+        {
+            XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+            XmlNode schNode = xdoc.ReadNode(reader);
+            xdoc.AppendChild(schNode);
+            XDRSchema schema = new XDRSchema(this, false);
+            DataSetName = xdoc.DocumentElement.LocalName;
+            schema.LoadSchema((XmlElement)schNode, this);
+        }
+
+        /// <summary>
+        /// Reads the XML schema from the specified <see cref='System.IO.Stream'/> into the
+        /// <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void ReadXmlSchema(Stream stream)
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            ReadXmlSchema(new XmlTextReader(stream), false);
+        }
+
+        /// <summary>
+        /// Reads the XML schema from the specified <see cref='System.IO.TextReader'/> into the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void ReadXmlSchema(TextReader reader)
+        {
+            if (reader == null)
+            {
+                return;
+            }
+
+            ReadXmlSchema(new XmlTextReader(reader), false);
+        }
+
+        /// <summary>
+        /// Reads the XML schema from the specified file into the <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void ReadXmlSchema(string fileName)
+        {
+            XmlTextReader xr = new XmlTextReader(fileName);
+            try
+            {
+                ReadXmlSchema(xr, false);
+            }
+            finally
+            {
+                xr.Close();
+            }
+        }
+
+        #region WriteXmlSchema
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to using the specified <see cref='Stream'/> object.</summary>
+        /// <param name="stream">A <see cref='Stream'/> object used to write to a file.</param>
+        public void WriteXmlSchema(Stream stream) => WriteXmlSchema(stream, SchemaFormat.Public, null);
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to using the specified <see cref='Stream'/> object.</summary>
+        /// <param name="stream">A <see cref='Stream'/> object used to write to a file.</param>
+        /// <param name="multipleTargetConverter">A delegate used to convert <see cref='Type'/> into string.</param>
+        public void WriteXmlSchema(Stream stream, Converter<Type, string> multipleTargetConverter)
+        {
+            ADP.CheckArgumentNull(multipleTargetConverter, nameof(multipleTargetConverter));
+            WriteXmlSchema(stream, SchemaFormat.Public, multipleTargetConverter);
+        }
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to a file.</summary>
+        /// <param name="fileName">The file name (including the path) to which to write.</param>
+        public void WriteXmlSchema(string fileName) => WriteXmlSchema(fileName, SchemaFormat.Public, null);
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to a file.</summary>
+        /// <param name="fileName">The file name (including the path) to which to write.</param>
+        /// <param name="multipleTargetConverter">A delegate used to convert <see cref='Type'/> into string.</param>
+        public void WriteXmlSchema(string fileName, Converter<Type, string> multipleTargetConverter)
+        {
+            ADP.CheckArgumentNull(multipleTargetConverter, nameof(multipleTargetConverter));
+            WriteXmlSchema(fileName, SchemaFormat.Public, multipleTargetConverter);
+        }
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to a <see cref='TextWriter'/> object.</summary>
+        /// <param name="writer">The <see cref='TextWriter'/> object with which to write.</param>
+        public void WriteXmlSchema(TextWriter writer) => WriteXmlSchema(writer, SchemaFormat.Public, null);
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to a <see cref='TextWriter'/> object.</summary>
+        /// <param name="writer">The <see cref='TextWriter'/> object with which to write.</param>
+        /// <param name="multipleTargetConverter">A delegate used to convert <see cref='Type'/> into string.</param>
+        public void WriteXmlSchema(TextWriter writer, Converter<Type, string> multipleTargetConverter)
+        {
+            ADP.CheckArgumentNull(multipleTargetConverter, nameof(multipleTargetConverter));
+            WriteXmlSchema(writer, SchemaFormat.Public, multipleTargetConverter);
+        }
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to an <see cref='XmlWriter'/> object.</summary>
+        /// <param name="writer">The <see cref='XmlWriter'/> object with which to write.</param>
+        public void WriteXmlSchema(XmlWriter writer) => WriteXmlSchema(writer, SchemaFormat.Public, null);
+
+        /// <summary>Writes the <see cref='DataSet'/> structure as an XML schema to an <see cref='XmlWriter'/> object.</summary>
+        /// <param name="writer">The <see cref='XmlWriter'/> object with which to write.</param>
+        /// <param name="multipleTargetConverter">A delegate used to convert <see cref='Type'/> into string.</param>
+        public void WriteXmlSchema(XmlWriter writer, Converter<Type, string> multipleTargetConverter)
+        {
+            ADP.CheckArgumentNull(multipleTargetConverter, nameof(multipleTargetConverter));
+            WriteXmlSchema(writer, SchemaFormat.Public, multipleTargetConverter);
+        }
+
+        private void WriteXmlSchema(string fileName, SchemaFormat schemaFormat, Converter<Type, string> multipleTargetConverter)
+        {
+            XmlTextWriter xw = new XmlTextWriter(fileName, null);
+            try
+            {
+                xw.Formatting = Formatting.Indented;
+                xw.WriteStartDocument(true);
+                WriteXmlSchema(xw, schemaFormat, multipleTargetConverter);
+                xw.WriteEndDocument();
+            }
+            finally
+            {
+                xw.Close();
+            }
+        }
+
+        private void WriteXmlSchema(Stream stream, SchemaFormat schemaFormat, Converter<Type, string> multipleTargetConverter)
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            XmlTextWriter w = new XmlTextWriter(stream, null);
+            w.Formatting = Formatting.Indented;
+
+            WriteXmlSchema(w, schemaFormat, multipleTargetConverter);
+        }
+
+        private void WriteXmlSchema(TextWriter writer, SchemaFormat schemaFormat, Converter<Type, string> multipleTargetConverter)
+        {
+            if (writer == null)
+            {
+                return;
+            }
+
+            XmlTextWriter w = new XmlTextWriter(writer);
+            w.Formatting = Formatting.Indented;
+
+            WriteXmlSchema(w, schemaFormat, multipleTargetConverter);
+        }
+
+        private void WriteXmlSchema(XmlWriter writer, SchemaFormat schemaFormat, Converter<Type, string> multipleTargetConverter)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.WriteXmlSchema|INFO> {0}, schemaFormat={1}", ObjectID, schemaFormat);
+            try
+            {
+                // Generate SchemaTree and write it out
+                if (writer != null)
+                {
+                    XmlTreeGen treeGen = null;
+                    if (schemaFormat == SchemaFormat.WebService &&
+                        SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema &&
+                        writer.WriteState == WriteState.Element)
+                    {
+                        treeGen = new XmlTreeGen(SchemaFormat.WebServiceSkipSchema);
+                    }
+                    else
+                    {
+                        treeGen = new XmlTreeGen(schemaFormat);
+                    }
+
+                    treeGen.Save(this, null, writer, false, multipleTargetConverter);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+        #endregion
+
+        public XmlReadMode ReadXml(XmlReader reader) => ReadXml(reader, false);
+
+        internal XmlReadMode ReadXml(XmlReader reader, bool denyResolving)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ReadXml|INFO> {0}, denyResolving={1}", ObjectID, denyResolving);
+            try
+            {
+                DataTable.DSRowDiffIdUsageSection rowDiffIdUsage = new DataTable.DSRowDiffIdUsageSection();
+                try
+                {
+                    bool fDataFound = false;
+                    bool fSchemaFound = false;
+                    bool fDiffsFound = false;
+                    bool fIsXdr = false;
+                    int iCurrentDepth = -1;
+                    XmlReadMode ret = XmlReadMode.Auto;
+                    bool isEmptyDataSet = false;
+                    bool topNodeIsProcessed = false; // we chanche topnode and there is just one case that we miss to process it
+                    // it is : <elem attrib1="Attrib">txt</elem>
+
+                    // clear the hashtable to avoid conflicts between diffgrams, SqlHotFix 782
+                    rowDiffIdUsage.Prepare(this);
+
+                    if (reader == null)
+                    {
+                        return ret;
+                    }
+
+                    if (Tables.Count == 0)
+                    {
+                        isEmptyDataSet = true;
+                    }
+
+                    if (reader is XmlTextReader)
+                    {
+                        ((XmlTextReader)reader).WhitespaceHandling = WhitespaceHandling.Significant;
+                    }
+
+                    XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+                    XmlDataLoader xmlload = null;
+
+                    reader.MoveToContent();
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        iCurrentDepth = reader.Depth;
+                    }
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                        {
+                            ReadXmlDiffgram(reader);
+                            // read the closing tag of the current element
+                            ReadEndElement(reader);
+                            return XmlReadMode.DiffGram;
+                        }
+
+                        // if reader points to the schema load it
+                        if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                        {
+                            // load XDR schema and exit
+                            ReadXDRSchema(reader);
+                            return XmlReadMode.ReadSchema; //since the top level element is a schema return
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                        {
+                            // load XSD schema and exit
+                            ReadXSDSchema(reader, denyResolving);
+                            return XmlReadMode.ReadSchema; //since the top level element is a schema return
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                        {
+                            throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                        }
+
+                        // now either the top level node is a table and we load it through dataReader...
+
+                        // ... or backup the top node and all its attributes because we may need to InferSchema
+                        XmlElement topNode = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                        if (reader.HasAttributes)
+                        {
+                            int attrCount = reader.AttributeCount;
+                            for (int i = 0; i < attrCount; i++)
+                            {
+                                reader.MoveToAttribute(i);
+                                if (reader.NamespaceURI.Equals(Keywords.XSD_XMLNS_NS))
+                                    topNode.SetAttribute(reader.Name, reader.GetAttribute(i));
+                                else
+                                {
+                                    XmlAttribute attr = topNode.SetAttributeNode(reader.LocalName, reader.NamespaceURI);
+                                    attr.Prefix = reader.Prefix;
+                                    attr.Value = reader.GetAttribute(i);
+                                }
+                            }
+                        }
+                        reader.Read();
+                        string rootNodeSimpleContent = reader.Value;
+
+                        while (MoveToElement(reader, iCurrentDepth))
+                        {
+                            if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                            {
+                                ReadXmlDiffgram(reader);
+                                // read the closing tag of the current element
+                                // YUKON FIX                            ReadEndElement(reader);
+                                //                            return XmlReadMode.DiffGram;
+                                ret = XmlReadMode.DiffGram; // continue reading for multiple schemas
+                            }
+
+                            // if reader points to the schema load it...
+
+
+                            if (!fSchemaFound && !fDataFound && reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                            {
+                                // load XDR schema and exit
+                                ReadXDRSchema(reader);
+                                fSchemaFound = true;
+                                fIsXdr = true;
+                                continue;
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                            {
+                                // load XSD schema and exit
+                                ReadXSDSchema(reader, denyResolving);
+                                fSchemaFound = true;
+                                continue;
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                            {
+                                throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                            }
+
+                            if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                            {
+                                ReadXmlDiffgram(reader);
+                                fDiffsFound = true;
+                                ret = XmlReadMode.DiffGram;
+                            }
+                            else
+                            {
+                                // We have found data IFF the reader.NodeType == Element and reader.depth == currentDepth-1
+                                // if reader.NodeType == whitespace, skip all whitespace.
+                                // skip processing i.e. continue if the first non-whitespace node is not of type element.
+                                while (!reader.EOF && reader.NodeType == XmlNodeType.Whitespace)
+                                    reader.Read();
+                                if (reader.NodeType != XmlNodeType.Element)
+                                    continue;
+                                // we found data here
+                                fDataFound = true;
+
+                                if (!fSchemaFound && Tables.Count == 0)
+                                {
+                                    XmlNode node = xdoc.ReadNode(reader);
+                                    topNode.AppendChild(node);
+                                }
+                                else
+                                {
+                                    if (xmlload == null)
+                                    {
+                                        xmlload = new XmlDataLoader(this, fIsXdr, topNode, false);
+                                    }
+
+                                    xmlload.LoadData(reader);
+                                    topNodeIsProcessed = true; // we process the topnode
+                                    if (fSchemaFound)
+                                    {
+                                        ret = XmlReadMode.ReadSchema;
+                                    }
+                                    else
+                                    {
+                                        ret = XmlReadMode.IgnoreSchema;
+                                    }
+                                }
+                            }
+                        }
+                        // read the closing tag of the current element
+                        ReadEndElement(reader);
+                        bool isfTopLevelTableSet = false;
+                        bool tmpValue = _fTopLevelTable;
+                        //While inference we ignore root elements text content
+                        if (!fSchemaFound && Tables.Count == 0 && !topNode.HasChildNodes)
+                        {
+                            //We shoule not come add SC of root elemnt to topNode if we are not infering
+                            _fTopLevelTable = true;
+                            isfTopLevelTableSet = true;
+                            if ((rootNodeSimpleContent != null && rootNodeSimpleContent.Length > 0))
+                            {
+                                topNode.InnerText = rootNodeSimpleContent;
+                            }
+                        }
+                        if (!isEmptyDataSet)
+                        {
+                            if ((rootNodeSimpleContent != null && rootNodeSimpleContent.Length > 0))
+                            {
+                                topNode.InnerText = rootNodeSimpleContent;
+                            }
+                        }
+
+                        // now top node contains the data part
+                        xdoc.AppendChild(topNode);
+
+                        if (xmlload == null)
+                        {
+                            xmlload = new XmlDataLoader(this, fIsXdr, topNode, false);
+                        }
+
+                        if (!isEmptyDataSet && !topNodeIsProcessed)
+                        {
+                            XmlElement root = xdoc.DocumentElement;
+                            Debug.Assert(root.NamespaceURI != null, "root.NamespaceURI should not ne null, it should be empty string");
+                            // just recognize that below given Xml represents datatable in toplevel
+                            //<table attr1="foo" attr2="bar" table_Text="junk">text</table>
+                            // only allow root element with simple content, if any
+                            if (root.ChildNodes.Count == 0 || ((root.ChildNodes.Count == 1) && root.FirstChild.GetType() == typeof(System.Xml.XmlText)))
+                            {
+                                bool initfTopLevelTable = _fTopLevelTable;
+                                // if root element maps to a datatable
+                                // ds and dt cant have the samm name and ns at the same time, how to write to xml
+                                if (DataSetName != root.Name && _namespaceURI != root.NamespaceURI &&
+                                    Tables.Contains(root.Name, (root.NamespaceURI.Length == 0) ? null : root.NamespaceURI, false, true))
+                                {
+                                    _fTopLevelTable = true;
+                                }
+                                try
+                                {
+                                    xmlload.LoadData(xdoc);
+                                }
+                                finally
+                                {
+                                    _fTopLevelTable = initfTopLevelTable; // this is not for inference, we have schema and we were skipping
+                                    // topnode where it was a datatable, We must restore the value
+                                }
+                            }
+                        }
+
+                        // above check and below check are orthogonal
+                        // so we InferSchema
+                        if (!fDiffsFound)
+                        {
+                            // Load Data
+                            if (!fSchemaFound && Tables.Count == 0)
+                            {
+                                InferSchema(xdoc, null, XmlReadMode.Auto);
+                                ret = XmlReadMode.InferSchema;
+                                xmlload.FromInference = true;
+                                try
+                                {
+                                    xmlload.LoadData(xdoc);
+                                }
+                                finally
+                                {
+                                    xmlload.FromInference = false;
+                                }
+                            }
+                            //We dont need this assignement. Once we set it(where we set it during inference), it won't be changed
+                            if (isfTopLevelTableSet)
+                                _fTopLevelTable = tmpValue;
+                        }
+                    }
+
+                    return ret;
+                }
+                finally
+                {
+                    rowDiffIdUsage.Cleanup();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public XmlReadMode ReadXml(Stream stream)
+        {
+            if (stream == null)
+            {
+                return XmlReadMode.Auto;
+            }
+
+            XmlTextReader xr = new XmlTextReader(stream);
+
+            // Prevent Dtd entity in dataset 
+            xr.XmlResolver = null;
+
+            return ReadXml(xr, false);
+        }
+
+        public XmlReadMode ReadXml(TextReader reader)
+        {
+            if (reader == null)
+            {
+                return XmlReadMode.Auto;
+            }
+
+            XmlTextReader xr = new XmlTextReader(reader);
+
+            // Prevent Dtd entity in dataset 
+            xr.XmlResolver = null;
+
+            return ReadXml(xr, false);
+        }
+
+        public XmlReadMode ReadXml(string fileName)
+        {
+            XmlTextReader xr = new XmlTextReader(fileName);
+
+            // Prevent Dtd entity in dataset 
+            xr.XmlResolver = null;
+
+            try
+            {
+                return ReadXml(xr, false);
+            }
+            finally
+            {
+                xr.Close();
+            }
+        }
+
+        internal void InferSchema(XmlDocument xdoc, string[] excludedNamespaces, XmlReadMode mode)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.InferSchema|INFO> {0}, mode={1}", ObjectID, mode);
+            try
+            {
+                string ns = xdoc.DocumentElement.NamespaceURI;
+                if (null == excludedNamespaces)
+                {
+                    excludedNamespaces = Array.Empty<string>();
+                }
+                XmlNodeReader xnr = new XmlIgnoreNamespaceReader(xdoc, excludedNamespaces);
+                XmlSchemaInference infer = new XmlSchemaInference();
+
+                infer.Occurrence = XmlSchemaInference.InferenceOption.Relaxed;
+
+                infer.TypeInference = (mode == XmlReadMode.InferTypedSchema) ?
+                    XmlSchemaInference.InferenceOption.Restricted :
+                    XmlSchemaInference.InferenceOption.Relaxed;
+
+                XmlSchemaSet schemaSet = infer.InferSchema(xnr);
+                schemaSet.Compile();
+
+                XSDSchema schema = new XSDSchema();
+                schema.FromInference = true;
+
+                try
+                {
+                    schema.LoadSchema(schemaSet, this);
+                }
+                finally
+                {
+                    schema.FromInference = false; // this is always false if you are not calling fron inference
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        private bool IsEmpty()
+        {
+            foreach (DataTable table in Tables)
+            {
+                if (table.Rows.Count > 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void ReadXmlDiffgram(XmlReader reader)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ReadXmlDiffgram|INFO> {0}", ObjectID);
+            try
+            {
+                int d = reader.Depth;
+                bool fEnforce = EnforceConstraints;
+                EnforceConstraints = false;
+                DataSet newDs;
+                bool isEmpty = IsEmpty();
+
+                if (isEmpty)
+                {
+                    newDs = this;
+                }
+                else
+                {
+                    newDs = Clone();
+                    newDs.EnforceConstraints = false;
+                }
+
+                foreach (DataTable t in newDs.Tables)
+                {
+                    t.Rows._nullInList = 0;
+                }
+                reader.MoveToContent();
+                if ((reader.LocalName != Keywords.DIFFGRAM) && (reader.NamespaceURI != Keywords.DFFNS))
+                {
+                    return;
+                }
+
+                reader.Read();
+                if (reader.NodeType == XmlNodeType.Whitespace)
+                {
+                    MoveToElement(reader, reader.Depth - 1 /*iCurrentDepth*/); // skip over whitespace.
+                }
+
+                newDs._fInLoadDiffgram = true;
+
+                if (reader.Depth > d)
+                {
+                    if ((reader.NamespaceURI != Keywords.DFFNS) && (reader.NamespaceURI != Keywords.MSDNS))
+                    {
+                        //we should be inside the dataset part
+                        XmlDocument xdoc = new XmlDocument();
+                        XmlElement node = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                        reader.Read();
+                        if (reader.NodeType == XmlNodeType.Whitespace)
+                        {
+                            MoveToElement(reader, reader.Depth - 1 /*iCurrentDepth*/); // skip over whitespace.
+                        }
+                        if (reader.Depth - 1 > d)
+                        {
+                            XmlDataLoader xmlload = new XmlDataLoader(newDs, false, node, false);
+                            xmlload._isDiffgram = true; // turn on the special processing
+                            xmlload.LoadData(reader);
+                        }
+                        ReadEndElement(reader);
+                        if (reader.NodeType == XmlNodeType.Whitespace)
+                        {
+                            MoveToElement(reader, reader.Depth - 1 /*iCurrentDepth*/); // skip over whitespace.
+                        }
+                    }
+                    Debug.Assert(reader.NodeType != XmlNodeType.Whitespace, "Should not be on Whitespace node");
+
+                    if (((reader.LocalName == Keywords.SQL_BEFORE) && (reader.NamespaceURI == Keywords.DFFNS)) ||
+                        ((reader.LocalName == Keywords.MSD_ERRORS) && (reader.NamespaceURI == Keywords.DFFNS)))
+                    {
+                        //this will consume the changes and the errors part
+                        XMLDiffLoader diffLoader = new XMLDiffLoader();
+                        diffLoader.LoadDiffGram(newDs, reader);
+                    }
+
+                    // get to the closing diff tag
+                    while (reader.Depth > d)
+                    {
+                        reader.Read();
+                    }
+                    // read the closing tag
+                    ReadEndElement(reader);
+                }
+
+                foreach (DataTable t in newDs.Tables)
+                {
+                    if (t.Rows._nullInList > 0)
+                    {
+                        throw ExceptionBuilder.RowInsertMissing(t.TableName);
+                    }
+                }
+
+                newDs._fInLoadDiffgram = false;
+
+                //terrible performance!
+                foreach (DataTable t in newDs.Tables)
+                {
+                    DataRelation[] nestedParentRelations = t.NestedParentRelations;
+                    foreach (DataRelation rel in nestedParentRelations)
+                    {
+                        if (rel.ParentTable == t)
+                        {
+                            foreach (DataRow r in t.Rows)
+                            {
+                                foreach (DataRelation rel2 in nestedParentRelations)
+                                {
+                                    r.CheckForLoops(rel2);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (!isEmpty)
+                {
+                    Merge(newDs);
+                    if (_dataSetName == "NewDataSet")
+                    {
+                        _dataSetName = newDs._dataSetName;
+                    }
+                    newDs.EnforceConstraints = fEnforce;
+                }
+                EnforceConstraints = fEnforce;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        public XmlReadMode ReadXml(XmlReader reader, XmlReadMode mode) => ReadXml(reader, mode, false);
+
+        internal XmlReadMode ReadXml(XmlReader reader, XmlReadMode mode, bool denyResolving)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ReadXml|INFO> {0}, mode={1}, denyResolving={2}", ObjectID, mode, denyResolving);
+            try
+            {
+                XmlReadMode ret = mode;
+
+                if (reader == null)
+                {
+                    return ret;
+                }
+
+                if (mode == XmlReadMode.Auto)
+                {
+                    // nested ReadXml calls on the same DataSet must be done outside of RowDiffIdUsage scope
+                    return ReadXml(reader);
+                }
+
+                DataTable.DSRowDiffIdUsageSection rowDiffIdUsage = new DataTable.DSRowDiffIdUsageSection();
+                try
+                {
+                    bool fSchemaFound = false;
+                    bool fDataFound = false;
+                    bool fIsXdr = false;
+                    int iCurrentDepth = -1;
+
+                    // prepare and cleanup rowDiffId hashtable
+                    rowDiffIdUsage.Prepare(this);
+
+                    if (reader is XmlTextReader)
+                    {
+                        ((XmlTextReader)reader).WhitespaceHandling = WhitespaceHandling.Significant;
+                    }
+
+                    XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+
+                    if ((mode != XmlReadMode.Fragment) && (reader.NodeType == XmlNodeType.Element))
+                    {
+                        iCurrentDepth = reader.Depth;
+                    }
+
+                    reader.MoveToContent();
+                    XmlDataLoader xmlload = null;
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        XmlElement topNode = null;
+                        if (mode == XmlReadMode.Fragment)
+                        {
+                            xdoc.AppendChild(xdoc.CreateElement("ds_sqlXmlWraPPeR"));
+                            topNode = xdoc.DocumentElement;
+                        }
+                        else
+                        {
+                            //handle the top node
+                            if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                            {
+                                if ((mode == XmlReadMode.DiffGram) || (mode == XmlReadMode.IgnoreSchema))
+                                {
+                                    ReadXmlDiffgram(reader);
+                                    // read the closing tag of the current element
+                                    ReadEndElement(reader);
+                                }
+                                else
+                                {
+                                    reader.Skip();
+                                }
+                                return ret;
+                            }
+
+                            if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                            {
+                                // load XDR schema and exit
+                                if ((mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema) &&
+                                    (mode != XmlReadMode.InferTypedSchema))
+                                {
+                                    ReadXDRSchema(reader);
+                                }
+                                else
+                                {
+                                    reader.Skip();
+                                }
+                                return ret; //since the top level element is a schema return
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                            {
+                                // load XSD schema and exit
+                                if ((mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema) &&
+                                    (mode != XmlReadMode.InferTypedSchema))
+                                {
+                                    ReadXSDSchema(reader, denyResolving);
+                                }
+                                else
+                                {
+                                    reader.Skip();
+                                }
+
+                                return ret; //since the top level element is a schema return
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                            {
+                                throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                            }
+
+                            // now either the top level node is a table and we load it through dataReader...
+                            // ... or backup the top node and all its attributes
+                            topNode = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                            if (reader.HasAttributes)
+                            {
+                                int attrCount = reader.AttributeCount;
+                                for (int i = 0; i < attrCount; i++)
+                                {
+                                    reader.MoveToAttribute(i);
+                                    if (reader.NamespaceURI.Equals(Keywords.XSD_XMLNS_NS))
+                                        topNode.SetAttribute(reader.Name, reader.GetAttribute(i));
+                                    else
+                                    {
+                                        XmlAttribute attr = topNode.SetAttributeNode(reader.LocalName, reader.NamespaceURI);
+                                        attr.Prefix = reader.Prefix;
+                                        attr.Value = reader.GetAttribute(i);
+                                    }
+                                }
+                            }
+                            reader.Read();
+                        }
+
+                        while (MoveToElement(reader, iCurrentDepth))
+                        {
+                            if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                            {
+                                // load XDR schema
+                                if (!fSchemaFound && !fDataFound && (mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema) &&
+                                    (mode != XmlReadMode.InferTypedSchema))
+                                {
+                                    ReadXDRSchema(reader);
+                                    fSchemaFound = true;
+                                    fIsXdr = true;
+                                }
+                                else
+                                {
+                                    reader.Skip();
+                                }
+                                continue;
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                            {
+                                // load XSD schema and exit
+                                if ((mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema) &&
+                                    (mode != XmlReadMode.InferTypedSchema))
+                                {
+                                    ReadXSDSchema(reader, denyResolving);
+                                    fSchemaFound = true;
+                                }
+                                else
+                                {
+                                    reader.Skip();
+                                }
+                                continue;
+                            }
+
+                            if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                            {
+                                if ((mode == XmlReadMode.DiffGram) || (mode == XmlReadMode.IgnoreSchema))
+                                {
+                                    ReadXmlDiffgram(reader);
+                                    ret = XmlReadMode.DiffGram;
+                                }
+                                else
+                                {
+                                    reader.Skip();
+                                }
+                                continue;
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                                throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+
+                            if (mode == XmlReadMode.DiffGram)
+                            {
+                                reader.Skip();
+                                continue; // we do not read data in diffgram mode
+                            }
+
+                            // if we are here we found some data
+                            fDataFound = true;
+
+                            if (mode == XmlReadMode.InferSchema || mode == XmlReadMode.InferTypedSchema)
+                            { //save the node in DOM until the end;
+                                XmlNode node = xdoc.ReadNode(reader);
+                                topNode.AppendChild(node);
+                            }
+                            else
+                            {
+                                if (xmlload == null)
+                                {
+                                    xmlload = new XmlDataLoader(this, fIsXdr, topNode, mode == XmlReadMode.IgnoreSchema);
+                                }
+                                xmlload.LoadData(reader);
+                            }
+                        } //end of the while
+
+                        // read the closing tag of the current element
+                        ReadEndElement(reader);
+
+                        // now top node contains the data part
+                        xdoc.AppendChild(topNode);
+                        if (xmlload == null)
+                            xmlload = new XmlDataLoader(this, fIsXdr, mode == XmlReadMode.IgnoreSchema);
+
+                        if (mode == XmlReadMode.DiffGram)
+                        {
+                            // we already got the diffs through XmlReader interface
+                            return ret;
+                        }
+
+                        // Load Data
+                        if (mode == XmlReadMode.InferSchema || mode == XmlReadMode.InferTypedSchema)
+                        {
+                            InferSchema(xdoc, null, mode);
+                            ret = XmlReadMode.InferSchema;
+                            xmlload.FromInference = true;
+
+                            try
+                            {
+                                xmlload.LoadData(xdoc);
+                            }
+                            finally
+                            {
+                                xmlload.FromInference = false;
+                            }
+                        }
+                    }
+
+                    return ret;
+                }
+                finally
+                {
+                    // prepare and cleanup rowDiffId hashtable
+                    rowDiffIdUsage.Cleanup();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public XmlReadMode ReadXml(Stream stream, XmlReadMode mode)
+        {
+            if (stream == null)
+            {
+                return XmlReadMode.Auto;
+            }
+
+            XmlTextReader reader = (mode == XmlReadMode.Fragment) ? new XmlTextReader(stream, XmlNodeType.Element, null) : new XmlTextReader(stream);
+            // Prevent Dtd entity in dataset 
+            reader.XmlResolver = null;
+            return ReadXml(reader, mode, false);
+        }
+
+        public XmlReadMode ReadXml(TextReader reader, XmlReadMode mode)
+        {
+            if (reader == null)
+            {
+                return XmlReadMode.Auto;
+            }
+
+            XmlTextReader xmlreader = (mode == XmlReadMode.Fragment) ? new XmlTextReader(reader.ReadToEnd(), XmlNodeType.Element, null) : new XmlTextReader(reader);
+            // Prevent Dtd entity in dataset 
+            xmlreader.XmlResolver = null;
+            return ReadXml(xmlreader, mode, false);
+        }
+
+        public XmlReadMode ReadXml(string fileName, XmlReadMode mode)
+        {
+            XmlTextReader xr = null;
+            if (mode == XmlReadMode.Fragment)
+            {
+                FileStream stream = new FileStream(fileName, FileMode.Open);
+                xr = new XmlTextReader(stream, XmlNodeType.Element, null);
+            }
+            else
+            {
+                xr = new XmlTextReader(fileName);
+            }
+
+            // Prevent Dtd entity in dataset             
+            xr.XmlResolver = null;
+
+            try
+            {
+                return ReadXml(xr, mode, false);
+            }
+            finally
+            {
+                xr.Close();
+            }
+        }
+
+        public void WriteXml(Stream stream) => WriteXml(stream, XmlWriteMode.IgnoreSchema);
+
+        public void WriteXml(TextWriter writer) => WriteXml(writer, XmlWriteMode.IgnoreSchema);
+
+        public void WriteXml(XmlWriter writer) => WriteXml(writer, XmlWriteMode.IgnoreSchema);
+
+        public void WriteXml(string fileName) => WriteXml(fileName, XmlWriteMode.IgnoreSchema);
+
+        /// <summary>
+        /// Writes schema and data for the DataSet.
+        /// </summary>
+        public void WriteXml(Stream stream, XmlWriteMode mode)
+        {
+            if (stream != null)
+            {
+                XmlTextWriter w = new XmlTextWriter(stream, null);
+                w.Formatting = Formatting.Indented;
+
+                WriteXml(w, mode);
+            }
+        }
+
+        public void WriteXml(TextWriter writer, XmlWriteMode mode)
+        {
+            if (writer != null)
+            {
+                XmlTextWriter w = new XmlTextWriter(writer);
+                w.Formatting = Formatting.Indented;
+
+                WriteXml(w, mode);
+            }
+        }
+
+        public void WriteXml(XmlWriter writer, XmlWriteMode mode)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.WriteXml|API> {0}, mode={1}", ObjectID, mode);
+            try
+            {
+                // Generate SchemaTree and write it out
+                if (writer != null)
+                {
+                    if (mode == XmlWriteMode.DiffGram)
+                    {
+                        // Create and save the updates
+                        new NewDiffgramGen(this).Save(writer);
+                    }
+                    else
+                    {
+                        // Create and save xml data
+                        new XmlDataTreeWriter(this).Save(writer, mode == XmlWriteMode.WriteSchema);
+                    }
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void WriteXml(string fileName, XmlWriteMode mode)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.WriteXml|API> {0}, fileName='{1}', mode={2}", ObjectID, fileName, (int)mode);
+            XmlTextWriter xw = new XmlTextWriter(fileName, null);
+            try
+            {
+                xw.Formatting = Formatting.Indented;
+                xw.WriteStartDocument(true);
+                if (xw != null)
+                {
+                    // Create and save the updates
+                    if (mode == XmlWriteMode.DiffGram)
+                    {
+                        new NewDiffgramGen(this).Save(xw);
+                    }
+                    else
+                    {
+                        // Create and save xml data
+                        new XmlDataTreeWriter(this).Save(xw, mode == XmlWriteMode.WriteSchema);
+                    }
+                }
+                xw.WriteEndDocument();
+            }
+            finally
+            {
+                xw.Close();
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection of parent relations which belong to a
+        /// specified table.
+        /// </summary>
+        internal DataRelationCollection GetParentRelations(DataTable table) => table.ParentRelations;
+
+        /// <summary>
+        /// Merges this <see cref='System.Data.DataSet'/> into a specified <see cref='System.Data.DataSet'/>.
+        /// </summary>
+        public void Merge(DataSet dataSet)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, dataSet={1}", ObjectID, (dataSet != null) ? dataSet.ObjectID : 0);
+            try
+            {
+                Merge(dataSet, false, MissingSchemaAction.Add);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Merges this <see cref='System.Data.DataSet'/> into a specified <see cref='System.Data.DataSet'/> preserving changes according to
+        /// the specified argument.
+        /// </summary>
+        public void Merge(DataSet dataSet, bool preserveChanges)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, dataSet={1}, preserveChanges={2}", ObjectID, (dataSet != null) ? dataSet.ObjectID : 0, preserveChanges);
+            try
+            {
+                Merge(dataSet, preserveChanges, MissingSchemaAction.Add);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Merges this <see cref='System.Data.DataSet'/> into a specified <see cref='System.Data.DataSet'/> preserving changes according to
+        /// the specified argument, and handling an incompatible schema according to the
+        /// specified argument.
+        /// </summary>
+        public void Merge(DataSet dataSet, bool preserveChanges, MissingSchemaAction missingSchemaAction)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, dataSet={1}, preserveChanges={2}, missingSchemaAction={3}", ObjectID, (dataSet != null) ? dataSet.ObjectID : 0, preserveChanges, missingSchemaAction);
+            try
+            {
+                // Argument checks
+                if (dataSet == null)
+                {
+                    throw ExceptionBuilder.ArgumentNull(nameof(dataSet));
+                }
+
+                switch (missingSchemaAction)
+                {
+                    case MissingSchemaAction.Add:
+                    case MissingSchemaAction.Ignore:
+                    case MissingSchemaAction.Error:
+                    case MissingSchemaAction.AddWithKey:
+                        Merger merger = new Merger(this, preserveChanges, missingSchemaAction);
+                        merger.MergeDataSet(dataSet);
+                        break;
+                    default:
+                        throw ADP.InvalidMissingSchemaAction(missingSchemaAction);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Merges this <see cref='System.Data.DataTable'/> into a specified <see cref='System.Data.DataTable'/>.
+        /// </summary>
+        public void Merge(DataTable table)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, table={1}", ObjectID, (table != null) ? table.ObjectID : 0);
+            try
+            {
+                Merge(table, false, MissingSchemaAction.Add);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Merges this <see cref='System.Data.DataTable'/> into a specified <see cref='System.Data.DataTable'/>. with a value to preserve changes
+        /// made to the target, and a value to deal with missing schemas.
+        /// </summary>
+        public void Merge(DataTable table, bool preserveChanges, MissingSchemaAction missingSchemaAction)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, table={1}, preserveChanges={2}, missingSchemaAction={3}", ObjectID, (table != null) ? table.ObjectID : 0, preserveChanges, missingSchemaAction);
+            try
+            {
+                // Argument checks
+                if (table == null)
+                {
+                    throw ExceptionBuilder.ArgumentNull(nameof(table));
+                }
+
+                switch (missingSchemaAction)
+                {
+                    case MissingSchemaAction.Add:
+                    case MissingSchemaAction.Ignore:
+                    case MissingSchemaAction.Error:
+                    case MissingSchemaAction.AddWithKey:
+                        Merger merger = new Merger(this, preserveChanges, missingSchemaAction);
+                        merger.MergeTable(table);
+                        break;
+                    default:
+                        throw ADP.InvalidMissingSchemaAction(missingSchemaAction);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void Merge(DataRow[] rows)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, rows", ObjectID);
+            try
+            {
+                Merge(rows, false, MissingSchemaAction.Add);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void Merge(DataRow[] rows, bool preserveChanges, MissingSchemaAction missingSchemaAction)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Merge|API> {0}, preserveChanges={1}, missingSchemaAction={2}", ObjectID, preserveChanges, missingSchemaAction);
+            try
+            {
+                // Argument checks
+                if (rows == null)
+                {
+                    throw ExceptionBuilder.ArgumentNull(nameof(rows));
+                }
+
+                switch (missingSchemaAction)
+                {
+                    case MissingSchemaAction.Add:
+                    case MissingSchemaAction.Ignore:
+                    case MissingSchemaAction.Error:
+                    case MissingSchemaAction.AddWithKey:
+                        Merger merger = new Merger(this, preserveChanges, missingSchemaAction);
+                        merger.MergeRows(rows);
+                        break;
+                    default:
+                        throw ADP.InvalidMissingSchemaAction(missingSchemaAction);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        protected virtual void OnPropertyChanging(PropertyChangedEventArgs pcevent)
+        {
+            PropertyChanging?.Invoke(this, pcevent);
+        }
+
+        /// <summary>
+        /// Inheriting classes should override this method to handle this event.
+        /// Call base.OnMergeFailed to send this event to any registered event
+        /// listeners.
+        /// </summary>
+        internal void OnMergeFailed(MergeFailedEventArgs mfevent)
+        {
+            if (MergeFailed != null)
+            {
+                MergeFailed(this, mfevent);
+            }
+            else
+            {
+                throw ExceptionBuilder.MergeFailed(mfevent.Conflict);
+            }
+        }
+
+        internal void RaiseMergeFailed(DataTable table, string conflict, MissingSchemaAction missingSchemaAction)
+        {
+            if (MissingSchemaAction.Error == missingSchemaAction)
+            {
+                throw ExceptionBuilder.MergeFailed(conflict);
+            }
+
+            OnMergeFailed(new MergeFailedEventArgs(table, conflict));
+        }
+
+        internal void OnDataRowCreated(DataRow row) => DataRowCreated?.Invoke(this, row);
+
+        internal void OnClearFunctionCalled(DataTable table) => ClearFunctionCalled?.Invoke(this, table);
+
+        private void OnInitialized() => Initialized?.Invoke(this, EventArgs.Empty);
+
+        /// <summary>
+        /// This method should be overridden by subclasses to restrict tables being removed.
+        /// </summary>
+        protected internal virtual void OnRemoveTable(DataTable table) { }
+
+        internal void OnRemovedTable(DataTable table)
+        {
+            DataViewManager viewManager = _defaultViewManager;
+            if (null != viewManager)
+            {
+                viewManager.DataViewSettings.Remove(table);
+            }
+        }
+
+        /// <summary>
+        /// This method should be overridden by subclasses to restrict tables being removed.
+        /// </summary>
+        protected virtual void OnRemoveRelation(DataRelation relation) { }
+
+        internal void OnRemoveRelationHack(DataRelation relation) => OnRemoveRelation(relation);
+
+        protected internal void RaisePropertyChanging(string name) => OnPropertyChanging(new PropertyChangedEventArgs(name));
+
+        internal DataTable[] TopLevelTables() => TopLevelTables(false);
+
+        internal DataTable[] TopLevelTables(bool forSchema)
+        {
+            // first let's figure out if we can represent the given dataSet as a tree using
+            // the fact that all connected undirected graphs with n-1 edges are trees.
+            List<DataTable> topTables = new List<DataTable>();
+
+            if (forSchema)
+            {
+                // prepend the tables that are nested more than once
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    DataTable table = Tables[i];
+                    if (table.NestedParentsCount > 1 || table.SelfNested)
+                    {
+                        topTables.Add(table);
+                    }
+                }
+            }
+            for (int i = 0; i < Tables.Count; i++)
+            {
+                DataTable table = Tables[i];
+                if (table.NestedParentsCount == 0 && !topTables.Contains(table))
+                {
+                    topTables.Add(table);
+                }
+            }
+
+            return topTables.Count == 0 ?
+                Array.Empty<DataTable>() :
+                topTables.ToArray();
+        }
+
+        /// <summary>
+        /// This method rolls back all the changes to have been made to this DataSet since
+        /// it was loaded or the last time AcceptChanges was called.
+        /// Any rows still in edit-mode cancel their edits.  New rows get removed.  Modified and
+        /// Deleted rows return back to their original state.
+        /// </summary>
+        public virtual void RejectChanges()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.RejectChanges|API> {0}", ObjectID);
+            try
+            {
+                bool fEnforce = EnforceConstraints;
+                EnforceConstraints = false;
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    Tables[i].RejectChanges();
+                }
+                EnforceConstraints = fEnforce;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Resets the dataSet back to it's original state.  Subclasses should override
+        /// to restore back to it's original state.
+        /// </summary>
+        public virtual void Reset()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Reset|API> {0}", ObjectID);
+            try
+            {
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    ConstraintCollection cons = Tables[i].Constraints;
+                    for (int j = 0; j < cons.Count;)
+                    {
+                        if (cons[j] is ForeignKeyConstraint)
+                        {
+                            cons.Remove(cons[j]);
+                        }
+                        else
+                        {
+                            j++;
+                        }
+                    }
+                }
+
+                Clear();
+                Relations.Clear();
+                Tables.Clear();
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal bool ValidateCaseConstraint()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ValidateCaseConstraint|INFO> {0}", ObjectID);
+            try
+            {
+                DataRelation relation = null;
+                for (int i = 0; i < Relations.Count; i++)
+                {
+                    relation = Relations[i];
+                    if (relation.ChildTable.CaseSensitive != relation.ParentTable.CaseSensitive)
+                    {
+                        return false;
+                    }
+                }
+
+                ForeignKeyConstraint constraint = null;
+                ConstraintCollection constraints = null;
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    constraints = Tables[i].Constraints;
+                    for (int j = 0; j < constraints.Count; j++)
+                    {
+                        if (constraints[j] is ForeignKeyConstraint)
+                        {
+                            constraint = (ForeignKeyConstraint)constraints[j];
+                            if (constraint.Table.CaseSensitive != constraint.RelatedTable.CaseSensitive)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                return true;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal bool ValidateLocaleConstraint()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ValidateLocaleConstraint|INFO> {0}", ObjectID);
+            try
+            {
+                DataRelation relation = null;
+                for (int i = 0; i < Relations.Count; i++)
+                {
+                    relation = Relations[i];
+                    if (relation.ChildTable.Locale.LCID != relation.ParentTable.Locale.LCID)
+                    {
+                        return false;
+                    }
+                }
+
+                ForeignKeyConstraint constraint = null;
+                ConstraintCollection constraints = null;
+                for (int i = 0; i < Tables.Count; i++)
+                {
+                    constraints = Tables[i].Constraints;
+                    for (int j = 0; j < constraints.Count; j++)
+                    {
+                        if (constraints[j] is ForeignKeyConstraint)
+                        {
+                            constraint = (ForeignKeyConstraint)constraints[j];
+                            if (constraint.Table.Locale.LCID != constraint.RelatedTable.Locale.LCID)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                return true;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        // SDUB: may be better to rewrite this as nonrecursive?
+        internal DataTable FindTable(DataTable baseTable, PropertyDescriptor[] props, int propStart)
+        {
+            if (props.Length < propStart + 1)
+            {
+                return baseTable;
+            }
+
+            PropertyDescriptor currentProp = props[propStart];
+
+            if (baseTable == null)
+            {
+                // the accessor is the table name.  if we don't find it, return null.
+                if (currentProp is DataTablePropertyDescriptor)
+                {
+                    return FindTable(((DataTablePropertyDescriptor)currentProp).Table, props, propStart + 1);
+                }
+                return null;
+            }
+
+            if (currentProp is DataRelationPropertyDescriptor)
+            {
+                return FindTable(((DataRelationPropertyDescriptor)currentProp).Relation.ChildTable, props, propStart + 1);
+            }
+
+            return null;
+        }
+
+        protected virtual void ReadXmlSerializable(XmlReader reader)
+        {
+            // <DataSet xsi:nil="true"> does not mean DataSet is null,but it does not have any child
+            // so  dont do anything, ignore the attributes and just return empty DataSet;
+            _useDataSetSchemaOnly = false;
+            _udtIsWrapped = false;
+
+            if (reader.HasAttributes)
+            {
+                const string xsinill = Keywords.XSI + ":" + Keywords.XSI_NIL;
+                if (reader.MoveToAttribute(xsinill))
+                {
+                    string nilAttrib = reader.GetAttribute(xsinill);
+                    if (string.Equals(nilAttrib, "true", StringComparison.Ordinal))
+                    {
+                        // case sensitive true comparison
+                        MoveToElement(reader, 1);
+                        return;
+                    }
+                }
+
+                const string UseDataSetSchemaOnlyString = Keywords.MSD + ":" + Keywords.USEDATASETSCHEMAONLY;
+                if (reader.MoveToAttribute(UseDataSetSchemaOnlyString))
+                {
+                    string useDataSetSchemaOnly = reader.GetAttribute(UseDataSetSchemaOnlyString);
+                    if (string.Equals(useDataSetSchemaOnly, "true", StringComparison.Ordinal) ||
+                        string.Equals(useDataSetSchemaOnly, "1", StringComparison.Ordinal))
+                    {
+                        _useDataSetSchemaOnly = true;
+                    }
+                    else if (!string.Equals(useDataSetSchemaOnly, "false", StringComparison.Ordinal) &&
+                             !string.Equals(useDataSetSchemaOnly, "0", StringComparison.Ordinal))
+                    {
+                        throw ExceptionBuilder.InvalidAttributeValue(Keywords.USEDATASETSCHEMAONLY, useDataSetSchemaOnly);
+                    }
+                }
+
+                const string udtIsWrappedString = Keywords.MSD + ":" + Keywords.UDTCOLUMNVALUEWRAPPED;
+                if (reader.MoveToAttribute(udtIsWrappedString))
+                {
+                    string _udtIsWrappedString = reader.GetAttribute(udtIsWrappedString);
+                    if (string.Equals(_udtIsWrappedString, "true", StringComparison.Ordinal) ||
+                        string.Equals(_udtIsWrappedString, "1", StringComparison.Ordinal))
+                    {
+                        _udtIsWrapped = true;
+                    }
+                    else if (!string.Equals(_udtIsWrappedString, "false", StringComparison.Ordinal) &&
+                             !string.Equals(_udtIsWrappedString, "0", StringComparison.Ordinal))
+                    {
+                        throw ExceptionBuilder.InvalidAttributeValue(Keywords.UDTCOLUMNVALUEWRAPPED, _udtIsWrappedString);
+                    }
+                }
+            }
+            ReadXml(reader, XmlReadMode.DiffGram, true);
+        }
+
+        protected virtual System.Xml.Schema.XmlSchema GetSchemaSerializable() => null;
+
+        public static XmlSchemaComplexType GetDataSetSchema(XmlSchemaSet schemaSet)
+        {
+            // For performance resons we are exploiting the fact that config files content is constant 
+            // for a given appdomain so we can safely cache the prepared schema complex type and reuse it
+            if (s_schemaTypeForWSDL == null)
+            {
+                // to change the config file, appdomain needs to restart; so it seems safe to cache the schema
+                XmlSchemaComplexType tempWSDL = new XmlSchemaComplexType();
+                XmlSchemaSequence sequence = new XmlSchemaSequence();
+
+                XmlSchemaAny any = new XmlSchemaAny();
+                any.Namespace = XmlSchema.Namespace;
+                any.MinOccurs = 0;
+                any.ProcessContents = XmlSchemaContentProcessing.Lax;
+                sequence.Items.Add(any);
+
+                any = new XmlSchemaAny();
+                any.Namespace = Keywords.DFFNS;
+                any.MinOccurs = 0; // when recognizing WSDL - MinOccurs="0" denotes DataSet, a MinOccurs="1" for DataTable
+                any.ProcessContents = XmlSchemaContentProcessing.Lax;
+                sequence.Items.Add(any);
+                sequence.MaxOccurs = decimal.MaxValue;
+
+                tempWSDL.Particle = sequence;
+
+                s_schemaTypeForWSDL = tempWSDL;
+            }
+            return s_schemaTypeForWSDL;
+        }
+
+        private static bool PublishLegacyWSDL() => false;
+
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            if (GetType() == typeof(DataSet))
+            {
+                return null;
+            }
+
+            MemoryStream stream = new MemoryStream();
+            // WriteXmlSchema(new XmlTextWriter(stream, null));
+            XmlWriter writer = new XmlTextWriter(stream, null);
+            if (writer != null)
+            {
+                (new XmlTreeGen(SchemaFormat.WebService)).Save(this, writer);
+            }
+            stream.Position = 0;
+            return XmlSchema.Read(new XmlTextReader(stream), null);
+        }
+
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            bool fNormalization = true;
+            XmlTextReader xmlTextReader = null;
+            IXmlTextParser xmlTextParser = reader as IXmlTextParser;
+            if (xmlTextParser != null)
+            {
+                fNormalization = xmlTextParser.Normalized;
+                xmlTextParser.Normalized = false;
+            }
+            else
+            {
+                xmlTextReader = reader as XmlTextReader;
+                if (xmlTextReader != null)
+                {
+                    fNormalization = xmlTextReader.Normalization;
+                    xmlTextReader.Normalization = false;
+                }
+            }
+
+            ReadXmlSerializable(reader);
+
+            if (xmlTextParser != null)
+            {
+                xmlTextParser.Normalized = fNormalization;
+            }
+            else if (xmlTextReader != null)
+            {
+                xmlTextReader.Normalization = fNormalization;
+            }
+        }
+
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            WriteXmlSchema(writer, SchemaFormat.WebService, null);
+            WriteXml(writer, XmlWriteMode.DiffGram);
+        }
+
+        public virtual void Load(IDataReader reader, LoadOption loadOption, FillErrorEventHandler errorHandler, params DataTable[] tables)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.Load|API> reader, loadOption={0}", loadOption);
+            try
+            {
+                foreach (DataTable dt in tables)
+                {
+                    ADP.CheckArgumentNull(dt, nameof(tables));
+                    if (dt.DataSet != this)
+                    {
+                        throw ExceptionBuilder.TableNotInTheDataSet(dt.TableName);
+                    }
+                }
+
+                var adapter = new LoadAdapter();
+                adapter.FillLoadOption = loadOption;
+                adapter.MissingSchemaAction = MissingSchemaAction.AddWithKey;
+                if (null != errorHandler)
+                {
+                    adapter.FillError += errorHandler;
+                }
+                adapter.FillFromReader(tables, reader, 0, 0);
+
+                if (!reader.IsClosed && !reader.NextResult())
+                {
+                    reader.Close();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void Load(IDataReader reader, LoadOption loadOption, params DataTable[] tables) =>
+            Load(reader, loadOption, null, tables);
+
+        public void Load(IDataReader reader, LoadOption loadOption, params string[] tables)
+        {
+            ADP.CheckArgumentNull(tables, nameof(tables));
+            var dataTables = new DataTable[tables.Length];
+            for (int i = 0; i < tables.Length; i++)
+            {
+                DataTable tempDT = Tables[tables[i]];
+                if (null == tempDT)
+                {
+                    tempDT = new DataTable(tables[i]);
+                    Tables.Add(tempDT);
+                }
+                dataTables[i] = tempDT;
+            }
+            Load(reader, loadOption, null, dataTables);
+        }
+
+        public DataTableReader CreateDataReader()
+        {
+            if (Tables.Count == 0)
+            {
+                throw ExceptionBuilder.CannotCreateDataReaderOnEmptyDataSet();
+            }
+
+            var dataTables = new DataTable[Tables.Count];
+            for (int i = 0; i < Tables.Count; i++)
+            {
+                dataTables[i] = Tables[i];
+            }
+            return CreateDataReader(dataTables);
+        }
+
+        public DataTableReader CreateDataReader(params DataTable[] dataTables)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.GetDataReader|API> {0}", ObjectID);
+            try
+            {
+                if (dataTables.Length == 0)
+                {
+                    throw ExceptionBuilder.DataTableReaderArgumentIsEmpty();
+                }
+
+                for (int i = 0; i < dataTables.Length; i++)
+                {
+                    if (dataTables[i] == null)
+                    {
+                        throw ExceptionBuilder.ArgumentContainsNullValue();
+                    }
+                }
+
+                return new DataTableReader(dataTables);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal string MainTableName
+        {
+            get { return _mainTableName; }
+            set { _mainTableName = value; }
+        }
+
+        internal int ObjectID => _objectID;
+    }
+}

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataSet.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataSet.cs
@@ -1965,9 +1965,11 @@ namespace System.Data
 
         internal XmlReadMode ReadXml(XmlReader reader, bool denyResolving)
         {
+            IDisposable? restrictedScope = null;
             long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ReadXml|INFO> {0}, denyResolving={1}", ObjectID, denyResolving);
             try
             {
+                restrictedScope = TypeLimiter.EnterRestrictedScope(this);
                 DataTable.DSRowDiffIdUsageSection rowDiffIdUsage = new DataTable.DSRowDiffIdUsageSection();
                 try
                 {
@@ -2235,6 +2237,7 @@ namespace System.Data
             }
             finally
             {
+                restrictedScope?.Dispose();
                 DataCommonEventSource.Log.ExitScope(logScopeId);
             }
         }
@@ -2472,9 +2475,11 @@ namespace System.Data
 
         internal XmlReadMode ReadXml(XmlReader reader, XmlReadMode mode, bool denyResolving)
         {
+            IDisposable? restictedScope = null;
             long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataSet.ReadXml|INFO> {0}, mode={1}, denyResolving={2}", ObjectID, mode, denyResolving);
             try
             {
+                restictedScope = TypeLimiter.EnterRestrictedScope(this);
                 XmlReadMode ret = mode;
 
                 if (reader == null)
@@ -2716,6 +2721,7 @@ namespace System.Data
             }
             finally
             {
+                restictedScope?.Dispose();
                 DataCommonEventSource.Log.ExitScope(logScopeId);
             }
         }

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataTable.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataTable.cs
@@ -1,0 +1,7192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+using System.Data.Common;
+using System.Runtime.CompilerServices;
+
+namespace System.Data
+{
+    /// <summary>
+    /// Represents one table of in-memory data.
+    /// </summary>
+    [ToolboxItem(false)]
+    [DesignTimeVisible(false)]
+    [DefaultProperty(nameof(TableName))]
+    [DefaultEvent(nameof(RowChanging))]
+    [XmlSchemaProvider(nameof(GetDataTableSchema))]
+    [Serializable]
+#if !MONO
+    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+#endif
+    public class DataTable : MarshalByValueComponent, IListSource, ISupportInitializeNotification, ISerializable, IXmlSerializable
+    {
+        private DataSet _dataSet;
+        private DataView _defaultView = null;
+
+        /// <summary>
+        /// Monotonically increasing number representing the order <see cref="DataRow"/> have been added to <see cref="DataRowCollection"/>.
+        /// </summary>
+        /// <remarks>This limits <see cref="DataRowCollection.Add(DataRow)"/> to <see cref="int.MaxValue"/> operations.</remarks>
+        internal long _nextRowID;
+        internal readonly DataRowCollection _rowCollection;
+
+        // columns
+        internal readonly DataColumnCollection _columnCollection;
+
+        // constraints
+        private readonly ConstraintCollection _constraintCollection;
+
+        //SimpleContent implementation
+        private int _elementColumnCount = 0;
+
+        // relations
+        internal DataRelationCollection _parentRelationsCollection;
+        internal DataRelationCollection _childRelationsCollection;
+
+        // RecordManager
+        internal readonly RecordManager _recordManager;
+
+        // index mgmt
+        internal readonly List<Index> _indexes;
+
+        private List<Index> _shadowIndexes;
+        private int _shadowCount;
+
+        // props
+        internal PropertyCollection _extendedProperties = null;
+        private string _tableName = string.Empty;
+        internal string _tableNamespace = null;
+        private string _tablePrefix = string.Empty;
+        internal DataExpression _displayExpression;
+        internal bool _fNestedInDataset = true;
+
+        // globalization stuff
+        private CultureInfo _culture;
+        private bool _cultureUserSet;
+        private CompareInfo _compareInfo;
+        private CompareOptions _compareFlags = CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth;
+        private IFormatProvider _formatProvider;
+        private StringComparer _hashCodeProvider;
+        private bool _caseSensitive;
+        private bool _caseSensitiveUserSet;
+
+        // XML properties
+        internal string _encodedTableName;           // For XmlDataDocument only
+        internal DataColumn _xmlText;            // text values of a complex xml element
+        internal DataColumn _colUnique;
+        internal bool _textOnly = false;         // the table has only text value with possible attributes
+        internal decimal _minOccurs = 1;    // default = 1
+        internal decimal _maxOccurs = 1;    // default = 1
+        internal bool _repeatableElement = false;
+        private object _typeName = null;
+
+        // primary key info
+        internal UniqueConstraint _primaryKey;
+        internal IndexField[] _primaryIndex = Array.Empty<IndexField>();
+        private DataColumn[] _delayedSetPrimaryKey = null;
+
+        // Loading Schema and/or Data related optimization
+        private Index _loadIndex;
+        private Index _loadIndexwithOriginalAdded = null;
+        private Index _loadIndexwithCurrentDeleted = null;
+        private int _suspendIndexEvents;
+
+        private bool _savedEnforceConstraints = false;
+        private bool _inDataLoad = false;
+        private bool _initialLoad;
+        private bool _schemaLoading = false;
+        private bool _enforceConstraints = true;
+        internal bool _suspendEnforceConstraints = false;
+
+        protected internal bool fInitInProgress = false;
+        private bool _inLoad = false;
+        internal bool _fInLoadDiffgram = false;
+
+        private byte _isTypedDataTable; // 0 == unknown, 1 = yes, 2 = No
+        private DataRow[] _emptyDataRowArray;
+
+        // Property Descriptor Cache for DataBinding
+        private PropertyDescriptorCollection _propertyDescriptorCollectionCache = null;
+
+        // Cache for relation that has this table as nested child table.
+        private DataRelation[] _nestedParentRelations = Array.Empty<DataRelation>();
+
+        // Dependent column list for expression evaluation
+        internal List<DataColumn> _dependentColumns = null;
+
+        // events
+        private bool _mergingData = false;
+        private DataRowChangeEventHandler _onRowChangedDelegate;
+        private DataRowChangeEventHandler _onRowChangingDelegate;
+        private DataRowChangeEventHandler _onRowDeletingDelegate;
+        private DataRowChangeEventHandler _onRowDeletedDelegate;
+        private DataColumnChangeEventHandler _onColumnChangedDelegate;
+        private DataColumnChangeEventHandler _onColumnChangingDelegate;
+        private DataTableClearEventHandler _onTableClearingDelegate;
+        private DataTableClearEventHandler _onTableClearedDelegate;
+        private DataTableNewRowEventHandler _onTableNewRowDelegate;
+        private PropertyChangedEventHandler _onPropertyChangingDelegate;
+
+        private EventHandler _onInitialized;
+
+        // misc
+        private readonly DataRowBuilder _rowBuilder;
+        private const string KEY_XMLSCHEMA = "XmlSchema";
+        private const string KEY_XMLDIFFGRAM = "XmlDiffGram";
+        private const string KEY_NAME = "TableName";
+
+        internal readonly List<DataView> _delayedViews = new List<DataView>();
+        private readonly List<DataViewListener> _dataViewListeners = new List<DataViewListener>();
+
+        internal Hashtable _rowDiffId = null;
+        internal readonly ReaderWriterLockSlim _indexesLock = new ReaderWriterLockSlim();
+        internal int _ukColumnPositionForInference = -1;
+
+        // default remoting format is Xml
+        private SerializationFormat _remotingFormat = SerializationFormat.Xml;
+
+        private static int s_objectTypeCount; // Bid counter
+        private readonly int _objectID = System.Threading.Interlocked.Increment(ref s_objectTypeCount);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DataTable'/> class with no arguments.
+        /// </summary>
+        public DataTable()
+        {
+            GC.SuppressFinalize(this);
+            DataCommonEventSource.Log.Trace("<ds.DataTable.DataTable|API> {0}", ObjectID);
+            _nextRowID = 1;
+            _recordManager = new RecordManager(this);
+
+            _culture = CultureInfo.CurrentCulture;
+            _columnCollection = new DataColumnCollection(this);
+            _constraintCollection = new ConstraintCollection(this);
+            _rowCollection = new DataRowCollection(this);
+            _indexes = new List<Index>();
+
+            _rowBuilder = new DataRowBuilder(this, -1);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Data.DataTable'/> class with the specified table
+        ///    name.
+        /// </summary>
+        public DataTable(string tableName) : this()
+        {
+            _tableName = tableName == null ? "" : tableName;
+        }
+
+        public DataTable(string tableName, string tableNamespace) : this(tableName)
+        {
+            Namespace = tableNamespace;
+        }
+
+        // Deserialize the table from binary/xml stream.
+        protected DataTable(SerializationInfo info, StreamingContext context) : this()
+        {
+            bool isSingleTable = context.Context != null ? Convert.ToBoolean(context.Context, CultureInfo.InvariantCulture) : true;
+            SerializationFormat remotingFormat = SerializationFormat.Xml;
+            SerializationInfoEnumerator e = info.GetEnumerator();
+            while (e.MoveNext())
+            {
+                switch (e.Name)
+                {
+                    case "DataTable.RemotingFormat": //DataTable.RemotingFormat does not exist in V1/V1.1 versions
+                        remotingFormat = (SerializationFormat)e.Value;
+                        break;
+                }
+            }
+
+            DeserializeDataTable(info, context, isSingleTable, remotingFormat);
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            SerializationFormat remotingFormat = RemotingFormat;
+            bool isSingleTable = context.Context != null ? Convert.ToBoolean(context.Context, CultureInfo.InvariantCulture) : true;
+            SerializeDataTable(info, context, isSingleTable, remotingFormat);
+        }
+
+        // Serialize the table schema and data.
+        private void SerializeDataTable(SerializationInfo info, StreamingContext context, bool isSingleTable, SerializationFormat remotingFormat)
+        {
+            info.AddValue("DataTable.RemotingVersion", new Version(2, 0));
+
+            // SqlHotFix 299, SerializationFormat enumeration types don't exist in V1.1 SP1
+            if (SerializationFormat.Xml != remotingFormat)
+            {
+                info.AddValue("DataTable.RemotingFormat", remotingFormat);
+            }
+
+            if (remotingFormat != SerializationFormat.Xml)
+            {
+                //Binary
+                SerializeTableSchema(info, context, isSingleTable);
+                if (isSingleTable)
+                {
+                    SerializeTableData(info, context, 0);
+                }
+            }
+            else
+            {
+                //XML/V1.0/V1.1
+                string tempDSNamespace = string.Empty;
+                bool fCreatedDataSet = false;
+
+                if (_dataSet == null)
+                {
+                    DataSet ds = new DataSet("tmpDataSet");
+                    // if user set values on DataTable, it isn't necessary
+                    // to set them on the DataSet because they won't be inherited
+                    // but it is simpler to set them in both places
+
+                    // if user did not set values on DataTable, it is required
+                    // to set them on the DataSet so the table will inherit
+                    // the value already on the Datatable
+                    ds.SetLocaleValue(_culture, _cultureUserSet);
+                    ds.CaseSensitive = CaseSensitive;
+                    ds._namespaceURI = Namespace;
+                    Debug.Assert(ds.RemotingFormat == SerializationFormat.Xml, "RemotingFormat must be SerializationFormat.Xml");
+                    ds.Tables.Add(this);
+                    fCreatedDataSet = true;
+                }
+                else
+                {
+                    tempDSNamespace = DataSet.Namespace;
+                    DataSet._namespaceURI = Namespace;
+                }
+
+                info.AddValue(KEY_XMLSCHEMA, _dataSet.GetXmlSchemaForRemoting(this));
+                info.AddValue(KEY_XMLDIFFGRAM, _dataSet.GetRemotingDiffGram(this));
+
+                if (fCreatedDataSet)
+                {
+                    _dataSet.Tables.Remove(this);
+                }
+                else
+                {
+                    _dataSet._namespaceURI = tempDSNamespace;
+                }
+            }
+        }
+
+        // Deserialize the table schema and data.
+        internal void DeserializeDataTable(SerializationInfo info, StreamingContext context, bool isSingleTable, SerializationFormat remotingFormat)
+        {
+            if (remotingFormat != SerializationFormat.Xml)
+            {
+                //Binary
+                DeserializeTableSchema(info, context, isSingleTable);
+                if (isSingleTable)
+                {
+                    DeserializeTableData(info, context, 0);
+                    ResetIndexes();
+                }
+            }
+            else
+            {
+                //XML/V1.0/V1.1
+                string strSchema = (string)info.GetValue(KEY_XMLSCHEMA, typeof(string));
+                string strData = (string)info.GetValue(KEY_XMLDIFFGRAM, typeof(string));
+
+                if (strSchema != null)
+                {
+                    DataSet ds = new DataSet();
+                    ds.ReadXmlSchema(new XmlTextReader(new StringReader(strSchema)));
+
+                    Debug.Assert(ds.Tables.Count == 1, "There should be exactly 1 table here");
+                    DataTable table = ds.Tables[0];
+                    table.CloneTo(this, null, false);
+                    //this is to avoid the cascading rules in the namespace
+                    Namespace = table.Namespace;
+
+                    if (strData != null)
+                    {
+                        ds.Tables.Remove(ds.Tables[0]);
+                        ds.Tables.Add(this);
+                        ds.ReadXml(new XmlTextReader(new StringReader(strData)), XmlReadMode.DiffGram);
+                        ds.Tables.Remove(this);
+                    }
+                }
+            }
+        }
+
+        // Serialize the columns
+        internal void SerializeTableSchema(SerializationInfo info, StreamingContext context, bool isSingleTable)
+        {
+            //DataTable basic  properties
+            info.AddValue("DataTable.TableName", TableName);
+            info.AddValue("DataTable.Namespace", Namespace);
+            info.AddValue("DataTable.Prefix", Prefix);
+            info.AddValue("DataTable.CaseSensitive", _caseSensitive);
+            info.AddValue("DataTable.caseSensitiveAmbient", !_caseSensitiveUserSet);
+            info.AddValue("DataTable.LocaleLCID", Locale.LCID);
+            info.AddValue("DataTable.MinimumCapacity", _recordManager.MinimumCapacity);
+
+            //DataTable state internal properties
+            info.AddValue("DataTable.NestedInDataSet", _fNestedInDataset);
+            info.AddValue("DataTable.TypeName", TypeName.ToString());
+            info.AddValue("DataTable.RepeatableElement", _repeatableElement);
+
+            //ExtendedProperties
+            info.AddValue("DataTable.ExtendedProperties", ExtendedProperties);
+
+            //Columns
+            info.AddValue("DataTable.Columns.Count", Columns.Count);
+
+            //Check for closure of expression in case of single table.
+            if (isSingleTable)
+            {
+                List<DataTable> list = new List<DataTable>();
+                list.Add(this);
+                if (!CheckForClosureOnExpressionTables(list))
+                {
+                    throw ExceptionBuilder.CanNotRemoteDataTable();
+                }
+            }
+
+            IFormatProvider formatProvider = CultureInfo.InvariantCulture;
+            for (int i = 0; i < Columns.Count; i++)
+            {
+                //DataColumn basic properties
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.ColumnName", i), Columns[i].ColumnName);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.Namespace", i), Columns[i]._columnUri);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.Prefix", i), Columns[i].Prefix);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.ColumnMapping", i), Columns[i].ColumnMapping);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.AllowDBNull", i), Columns[i].AllowDBNull);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrement", i), Columns[i].AutoIncrement);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrementStep", i), Columns[i].AutoIncrementStep);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrementSeed", i), Columns[i].AutoIncrementSeed);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.Caption", i), Columns[i].Caption);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.DefaultValue", i), Columns[i].DefaultValue);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.ReadOnly", i), Columns[i].ReadOnly);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.MaxLength", i), Columns[i].MaxLength);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.DataType_AssemblyQualifiedName", i), Columns[i].DataType.AssemblyQualifiedName);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.XmlDataType", i), Columns[i].XmlDataType);
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.SimpleType", i), Columns[i].SimpleType);
+
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.DateTimeMode", i), Columns[i].DateTimeMode);
+
+                //DataColumn internal state properties
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrementCurrent", i), Columns[i].AutoIncrementCurrent);
+
+                //Expression
+                if (isSingleTable)
+                {
+                    info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.Expression", i), Columns[i].Expression);
+                }
+
+                //ExtendedProperties
+                info.AddValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.ExtendedProperties", i), Columns[i]._extendedProperties);
+            }
+
+            //Constraints
+            if (isSingleTable)
+            {
+                SerializeConstraints(info, context, 0, false);
+            }
+        }
+
+        // Deserialize all the Columns
+        internal void DeserializeTableSchema(SerializationInfo info, StreamingContext context, bool isSingleTable)
+        {
+            //DataTable basic properties
+            _tableName = info.GetString("DataTable.TableName");
+            _tableNamespace = info.GetString("DataTable.Namespace");
+            _tablePrefix = info.GetString("DataTable.Prefix");
+
+            bool caseSensitive = info.GetBoolean("DataTable.CaseSensitive");
+            SetCaseSensitiveValue(caseSensitive, true, false);
+            _caseSensitiveUserSet = !info.GetBoolean("DataTable.caseSensitiveAmbient");
+
+            int lcid = (int)info.GetValue("DataTable.LocaleLCID", typeof(int));
+            CultureInfo culture = new CultureInfo(lcid);
+            SetLocaleValue(culture, true, false);
+            _cultureUserSet = true;
+
+            MinimumCapacity = info.GetInt32("DataTable.MinimumCapacity");
+
+            //DataTable state internal properties
+            _fNestedInDataset = info.GetBoolean("DataTable.NestedInDataSet");
+            string tName = info.GetString("DataTable.TypeName");
+            _typeName = new XmlQualifiedName(tName);
+            _repeatableElement = info.GetBoolean("DataTable.RepeatableElement");
+
+            //ExtendedProperties
+            _extendedProperties = (PropertyCollection)info.GetValue("DataTable.ExtendedProperties", typeof(PropertyCollection));
+
+            //Columns
+            int colCount = info.GetInt32("DataTable.Columns.Count");
+            string[] expressions = new string[colCount];
+            Debug.Assert(Columns.Count == 0, "There is column in Table");
+
+            IFormatProvider formatProvider = CultureInfo.InvariantCulture;
+            for (int i = 0; i < colCount; i++)
+            {
+                DataColumn dc = new DataColumn();
+
+                //DataColumn public state properties
+                dc.ColumnName = info.GetString(string.Format(formatProvider, "DataTable.DataColumn_{0}.ColumnName", i));
+                dc._columnUri = info.GetString(string.Format(formatProvider, "DataTable.DataColumn_{0}.Namespace", i));
+                dc.Prefix = info.GetString(string.Format(formatProvider, "DataTable.DataColumn_{0}.Prefix", i));
+
+                string typeName = (string)info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.DataType_AssemblyQualifiedName", i), typeof(string));
+                dc.DataType = Type.GetType(typeName, throwOnError: true);
+                dc.XmlDataType = (string)info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.XmlDataType", i), typeof(string));
+                dc.SimpleType = (SimpleType)info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.SimpleType", i), typeof(SimpleType));
+
+                dc.ColumnMapping = (MappingType)info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.ColumnMapping", i), typeof(MappingType));
+                dc.DateTimeMode = (DataSetDateTime)info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.DateTimeMode", i), typeof(DataSetDateTime));
+
+                dc.AllowDBNull = info.GetBoolean(string.Format(formatProvider, "DataTable.DataColumn_{0}.AllowDBNull", i));
+                dc.AutoIncrement = info.GetBoolean(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrement", i));
+                dc.AutoIncrementStep = info.GetInt64(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrementStep", i));
+                dc.AutoIncrementSeed = info.GetInt64(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrementSeed", i));
+                dc.Caption = info.GetString(string.Format(formatProvider, "DataTable.DataColumn_{0}.Caption", i));
+                dc.DefaultValue = info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.DefaultValue", i), typeof(object));
+                dc.ReadOnly = info.GetBoolean(string.Format(formatProvider, "DataTable.DataColumn_{0}.ReadOnly", i));
+                dc.MaxLength = info.GetInt32(string.Format(formatProvider, "DataTable.DataColumn_{0}.MaxLength", i));
+
+                //DataColumn internal state properties
+                dc.AutoIncrementCurrent = info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.AutoIncrementCurrent", i), typeof(object));
+
+                //Expression
+                if (isSingleTable)
+                {
+                    expressions[i] = info.GetString(string.Format(formatProvider, "DataTable.DataColumn_{0}.Expression", i));
+                }
+
+                //ExtendedProperties
+                dc._extendedProperties = (PropertyCollection)info.GetValue(string.Format(formatProvider, "DataTable.DataColumn_{0}.ExtendedProperties", i), typeof(PropertyCollection));
+                Columns.Add(dc);
+            }
+            if (isSingleTable)
+            {
+                for (int i = 0; i < colCount; i++)
+                {
+                    if (expressions[i] != null)
+                    {
+                        Columns[i].Expression = expressions[i];
+                    }
+                }
+            }
+
+            //Constraints
+            if (isSingleTable)
+            {
+                DeserializeConstraints(info, context, /*table index */ 0, /* serialize all constraints */false);// since single table, send table index as 0, meanwhile passing
+                // false for 'allConstraints' means, handle all the constraint related to the table
+            }
+        }
+
+        // Serialize constraints availabe on the table - note this function is marked internal because it is called by the DataSet deserializer.
+        // ***Schema for Serializing ArrayList of Constraints***
+        // Unique Constraint - ["U"]->[constraintName]->[columnIndexes]->[IsPrimaryKey]->[extendedProperties]
+        // Foriegn Key Constraint - ["F"]->[constraintName]->[parentTableIndex, parentcolumnIndexes]->[childTableIndex, childColumnIndexes]->[AcceptRejectRule, UpdateRule, DeleteRule]->[extendedProperties]
+        internal void SerializeConstraints(SerializationInfo info, StreamingContext context, int serIndex, bool allConstraints)
+        {
+            if (allConstraints)
+            {
+                Debug.Assert(DataSet != null);
+            }
+
+            ArrayList constraintList = new ArrayList();
+
+            for (int i = 0; i < Constraints.Count; i++)
+            {
+                Constraint c = Constraints[i];
+
+                UniqueConstraint uc = c as UniqueConstraint;
+                if (uc != null)
+                {
+                    int[] colInfo = new int[uc.Columns.Length];
+                    for (int j = 0; j < colInfo.Length; j++)
+                    {
+                        colInfo[j] = uc.Columns[j].Ordinal;
+                    }
+
+                    ArrayList list = new ArrayList();
+                    list.Add("U");
+                    list.Add(uc.ConstraintName);
+                    list.Add(colInfo);
+                    list.Add(uc.IsPrimaryKey);
+                    list.Add(uc.ExtendedProperties);
+
+                    constraintList.Add(list);
+                }
+                else
+                {
+                    ForeignKeyConstraint fk = c as ForeignKeyConstraint;
+                    Debug.Assert(fk != null);
+                    bool shouldSerialize = (allConstraints == true) || (fk.Table == this && fk.RelatedTable == this);
+
+                    if (shouldSerialize)
+                    {
+                        int[] parentInfo = new int[fk.RelatedColumns.Length + 1];
+                        parentInfo[0] = allConstraints ? DataSet.Tables.IndexOf(fk.RelatedTable) : 0;
+                        for (int j = 1; j < parentInfo.Length; j++)
+                        {
+                            parentInfo[j] = fk.RelatedColumns[j - 1].Ordinal;
+                        }
+
+                        int[] childInfo = new int[fk.Columns.Length + 1];
+                        childInfo[0] = allConstraints ? DataSet.Tables.IndexOf(fk.Table) : 0;   //Since the constraint is on the current table, this is the child table.
+                        for (int j = 1; j < childInfo.Length; j++)
+                        {
+                            childInfo[j] = fk.Columns[j - 1].Ordinal;
+                        }
+
+                        ArrayList list = new ArrayList();
+                        list.Add("F");
+                        list.Add(fk.ConstraintName);
+                        list.Add(parentInfo);
+                        list.Add(childInfo);
+                        list.Add(new int[] { (int)fk.AcceptRejectRule, (int)fk.UpdateRule, (int)fk.DeleteRule });
+                        list.Add(fk.ExtendedProperties);
+
+                        constraintList.Add(list);
+                    }
+                }
+            }
+            info.AddValue(string.Format(CultureInfo.InvariantCulture, "DataTable_{0}.Constraints", serIndex), constraintList);
+        }
+
+        // Deserialize the constraints on the table.
+        // ***Schema for Serializing ArrayList of Constraints***
+        // Unique Constraint - ["U"]->[constraintName]->[columnIndexes]->[IsPrimaryKey]->[extendedProperties]
+        // Foriegn Key Constraint - ["F"]->[constraintName]->[parentTableIndex, parentcolumnIndexes]->[childTableIndex, childColumnIndexes]->[AcceptRejectRule, UpdateRule, DeleteRule]->[extendedProperties]
+        internal void DeserializeConstraints(SerializationInfo info, StreamingContext context, int serIndex, bool allConstraints)
+        {
+            ArrayList constraintList = (ArrayList)info.GetValue(string.Format(CultureInfo.InvariantCulture, "DataTable_{0}.Constraints", serIndex), typeof(ArrayList));
+
+            foreach (ArrayList list in constraintList)
+            {
+                string con = (string)list[0];
+
+                if (con.Equals("U"))
+                {
+                    //Unique Constraints
+                    string constraintName = (string)list[1];
+
+                    int[] keyColumnIndexes = (int[])list[2];
+                    bool isPrimaryKey = (bool)list[3];
+                    PropertyCollection extendedProperties = (PropertyCollection)list[4];
+
+                    DataColumn[] keyColumns = new DataColumn[keyColumnIndexes.Length];
+                    for (int i = 0; i < keyColumnIndexes.Length; i++)
+                    {
+                        keyColumns[i] = Columns[keyColumnIndexes[i]];
+                    }
+
+                    //Create the constraint.
+                    UniqueConstraint uc = new UniqueConstraint(constraintName, keyColumns, isPrimaryKey);
+                    uc._extendedProperties = extendedProperties;
+
+                    //Add the unique constraint and it will in turn set the primary keys also if needed.
+                    Constraints.Add(uc);
+                }
+                else
+                {
+                    //ForeignKeyConstraints
+                    Debug.Assert(con.Equals("F"));
+
+                    string constraintName = (string)list[1];
+                    int[] parentInfo = (int[])list[2];
+                    int[] childInfo = (int[])list[3];
+                    int[] rules = (int[])list[4];
+                    PropertyCollection extendedProperties = (PropertyCollection)list[5];
+
+                    //ParentKey Columns.
+                    DataTable parentTable = (allConstraints == false) ? this : DataSet.Tables[parentInfo[0]];
+                    DataColumn[] parentkeyColumns = new DataColumn[parentInfo.Length - 1];
+                    for (int i = 0; i < parentkeyColumns.Length; i++)
+                    {
+                        parentkeyColumns[i] = parentTable.Columns[parentInfo[i + 1]];
+                    }
+
+                    //ChildKey Columns.
+                    DataTable childTable = (allConstraints == false) ? this : DataSet.Tables[childInfo[0]];
+                    DataColumn[] childkeyColumns = new DataColumn[childInfo.Length - 1];
+                    for (int i = 0; i < childkeyColumns.Length; i++)
+                    {
+                        childkeyColumns[i] = childTable.Columns[childInfo[i + 1]];
+                    }
+
+                    //Create the Constraint.
+                    ForeignKeyConstraint fk = new ForeignKeyConstraint(constraintName, parentkeyColumns, childkeyColumns);
+                    fk.AcceptRejectRule = (AcceptRejectRule)rules[0];
+                    fk.UpdateRule = (Rule)rules[1];
+                    fk.DeleteRule = (Rule)rules[2];
+                    fk._extendedProperties = extendedProperties;
+
+                    //Add just the foreign key constraint without creating unique constraint.
+                    Constraints.Add(fk, false);
+                }
+            }
+        }
+
+        // Serialize the expressions on the table - Marked internal so that DataSet deserializer can call into this
+        internal void SerializeExpressionColumns(SerializationInfo info, StreamingContext context, int serIndex)
+        {
+            int colCount = Columns.Count;
+            for (int i = 0; i < colCount; i++)
+            {
+                info.AddValue(string.Format(CultureInfo.InvariantCulture, "DataTable_{0}.DataColumn_{1}.Expression", serIndex, i), Columns[i].Expression);
+            }
+        }
+
+        // Deserialize the expressions on the table - Marked internal so that DataSet deserializer can call into this
+        internal void DeserializeExpressionColumns(SerializationInfo info, StreamingContext context, int serIndex)
+        {
+            int colCount = Columns.Count;
+            for (int i = 0; i < colCount; i++)
+            {
+                string expr = info.GetString(string.Format(CultureInfo.InvariantCulture, "DataTable_{0}.DataColumn_{1}.Expression", serIndex, i));
+                if (0 != expr.Length)
+                {
+                    Columns[i].Expression = expr;
+                }
+            }
+        }
+
+        // Serialize all the Rows.
+        internal void SerializeTableData(SerializationInfo info, StreamingContext context, int serIndex)
+        {
+            //Cache all the column count, row count
+            int colCount = Columns.Count;
+            int rowCount = Rows.Count;
+            int modifiedRowCount = 0;
+            int editRowCount = 0;
+
+            //Compute row states and assign the bits accordingly - 00[Unchanged], 01[Added], 10[Modifed], 11[Deleted]
+            BitArray rowStates = new BitArray(rowCount * 3, false); //All bit flags are set to false on initialization of the BitArray.
+            for (int i = 0; i < rowCount; i++)
+            {
+                int bitIndex = i * 3;
+                DataRow row = Rows[i];
+                DataRowState rowState = row.RowState;
+                switch (rowState)
+                {
+                    case DataRowState.Unchanged:
+                        //rowStates[bitIndex] = false;
+                        //rowStates[bitIndex + 1] = false;
+                        break;
+                    case DataRowState.Added:
+                        //rowStates[bitIndex] = false;
+                        rowStates[bitIndex + 1] = true;
+                        break;
+                    case DataRowState.Modified:
+                        rowStates[bitIndex] = true;
+                        //rowStates[bitIndex + 1] = false;
+                        modifiedRowCount++;
+                        break;
+                    case DataRowState.Deleted:
+                        rowStates[bitIndex] = true;
+                        rowStates[bitIndex + 1] = true;
+                        break;
+                    default:
+                        throw ExceptionBuilder.InvalidRowState(rowState);
+                }
+                if (-1 != row._tempRecord)
+                {
+                    rowStates[bitIndex + 2] = true;
+                    editRowCount++;
+                }
+            }
+
+            //Compute the actual storage records that need to be created.
+            int recordCount = rowCount + modifiedRowCount + editRowCount;
+
+            //Create column storages.
+            ArrayList storeList = new ArrayList();
+            ArrayList nullbitList = new ArrayList();
+            if (recordCount > 0)
+            {
+                //Create the storage only if have records.
+                for (int i = 0; i < colCount; i++)
+                {
+                    object store = Columns[i].GetEmptyColumnStore(recordCount);
+                    storeList.Add(store);
+                    BitArray nullbits = new BitArray(recordCount);
+                    nullbitList.Add(nullbits);
+                }
+            }
+
+            //Copy values into column storages
+            int recordsConsumed = 0;
+            Hashtable rowErrors = new Hashtable();
+            Hashtable colErrors = new Hashtable();
+            for (int i = 0; i < rowCount; i++)
+            {
+                int recordsPerRow = Rows[i].CopyValuesIntoStore(storeList, nullbitList, recordsConsumed);
+                GetRowAndColumnErrors(i, rowErrors, colErrors);
+                recordsConsumed += recordsPerRow;
+            }
+
+            IFormatProvider formatProvider = CultureInfo.InvariantCulture;
+            //Serialize all the computed values.
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.Rows.Count", serIndex), rowCount);
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.Records.Count", serIndex), recordCount);
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.RowStates", serIndex), rowStates);
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.Records", serIndex), storeList);
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.NullBits", serIndex), nullbitList);
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.RowErrors", serIndex), rowErrors);
+            info.AddValue(string.Format(formatProvider, "DataTable_{0}.ColumnErrors", serIndex), colErrors);
+        }
+
+        // Deserialize all the Rows.
+        internal void DeserializeTableData(SerializationInfo info, StreamingContext context, int serIndex)
+        {
+            bool enforceConstraintsOrg = _enforceConstraints;
+            bool inDataLoadOrg = _inDataLoad;
+
+            try
+            {
+                _enforceConstraints = false;
+                _inDataLoad = true;
+                IFormatProvider formatProvider = CultureInfo.InvariantCulture;
+                int rowCount = info.GetInt32(string.Format(formatProvider, "DataTable_{0}.Rows.Count", serIndex));
+                int recordCount = info.GetInt32(string.Format(formatProvider, "DataTable_{0}.Records.Count", serIndex));
+                BitArray rowStates = (BitArray)info.GetValue(string.Format(formatProvider, "DataTable_{0}.RowStates", serIndex), typeof(BitArray));
+                ArrayList storeList = (ArrayList)info.GetValue(string.Format(formatProvider, "DataTable_{0}.Records", serIndex), typeof(ArrayList));
+                ArrayList nullbitList = (ArrayList)info.GetValue(string.Format(formatProvider, "DataTable_{0}.NullBits", serIndex), typeof(ArrayList));
+                Hashtable rowErrors = (Hashtable)info.GetValue(string.Format(formatProvider, "DataTable_{0}.RowErrors", serIndex), typeof(Hashtable));
+                rowErrors.OnDeserialization(this);//OnDeSerialization must be called since the hashtable gets deserialized after the whole graph gets deserialized
+                Hashtable colErrors = (Hashtable)info.GetValue(string.Format(formatProvider, "DataTable_{0}.ColumnErrors", serIndex), typeof(Hashtable));
+                colErrors.OnDeserialization(this);//OnDeSerialization must be called since the hashtable gets deserialized after the whole graph gets deserialized
+
+                if (recordCount <= 0)
+                {
+                    //No need for deserialization of the storage and errors if there are no records.
+                    return;
+                }
+
+                //Point the record manager storage to the deserialized values.
+                for (int i = 0; i < Columns.Count; i++)
+                {
+                    Columns[i].SetStorage(storeList[i], (BitArray)nullbitList[i]);
+                }
+
+                //Create rows and set the records appropriately.
+                int recordIndex = 0;
+                DataRow[] rowArr = new DataRow[recordCount];
+                for (int i = 0; i < rowCount; i++)
+                {
+                    //Create a new row which sets old and new records to -1.
+                    DataRow row = NewEmptyRow();
+                    rowArr[recordIndex] = row;
+                    int bitIndex = i * 3;
+                    switch (ConvertToRowState(rowStates, bitIndex))
+                    {
+                        case DataRowState.Unchanged:
+                            row._oldRecord = recordIndex;
+                            row._newRecord = recordIndex;
+                            recordIndex += 1;
+                            break;
+                        case DataRowState.Added:
+                            row._oldRecord = -1;
+                            row._newRecord = recordIndex;
+                            recordIndex += 1;
+                            break;
+                        case DataRowState.Modified:
+                            row._oldRecord = recordIndex;
+                            row._newRecord = recordIndex + 1;
+                            rowArr[recordIndex + 1] = row;
+                            recordIndex += 2;
+                            break;
+                        case DataRowState.Deleted:
+                            row._oldRecord = recordIndex;
+                            row._newRecord = -1;
+                            recordIndex += 1;
+                            break;
+                    }
+                    if (rowStates[bitIndex + 2])
+                    {
+                        row._tempRecord = recordIndex;
+                        rowArr[recordIndex] = row;
+                        recordIndex += 1;
+                    }
+                    else
+                    {
+                        row._tempRecord = -1;
+                    }
+                    Rows.ArrayAdd(row);
+                    row.rowID = _nextRowID;
+                    _nextRowID++;
+                    ConvertToRowError(i, rowErrors, colErrors);
+                }
+                _recordManager.SetRowCache(rowArr);
+                ResetIndexes();
+            }
+            finally
+            {
+                _enforceConstraints = enforceConstraintsOrg;
+                _inDataLoad = inDataLoadOrg;
+            }
+        }
+
+        // Constructs the RowState from the two bits in the bitarray.
+        private DataRowState ConvertToRowState(BitArray bitStates, int bitIndex)
+        {
+            Debug.Assert(bitStates != null);
+            Debug.Assert(bitStates.Length > bitIndex);
+
+            bool b1 = bitStates[bitIndex];
+            bool b2 = bitStates[bitIndex + 1];
+
+            if (!b1 && !b2)
+            {
+                return DataRowState.Unchanged;
+            }
+            else if (!b1 && b2)
+            {
+                return DataRowState.Added;
+            }
+            else if (b1 && !b2)
+            {
+                return DataRowState.Modified;
+            }
+            else if (b1 && b2)
+            {
+                return DataRowState.Deleted;
+            }
+            else
+            {
+                throw ExceptionBuilder.InvalidRowBitPattern();
+            }
+        }
+
+        // Get the error on the row and columns - Marked internal so that DataSet deserializer can call into this
+        internal void GetRowAndColumnErrors(int rowIndex, Hashtable rowErrors, Hashtable colErrors)
+        {
+            Debug.Assert(Rows.Count > rowIndex);
+            Debug.Assert(rowErrors != null);
+            Debug.Assert(colErrors != null);
+
+            DataRow row = Rows[rowIndex];
+
+            if (row.HasErrors)
+            {
+                rowErrors.Add(rowIndex, row.RowError);
+                DataColumn[] dcArr = row.GetColumnsInError();
+                if (dcArr.Length > 0)
+                {
+                    int[] columnsInError = new int[dcArr.Length];
+                    string[] columnErrors = new string[dcArr.Length];
+                    for (int i = 0; i < dcArr.Length; i++)
+                    {
+                        columnsInError[i] = dcArr[i].Ordinal;
+                        columnErrors[i] = row.GetColumnError(dcArr[i]);
+                    }
+                    ArrayList list = new ArrayList();
+                    list.Add(columnsInError);
+                    list.Add(columnErrors);
+                    colErrors.Add(rowIndex, list);
+                }
+            }
+        }
+
+        // Set the row and columns in error..
+        private void ConvertToRowError(int rowIndex, Hashtable rowErrors, Hashtable colErrors)
+        {
+            Debug.Assert(Rows.Count > rowIndex);
+            Debug.Assert(rowErrors != null);
+            Debug.Assert(colErrors != null);
+
+            DataRow row = Rows[rowIndex];
+
+            if (rowErrors.ContainsKey(rowIndex))
+            {
+                row.RowError = (string)rowErrors[rowIndex];
+            }
+            if (colErrors.ContainsKey(rowIndex))
+            {
+                ArrayList list = (ArrayList)colErrors[rowIndex];
+                int[] columnsInError = (int[])list[0];
+                string[] columnErrors = (string[])list[1];
+                Debug.Assert(columnsInError.Length == columnErrors.Length);
+                for (int i = 0; i < columnsInError.Length; i++)
+                {
+                    row.SetColumnError(columnsInError[i], columnErrors[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether string comparisons within the table are case-sensitive.
+        /// </summary>
+        public bool CaseSensitive
+        {
+            get { return _caseSensitive; }
+            set
+            {
+                if (_caseSensitive != value)
+                {
+                    bool oldValue = _caseSensitive;
+                    bool oldUserSet = _caseSensitiveUserSet;
+                    _caseSensitive = value;
+                    _caseSensitiveUserSet = true;
+
+                    if (DataSet != null && !DataSet.ValidateCaseConstraint())
+                    {
+                        _caseSensitive = oldValue;
+                        _caseSensitiveUserSet = oldUserSet;
+                        throw ExceptionBuilder.CannotChangeCaseLocale();
+                    }
+                    SetCaseSensitiveValue(value, true, true);
+                }
+                _caseSensitiveUserSet = true;
+            }
+        }
+
+        internal bool AreIndexEventsSuspended => 0 < _suspendIndexEvents;
+
+        internal void RestoreIndexEvents(bool forceReset)
+        {
+            DataCommonEventSource.Log.Trace("<ds.DataTable.RestoreIndexEvents|Info> {0}, {1}", ObjectID, _suspendIndexEvents);
+            if (0 < _suspendIndexEvents)
+            {
+                _suspendIndexEvents--;
+                if (0 == _suspendIndexEvents)
+                {
+                    Exception first = null;
+                    SetShadowIndexes();
+                    try
+                    {
+                        // the length of shadowIndexes will not change
+                        // but the array instance may change during
+                        // events during Index.Reset
+                        int numIndexes = _shadowIndexes.Count;
+                        for (int i = 0; i < numIndexes; i++)
+                        {
+                            Index ndx = _shadowIndexes[i];// shadowindexes may change, see ShadowIndexCopy()
+                            try
+                            {
+                                if (forceReset || ndx.HasRemoteAggregate)
+                                {
+                                    ndx.Reset(); // resets & fires
+                                }
+                                else
+                                {
+                                    ndx.FireResetEvent(); // fire the Reset event we were firing
+                                }
+                            }
+                            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
+                            {
+                                ExceptionBuilder.TraceExceptionWithoutRethrow(e);
+                                if (null == first)
+                                {
+                                    first = e;
+                                }
+                            }
+                        }
+                        if (null != first)
+                        {
+                            throw first;
+                        }
+                    }
+                    finally
+                    {
+                        RestoreShadowIndexes();
+                    }
+                }
+            }
+        }
+
+        internal void SuspendIndexEvents()
+        {
+            DataCommonEventSource.Log.Trace("<ds.DataTable.SuspendIndexEvents|Info> {0}, {1}", ObjectID, _suspendIndexEvents);
+            _suspendIndexEvents++;
+        }
+
+        [Browsable(false)]
+        public bool IsInitialized => !fInitInProgress;
+
+        private bool IsTypedDataTable
+        {
+            get
+            {
+                switch (_isTypedDataTable)
+                {
+                    case 0:
+                        _isTypedDataTable = (byte)((GetType() != typeof(DataTable)) ? 1 : 2);
+                        return (1 == _isTypedDataTable);
+                    case 1:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        internal bool SetCaseSensitiveValue(bool isCaseSensitive, bool userSet, bool resetIndexes)
+        {
+            if (userSet || (!_caseSensitiveUserSet && (_caseSensitive != isCaseSensitive)))
+            {
+                _caseSensitive = isCaseSensitive;
+                if (isCaseSensitive)
+                {
+                    _compareFlags = CompareOptions.None;
+                }
+                else
+                {
+                    _compareFlags = CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth;
+                }
+                if (resetIndexes)
+                {
+                    ResetIndexes();
+                    foreach (Constraint constraint in Constraints)
+                    {
+                        constraint.CheckConstraint();
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+
+        private void ResetCaseSensitive()
+        {
+            // this method is used design-time scenarios via reflection
+            //   by the property grid context menu to show the Reset option or not
+            SetCaseSensitiveValue((null != _dataSet) && _dataSet.CaseSensitive, true, true);
+            _caseSensitiveUserSet = false;
+        }
+
+        internal bool ShouldSerializeCaseSensitive()
+        {
+            // this method is used design-time scenarios via reflection
+            //   by the property grid to show the CaseSensitive property in bold or not
+            //   by the code dom for persisting the CaseSensitive property or not
+            return _caseSensitiveUserSet;
+        }
+
+        internal bool SelfNested
+        {
+            get
+            {
+                // Is this correct? if ((top[i].nestedParentRelation!= null) && (top[i].nestedParentRelation.ParentTable == top[i]))
+                foreach (DataRelation rel in ParentRelations)
+                {
+                    if (rel.Nested && rel.ParentTable == this)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)] // don't have debugger view expand this
+        internal List<Index> LiveIndexes
+        {
+            get
+            {
+                if (!AreIndexEventsSuspended)
+                {
+                    for (int i = _indexes.Count - 1; 0 <= i; --i)
+                    {
+                        Index index = _indexes[i];
+                        if (index.RefCount <= 1)
+                        {
+                            index.RemoveRef();
+                        }
+                    }
+                }
+                return _indexes;
+            }
+        }
+
+        [DefaultValue(SerializationFormat.Xml)]
+        public SerializationFormat RemotingFormat
+        {
+            get { return _remotingFormat; }
+            set
+            {
+                if (value != SerializationFormat.Binary && value != SerializationFormat.Xml)
+                {
+                    throw ExceptionBuilder.InvalidRemotingFormat(value);
+                }
+                // table can not have different format than its dataset, unless it is stand alone datatable
+                if (DataSet != null && value != DataSet.RemotingFormat)
+                {
+                    throw ExceptionBuilder.CanNotSetRemotingFormat();
+                }
+                _remotingFormat = value;
+            }
+        }
+
+        // used to keep temporary state of unique Key posiotion to be added for inference only
+        internal int UKColumnPositionForInference
+        {
+            get { return _ukColumnPositionForInference; }
+            set { _ukColumnPositionForInference = value; }
+        }
+
+        /// <summary>
+        /// Gets the collection of child relations for this <see cref='System.Data.DataTable'/>.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public DataRelationCollection ChildRelations =>
+            _childRelationsCollection ?? (_childRelationsCollection = new DataRelationCollection.DataTableRelationCollection(this, false));
+
+        /// <summary>
+        /// Gets the collection of columns that belong to this table.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public DataColumnCollection Columns => _columnCollection;
+
+        private void ResetColumns()
+        {
+            // this method is used design-time scenarios via reflection
+            //   by the property grid context menu to show the Reset option or not
+            Columns.Clear();
+        }
+
+        private CompareInfo CompareInfo => _compareInfo ?? (_compareInfo = Locale.CompareInfo);
+
+        /// <summary>
+        /// Gets the collection of constraints maintained by this table.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public ConstraintCollection Constraints => _constraintCollection;
+
+        /// <summary>
+        /// Resets the <see cref='System.Data.DataTable.Constraints'/> property to its default state.
+        /// </summary>
+        private void ResetConstraints() => Constraints.Clear();
+
+        /// <summary>
+        /// Gets the <see cref='System.Data.DataSet'/> that this table belongs to.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden), Browsable(false)]
+        public DataSet DataSet => _dataSet;
+
+        /// <summary>
+        /// Internal method for setting the DataSet pointer.
+        /// </summary>
+        internal void SetDataSet(DataSet dataSet)
+        {
+            if (_dataSet != dataSet)
+            {
+                _dataSet = dataSet;
+
+                // Inform all the columns of the dataset being set.
+                DataColumnCollection cols = Columns;
+                for (int i = 0; i < cols.Count; i++)
+                {
+                    cols[i].OnSetDataSet();
+                }
+
+                if (DataSet != null)
+                {
+                    _defaultView = null;
+                }
+                //Set the remoting format variable directly
+                if (dataSet != null)
+                {
+                    _remotingFormat = dataSet.RemotingFormat;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a customized view of the table which may include a
+        /// filtered view, or a cursor position.
+        /// </summary>
+        [Browsable(false)]
+        public DataView DefaultView
+        {
+            get
+            {
+                DataView view = _defaultView;
+                if (null == view)
+                {
+                    if (null != _dataSet)
+                    {
+                        view = _dataSet.DefaultViewManager.CreateDataView(this);
+                    }
+                    else
+                    {
+                        view = new DataView(this, true);
+                        view.SetIndex2("", DataViewRowState.CurrentRows, null, true);
+                    }
+
+                    // avoid HostProtectionAttribute(Synchronization=true) by not calling virtual methods from inside a lock
+                    view = Interlocked.CompareExchange<DataView>(ref _defaultView, view, null);
+                    if (null == view)
+                    {
+                        view = _defaultView;
+                    }
+                }
+                return view;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the expression that will return a value used to represent
+        /// this table in UI.
+        /// </summary>
+        [DefaultValue("")]
+        public string DisplayExpression
+        {
+            get { return DisplayExpressionInternal; }
+            set
+            {
+                _displayExpression = !string.IsNullOrEmpty(value) ?
+                    new DataExpression(this, value) :
+                    null;
+            }
+        }
+        internal string DisplayExpressionInternal => _displayExpression != null ? _displayExpression.Expression : string.Empty;
+
+        internal bool EnforceConstraints
+        {
+            get
+            {
+                if (SuspendEnforceConstraints)
+                {
+                    return false;
+                }
+                if (_dataSet != null)
+                {
+                    return _dataSet.EnforceConstraints;
+                }
+
+                return _enforceConstraints;
+            }
+            set
+            {
+                if (_dataSet == null && _enforceConstraints != value)
+                {
+                    if (value)
+                    {
+                        EnableConstraints();
+                    }
+
+                    _enforceConstraints = value;
+                }
+            }
+        }
+
+        internal bool SuspendEnforceConstraints
+        {
+            get { return _suspendEnforceConstraints; }
+            set { _suspendEnforceConstraints = value; }
+        }
+
+        internal void EnableConstraints()
+        {
+            bool errors = false;
+            foreach (Constraint constr in Constraints)
+            {
+                if (constr is UniqueConstraint)
+                {
+                    errors |= constr.IsConstraintViolated();
+                }
+            }
+
+            foreach (DataColumn column in Columns)
+            {
+                if (!column.AllowDBNull)
+                {
+                    errors |= column.IsNotAllowDBNullViolated();
+                }
+                if (column.MaxLength >= 0)
+                {
+                    errors |= column.IsMaxLengthViolated();
+                }
+            }
+
+            if (errors)
+            {
+                EnforceConstraints = false;
+                throw ExceptionBuilder.EnforceConstraint();
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection of customized user information.
+        /// </summary>
+        [Browsable(false)]
+        public PropertyCollection ExtendedProperties => _extendedProperties ?? (_extendedProperties = new PropertyCollection());
+
+        internal IFormatProvider FormatProvider
+        {
+            get
+            {
+                // used for Formating/Parsing
+                // http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpref/html/frlrfsystemglobalizationcultureinfoclassisneutralculturetopic.asp
+                if (null == _formatProvider)
+                {
+                    CultureInfo culture = Locale;
+                    if (culture.IsNeutralCulture)
+                    {
+                        culture = CultureInfo.InvariantCulture;
+                    }
+                    _formatProvider = culture;
+                }
+                return _formatProvider;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether there are errors in any of the rows in any of
+        /// the tables of the <see cref='System.Data.DataSet'/> to which the table belongs.
+        /// </summary>
+        [Browsable(false)]
+        public bool HasErrors
+        {
+            get
+            {
+                for (int i = 0; i < Rows.Count; i++)
+                {
+                    if (Rows[i].HasErrors)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the locale information used to compare strings within the table.
+        /// Also used for locale sensitive, case,kana,width insensitive column name lookups
+        /// Also used for converting values to and from string
+        /// </summary>
+        public CultureInfo Locale
+        {
+            get
+            {
+                // used for Comparing not Formatting/Parsing
+                Debug.Assert(null != _culture, "null culture");
+                return _culture;
+            }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.set_Locale|API> {0}", ObjectID);
+                try
+                {
+                    bool userSet = true;
+                    if (null == value)
+                    {
+                        // reset Locale to inherit from DataSet
+                        userSet = false;
+                        value = (null != _dataSet) ? _dataSet.Locale : _culture;
+                    }
+                    if (_culture != value && !_culture.Equals(value))
+                    {
+                        bool flag = false;
+                        bool exceptionThrown = false;
+                        CultureInfo oldLocale = _culture;
+                        bool oldUserSet = _cultureUserSet;
+                        try
+                        {
+                            _cultureUserSet = true;
+                            SetLocaleValue(value, true, false);
+                            if ((null == DataSet) || DataSet.ValidateLocaleConstraint())
+                            {
+                                flag = false;
+                                SetLocaleValue(value, true, true);
+                                flag = true;
+                            }
+                        }
+                        catch
+                        {
+                            exceptionThrown = true;
+                            throw;
+                        }
+                        finally
+                        {
+                            if (!flag)
+                            {
+                                // reset old locale if ValidationFailed or exception thrown
+                                try
+                                {
+                                    SetLocaleValue(oldLocale, true, true);
+                                }
+                                catch (Exception e) when (ADP.IsCatchableExceptionType(e))
+                                {
+                                    // failed to reset all indexes for all constraints
+                                    ADP.TraceExceptionWithoutRethrow(e);
+                                }
+                                _cultureUserSet = oldUserSet;
+                                if (!exceptionThrown)
+                                {
+                                    throw ExceptionBuilder.CannotChangeCaseLocale(null);
+                                }
+                            }
+                        }
+                        SetLocaleValue(value, true, true);
+                    }
+                    _cultureUserSet = userSet;
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+        internal bool SetLocaleValue(CultureInfo culture, bool userSet, bool resetIndexes)
+        {
+            Debug.Assert(null != culture, "SetLocaleValue: no locale");
+            if (userSet || resetIndexes || (!_cultureUserSet && !_culture.Equals(culture)))
+            {
+                _culture = culture;
+                _compareInfo = null;
+                _formatProvider = null;
+                _hashCodeProvider = null;
+
+                foreach (DataColumn column in Columns)
+                {
+                    column._hashCode = GetSpecialHashCode(column.ColumnName);
+                }
+                if (resetIndexes)
+                {
+                    ResetIndexes();
+                    foreach (Constraint constraint in Constraints)
+                    {
+                        constraint.CheckConstraint();
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        internal bool ShouldSerializeLocale()
+        {
+            // this method is used design-time scenarios via reflection
+            //   by the property grid to show the Locale property in bold or not
+            //   by the code dom for persisting the Locale property or not
+
+            // we always want the locale persisted if set by user or different the current thread if standalone table
+            // but that logic should by performed by the serializion code
+            return _cultureUserSet;
+        }
+
+        /// <summary>
+        /// Gets or sets the initial starting size for this table.
+        /// </summary>
+        [DefaultValue(50)]
+        public int MinimumCapacity
+        {
+            get { return _recordManager.MinimumCapacity; }
+            set
+            {
+                if (value != _recordManager.MinimumCapacity)
+                {
+                    _recordManager.MinimumCapacity = value;
+                }
+            }
+        }
+
+        internal int RecordCapacity => _recordManager.RecordCapacity;
+
+        internal int ElementColumnCount
+        {
+            get { return _elementColumnCount; }
+            set
+            {
+                if ((value > 0) && (_xmlText != null))
+                {
+                    throw ExceptionBuilder.TableCannotAddToSimpleContent();
+                }
+                else
+                {
+                    _elementColumnCount = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection of parent relations for this <see cref='System.Data.DataTable'/>.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public DataRelationCollection ParentRelations => _parentRelationsCollection ??
+            (_parentRelationsCollection = new DataRelationCollection.DataTableRelationCollection(this, true));
+
+        internal bool MergingData
+        {
+            get { return _mergingData; }
+            set { _mergingData = value; }
+        }
+
+        internal DataRelation[] NestedParentRelations
+        {
+            get
+            {
+#if DEBUG
+                DataRelation[] nRel = FindNestedParentRelations();
+                Debug.Assert(nRel.Length == _nestedParentRelations.Length, "nestedParent cache is broken");
+                for (int i = 0; i < nRel.Length; i++)
+                {
+                    Debug.Assert(null != nRel[i], "null relation");
+                    Debug.Assert(null != _nestedParentRelations[i], "null relation");
+                    Debug.Assert(nRel[i] == _nestedParentRelations[i], "unequal relations");
+                }
+#endif
+                return _nestedParentRelations;
+            }
+        }
+
+        internal bool SchemaLoading => _schemaLoading;
+
+        internal void CacheNestedParent()
+        {
+            _nestedParentRelations = FindNestedParentRelations();
+        }
+
+        private DataRelation[] FindNestedParentRelations()
+        {
+            List<DataRelation> nestedParents = null;
+            foreach (DataRelation relation in ParentRelations)
+            {
+                if (relation.Nested)
+                {
+                    if (null == nestedParents)
+                    {
+                        nestedParents = new List<DataRelation>();
+                    }
+                    nestedParents.Add(relation);
+                }
+            }
+
+            return (null == nestedParents) || (nestedParents.Count == 0) ?
+                Array.Empty<DataRelation>() :
+                nestedParents.ToArray();
+        }
+
+        internal int NestedParentsCount
+        {
+            get
+            {
+                int count = 0;
+                foreach (DataRelation relation in ParentRelations)
+                {
+                    if (relation.Nested)
+                    {
+                        count++;
+                    }
+                }
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets an array of columns that function as primary keys for the data table.
+        /// </summary>
+        [TypeConverter(typeof(PrimaryKeyTypeConverter))]
+        public DataColumn[] PrimaryKey
+        {
+            get
+            {
+                UniqueConstraint primayKeyConstraint = _primaryKey;
+                if (null != primayKeyConstraint)
+                {
+                    Debug.Assert(2 <= _primaryKey.ConstraintIndex.RefCount, "bad primaryKey index RefCount");
+                    return primayKeyConstraint.Key.ToArray();
+                }
+                return Array.Empty<DataColumn>();
+            }
+            set
+            {
+                UniqueConstraint key = null;
+                UniqueConstraint existingKey = null;
+
+                // Loading with persisted property
+                if (fInitInProgress && value != null)
+                {
+                    _delayedSetPrimaryKey = value;
+                    return;
+                }
+
+                if ((value != null) && (value.Length != 0))
+                {
+                    int count = 0;
+                    for (int i = 0; i < value.Length; i++)
+                    {
+                        if (value[i] != null)
+                        {
+                            count++;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    if (count != 0)
+                    {
+                        DataColumn[] newValue = value;
+                        if (count != value.Length)
+                        {
+                            newValue = new DataColumn[count];
+                            for (int i = 0; i < count; i++)
+                            {
+                                newValue[i] = value[i];
+                            }
+                        }
+                        key = new UniqueConstraint(newValue);
+                        if (key.Table != this)
+                            throw ExceptionBuilder.TableForeignPrimaryKey();
+                    }
+                }
+
+                if (key == _primaryKey || (key != null && key.Equals(_primaryKey)))
+                {
+                    return;
+                }
+
+                // Use an existing UniqueConstraint that matches if one exists
+                if ((existingKey = (UniqueConstraint)Constraints.FindConstraint(key)) != null)
+                {
+                    key.ColumnsReference.CopyTo(existingKey.Key.ColumnsReference, 0);
+                    key = existingKey;
+                }
+
+                UniqueConstraint oldKey = _primaryKey;
+                _primaryKey = null;
+                if (oldKey != null)
+                {
+                    oldKey.ConstraintIndex.RemoveRef();
+
+                    // if PrimaryKey is removed, reset LoadDataRow indexes
+                    if (null != _loadIndex)
+                    {
+                        _loadIndex.RemoveRef();
+                        _loadIndex = null;
+                    }
+                    if (null != _loadIndexwithOriginalAdded)
+                    {
+                        _loadIndexwithOriginalAdded.RemoveRef();
+                        _loadIndexwithOriginalAdded = null;
+                    }
+                    if (null != _loadIndexwithCurrentDeleted)
+                    {
+                        _loadIndexwithCurrentDeleted.RemoveRef();
+                        _loadIndexwithCurrentDeleted = null;
+                    }
+                    Constraints.Remove(oldKey);
+                }
+
+                // Add the key if there isnt an existing matching key in collection
+                if (key != null && existingKey == null)
+                {
+                    Constraints.Add(key);
+                }
+
+                _primaryKey = key;
+
+                Debug.Assert(Constraints.FindConstraint(_primaryKey) == _primaryKey, "PrimaryKey is not in ConstraintCollection");
+                _primaryIndex = (key != null) ? key.Key.GetIndexDesc() : Array.Empty<IndexField>();
+
+                if (_primaryKey != null)
+                {
+                    // must set index for DataView.Sort before setting AllowDBNull which can fail
+                    key.ConstraintIndex.AddRef();
+
+                    for (int i = 0; i < key.ColumnsReference.Length; i++)
+                    {
+                        key.ColumnsReference[i].AllowDBNull = false;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the <see cref='System.Data.DataTable.PrimaryKey'/> property should be persisted.
+        /// </summary>
+        private bool ShouldSerializePrimaryKey() => _primaryKey != null;
+
+        /// <summary>
+        /// Resets the <see cref='System.Data.DataTable.PrimaryKey'/> property to its default state.
+        /// </summary>
+        private void ResetPrimaryKey()
+        {
+            PrimaryKey = null;
+        }
+
+        /// <summary>
+        /// Gets the collection of rows that belong to this table.
+        /// </summary>
+        [Browsable(false)]
+        public DataRowCollection Rows => _rowCollection;
+
+        /// <summary>
+        /// Gets or sets the name of the table.
+        /// </summary>
+        [RefreshProperties(RefreshProperties.All)]
+        [DefaultValue("")]
+        public string TableName
+        {
+            get { return _tableName; }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.set_TableName|API> {0}, value='{1}'", ObjectID, value);
+                try
+                {
+                    if (value == null)
+                    {
+                        value = string.Empty;
+                    }
+                    CultureInfo currentLocale = Locale;
+                    if (string.Compare(_tableName, value, true, currentLocale) != 0)
+                    {
+                        if (_dataSet != null)
+                        {
+                            if (value.Length == 0)
+                            {
+                                throw ExceptionBuilder.NoTableName();
+                            }
+                            if ((0 == string.Compare(value, _dataSet.DataSetName, true, _dataSet.Locale)) && !_fNestedInDataset)
+                            {
+                                throw ExceptionBuilder.DatasetConflictingName(_dataSet.DataSetName);
+                            }
+
+                            DataRelation[] nestedRelations = NestedParentRelations;
+                            if (nestedRelations.Length == 0)
+                            {
+                                _dataSet.Tables.RegisterName(value, Namespace);
+                            }
+                            else
+                            {
+                                foreach (DataRelation rel in nestedRelations)
+                                {
+                                    if (!rel.ParentTable.Columns.CanRegisterName(value))
+                                    {
+                                        throw ExceptionBuilder.CannotAddDuplicate2(value);
+                                    }
+                                }
+                                // if it cannot register the following line will throw exception
+                                _dataSet.Tables.RegisterName(value, Namespace);
+
+                                foreach (DataRelation rel in nestedRelations)
+                                {
+                                    rel.ParentTable.Columns.RegisterColumnName(value, null);
+                                    rel.ParentTable.Columns.UnregisterName(TableName);
+                                }
+                            }
+
+                            if (_tableName.Length != 0)
+                            {
+                                _dataSet.Tables.UnregisterName(_tableName);
+                            }
+                        }
+                        RaisePropertyChanging(nameof(TableName));
+                        _tableName = value;
+                        _encodedTableName = null;
+                    }
+                    else if (string.Compare(_tableName, value, false, currentLocale) != 0)
+                    {
+                        RaisePropertyChanging(nameof(TableName));
+                        _tableName = value;
+                        _encodedTableName = null;
+                    }
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+
+
+        internal string EncodedTableName
+        {
+            get
+            {
+                string encodedTblName = _encodedTableName;
+                if (null == encodedTblName)
+                {
+                    encodedTblName = XmlConvert.EncodeLocalName(TableName);
+                    _encodedTableName = encodedTblName;
+                }
+                return encodedTblName;
+            }
+        }
+        private string GetInheritedNamespace(List<DataTable> visitedTables)
+        {
+            // if there is nested relation: ie: this table is nested child of another table and
+            // if it is not self nested, return parent tables NS: Meanwhile make sure
+            DataRelation[] nestedRelations = NestedParentRelations;
+            if (nestedRelations.Length > 0)
+            {
+                for (int i = 0; i < nestedRelations.Length; i++)
+                {
+                    DataRelation rel = nestedRelations[i];
+                    if (rel.ParentTable._tableNamespace != null)
+                    {
+                        return rel.ParentTable._tableNamespace; // if parent table has a non-null NS, return it
+                    }
+                }
+                // Assumption, in hierarchy of multiple nested relation, a child table with no NS, has DataRelation
+                // only and only with parent DataTable witin the same namespace
+                int j = 0;
+                while (j < nestedRelations.Length && ((nestedRelations[j].ParentTable == this) || (visitedTables.Contains(nestedRelations[j].ParentTable))))
+                {
+                    j++;
+                }
+                if (j < nestedRelations.Length)
+                {
+                    DataTable parentTable = nestedRelations[j].ParentTable;
+                    if (!visitedTables.Contains(parentTable))
+                        visitedTables.Add(parentTable);
+                    return parentTable.GetInheritedNamespace(visitedTables);// this is the same as return parentTable.Namespace
+                }
+            } // dont put else
+
+            if (DataSet != null)
+            {
+                // if it cant return from parent tables, return NS from dataset, if exists
+                return DataSet.Namespace;
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the namespace for the <see cref='System.Data.DataTable'/>.
+        /// </summary>
+        public string Namespace
+        {
+            get { return _tableNamespace ?? GetInheritedNamespace(new List<DataTable>()); }
+            set
+            {
+                long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.set_Namespace|API> {0}, value='{1}'", ObjectID, value);
+                try
+                {
+                    if (value != _tableNamespace)
+                    {
+                        if (_dataSet != null)
+                        {
+                            string realNamespace = (value == null ? GetInheritedNamespace(new List<DataTable>()) : value);
+                            if (realNamespace != Namespace)
+                            {
+                                // do this extra check only if the namespace is really going to change
+                                // inheritance-wise.
+                                if (_dataSet.Tables.Contains(TableName, realNamespace, true, true))
+                                    throw ExceptionBuilder.DuplicateTableName2(TableName, realNamespace);
+
+                                CheckCascadingNamespaceConflict(realNamespace);
+                            }
+                        }
+                        CheckNamespaceValidityForNestedRelations(value);
+                        DoRaiseNamespaceChange();
+                    }
+                    _tableNamespace = value;
+                }
+                finally
+                {
+                    DataCommonEventSource.Log.ExitScope(logScopeId);
+                }
+            }
+        }
+        internal bool IsNamespaceInherited() => null == _tableNamespace;
+
+        internal void CheckCascadingNamespaceConflict(string realNamespace)
+        {
+            foreach (DataRelation rel in ChildRelations)
+            {
+                if ((rel.Nested) && (rel.ChildTable != this) && (rel.ChildTable._tableNamespace == null))
+                {
+                    DataTable childTable = rel.ChildTable;
+                    if (_dataSet.Tables.Contains(childTable.TableName, realNamespace, false, true))
+                        throw ExceptionBuilder.DuplicateTableName2(TableName, realNamespace);
+
+                    childTable.CheckCascadingNamespaceConflict(realNamespace);
+                }
+            }
+        }
+
+        internal void CheckNamespaceValidityForNestedRelations(string realNamespace)
+        {
+            foreach (DataRelation rel in ChildRelations)
+            {
+                if (rel.Nested)
+                {
+                    if (realNamespace != null)
+                    {
+                        rel.ChildTable.CheckNamespaceValidityForNestedParentRelations(realNamespace, this);
+                    }
+                    else
+                    {
+                        rel.ChildTable.CheckNamespaceValidityForNestedParentRelations(GetInheritedNamespace(new List<DataTable>()), this);
+                    }
+                }
+            }
+
+            if (realNamespace == null)
+            {
+                // this will affect this table if it has parent relations
+                CheckNamespaceValidityForNestedParentRelations(GetInheritedNamespace(new List<DataTable>()), this);
+            }
+        }
+        internal void CheckNamespaceValidityForNestedParentRelations(string ns, DataTable parentTable)
+        {
+            foreach (DataRelation rel in ParentRelations)
+            {
+                if (rel.Nested)
+                {
+                    if (rel.ParentTable != parentTable && rel.ParentTable.Namespace != ns)
+                    {
+                        throw ExceptionBuilder.InValidNestedRelation(TableName);
+                    }
+                }
+            }
+        }
+
+        internal void DoRaiseNamespaceChange()
+        {
+            RaisePropertyChanging(nameof(Namespace));
+            // raise column Namespace change
+
+            foreach (DataColumn col in Columns)
+            {
+                if (col._columnUri == null)
+                {
+                    col.RaisePropertyChanging(nameof(Namespace));
+                }
+            }
+
+            foreach (DataRelation rel in ChildRelations)
+            {
+                if ((rel.Nested) && (rel.ChildTable != this))
+                {
+                    DataTable childTable = rel.ChildTable;
+
+                    rel.ChildTable.DoRaiseNamespaceChange();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the <see cref='System.Data.DataTable.Namespace'/> property should be persisted.
+        /// </summary>
+        private bool ShouldSerializeNamespace() => _tableNamespace != null;
+
+        /// <summary>
+        /// Resets the <see cref='System.Data.DataTable.Namespace'/> property to its default state.
+        /// </summary>
+        private void ResetNamespace()
+        {
+            Namespace = null;
+        }
+
+        public virtual void BeginInit()
+        {
+            fInitInProgress = true;
+        }
+
+        public virtual void EndInit()
+        {
+            if (_dataSet == null || !_dataSet._fInitInProgress)
+            {
+                Columns.FinishInitCollection();
+                Constraints.FinishInitConstraints();
+                foreach (DataColumn dc in Columns)
+                {
+                    if (dc.Computed)
+                    {
+                        dc.Expression = dc.Expression;
+                    }
+                }
+            }
+
+            fInitInProgress = false; // It is must that we set off this flag after calling FinishInitxxx();
+            if (_delayedSetPrimaryKey != null)
+            {
+                PrimaryKey = _delayedSetPrimaryKey;
+                _delayedSetPrimaryKey = null;
+            }
+
+            if (_delayedViews.Count > 0)
+            {
+                foreach (DataView dv in _delayedViews)
+                {
+                    dv.EndInit();
+                }
+                _delayedViews.Clear();
+            }
+
+            OnInitialized();
+        }
+
+        [DefaultValue("")]
+        public string Prefix
+        {
+            get { return _tablePrefix; }
+            set
+            {
+                if (value == null)
+                {
+                    value = string.Empty;
+                }
+                DataCommonEventSource.Log.Trace("<ds.DataTable.set_Prefix|API> {0}, value='{1}'", ObjectID, value);
+                if ((XmlConvert.DecodeName(value) == value) && (XmlConvert.EncodeName(value) != value))
+                {
+                    throw ExceptionBuilder.InvalidPrefix(value);
+                }
+
+                _tablePrefix = value;
+            }
+        }
+
+        internal DataColumn XmlText
+        {
+            get { return _xmlText; }
+            set
+            {
+                if (_xmlText != value)
+                {
+                    if (_xmlText != null)
+                    {
+                        if (value != null)
+                        {
+                            throw ExceptionBuilder.MultipleTextOnlyColumns();
+                        }
+                        Columns.Remove(_xmlText);
+                    }
+                    else
+                    {
+                        Debug.Assert(value != null, "Value shoud not be null ??");
+                        Debug.Assert(value.ColumnMapping == MappingType.SimpleContent, "should be text node here");
+                        if (value != Columns[value.ColumnName])
+                        {
+                            Columns.Add(value);
+                        }
+                    }
+                    _xmlText = value;
+                }
+            }
+        }
+
+        internal decimal MaxOccurs
+        {
+            get { return _maxOccurs; }
+            set { _maxOccurs = value; }
+        }
+
+        internal decimal MinOccurs
+        {
+            get { return _minOccurs; }
+            set { _minOccurs = value; }
+        }
+
+        internal void SetKeyValues(DataKey key, object[] keyValues, int record)
+        {
+            for (int i = 0; i < keyValues.Length; i++)
+            {
+                key.ColumnsReference[i][record] = keyValues[i];
+            }
+        }
+
+        internal DataRow FindByIndex(Index ndx, object[] key)
+        {
+            Range range = ndx.FindRecords(key);
+            return range.IsNull ? null : _recordManager[ndx.GetRecord(range.Min)];
+        }
+
+        internal DataRow FindMergeTarget(DataRow row, DataKey key, Index ndx)
+        {
+            DataRow targetRow = null;
+
+            // Primary key match
+            if (key.HasValue)
+            {
+                Debug.Assert(ndx != null);
+                int findRecord = (row._oldRecord == -1) ? row._newRecord : row._oldRecord;
+                object[] values = key.GetKeyValues(findRecord);
+                targetRow = FindByIndex(ndx, values);
+            }
+            return targetRow;
+        }
+
+        private void SetMergeRecords(DataRow row, int newRecord, int oldRecord, DataRowAction action)
+        {
+            if (newRecord != -1)
+            {
+                SetNewRecord(row, newRecord, action, true, true);
+                SetOldRecord(row, oldRecord);
+            }
+            else
+            {
+                SetOldRecord(row, oldRecord);
+                if (row._newRecord != -1)
+                {
+                    Debug.Assert(action == DataRowAction.Delete, "Unexpected SetNewRecord action in merge function.");
+                    SetNewRecord(row, newRecord, action, true, true);
+                }
+            }
+        }
+
+        internal DataRow MergeRow(DataRow row, DataRow targetRow, bool preserveChanges, Index idxSearch)
+        {
+            if (targetRow == null)
+            {
+                targetRow = NewEmptyRow();
+                targetRow._oldRecord = _recordManager.ImportRecord(row.Table, row._oldRecord);
+                targetRow._newRecord = targetRow._oldRecord;
+                if (row._oldRecord != row._newRecord)
+                {
+                    targetRow._newRecord = _recordManager.ImportRecord(row.Table, row._newRecord);
+                }
+                InsertRow(targetRow, -1);
+            }
+            else
+            {
+                // Record Manager corruption during Merge when target row in edit state
+                // the newRecord would be freed and overwrite tempRecord (which became the newRecord)
+                // this would leave the DataRow referencing a freed record and leaking memory for the now lost record
+                int proposedRecord = targetRow._tempRecord; // by saving off the tempRecord, EndEdit won't free newRecord
+                targetRow._tempRecord = -1;
+                try
+                {
+                    DataRowState saveRowState = targetRow.RowState;
+                    int saveIdxRecord = (saveRowState == DataRowState.Added) ? targetRow._newRecord : saveIdxRecord = targetRow._oldRecord;
+                    int newRecord;
+                    int oldRecord;
+                    if (targetRow.RowState == DataRowState.Unchanged && row.RowState == DataRowState.Unchanged)
+                    {
+                        // unchanged row merging with unchanged row
+                        oldRecord = targetRow._oldRecord;
+                        newRecord = (preserveChanges) ? _recordManager.CopyRecord(this, oldRecord, -1) : targetRow._newRecord;
+                        oldRecord = _recordManager.CopyRecord(row.Table, row._oldRecord, targetRow._oldRecord);
+                        SetMergeRecords(targetRow, newRecord, oldRecord, DataRowAction.Change);
+                    }
+                    else if (row._newRecord == -1)
+                    {
+                        // Incoming row is deleted
+                        oldRecord = targetRow._oldRecord;
+                        if (preserveChanges)
+                        {
+                            newRecord = (targetRow.RowState == DataRowState.Unchanged) ? _recordManager.CopyRecord(this, oldRecord, -1) : targetRow._newRecord;
+                        }
+                        else
+                            newRecord = -1;
+                        oldRecord = _recordManager.CopyRecord(row.Table, row._oldRecord, oldRecord);
+
+                        // Change index record, need to update index
+                        if (saveIdxRecord != ((saveRowState == DataRowState.Added) ? newRecord : oldRecord))
+                        {
+                            SetMergeRecords(targetRow, newRecord, oldRecord, (newRecord == -1) ? DataRowAction.Delete : DataRowAction.Change);
+                            idxSearch.Reset();
+                            saveIdxRecord = ((saveRowState == DataRowState.Added) ? newRecord : oldRecord);
+                        }
+                        else
+                        {
+                            SetMergeRecords(targetRow, newRecord, oldRecord, (newRecord == -1) ? DataRowAction.Delete : DataRowAction.Change);
+                        }
+                    }
+                    else
+                    {
+                        // incoming row is added, modified or unchanged (targetRow is not unchanged)
+                        oldRecord = targetRow._oldRecord;
+                        newRecord = targetRow._newRecord;
+                        if (targetRow.RowState == DataRowState.Unchanged)
+                        {
+                            newRecord = _recordManager.CopyRecord(this, oldRecord, -1);
+                        }
+                        oldRecord = _recordManager.CopyRecord(row.Table, row._oldRecord, oldRecord);
+
+                        if (!preserveChanges)
+                        {
+                            newRecord = _recordManager.CopyRecord(row.Table, row._newRecord, newRecord);
+                        }
+                        SetMergeRecords(targetRow, newRecord, oldRecord, DataRowAction.Change);
+                    }
+
+                    if (saveRowState == DataRowState.Added && targetRow._oldRecord != -1)
+                    {
+                        idxSearch.Reset();
+                    }
+
+                    Debug.Assert(saveIdxRecord == ((saveRowState == DataRowState.Added) ? targetRow._newRecord : targetRow._oldRecord), "oops, you change index record without noticing it");
+                }
+                finally
+                {
+                    targetRow._tempRecord = proposedRecord;
+                }
+            }
+
+            // Merge all errors
+            if (row.HasErrors)
+            {
+                if (targetRow.RowError.Length == 0)
+                {
+                    targetRow.RowError = row.RowError;
+                }
+                else
+                {
+                    targetRow.RowError += " ]:[ " + row.RowError;
+                }
+                DataColumn[] cols = row.GetColumnsInError();
+
+                for (int i = 0; i < cols.Length; i++)
+                {
+                    DataColumn col = targetRow.Table.Columns[cols[i].ColumnName];
+                    targetRow.SetColumnError(col, row.GetColumnError(cols[i]));
+                }
+            }
+            else
+            {
+                if (!preserveChanges)
+                {
+                    targetRow.ClearErrors();
+                }
+            }
+
+            return targetRow;
+        }
+
+        /// <summary>
+        /// Commits all the changes made to this table since the last time <see cref='System.Data.DataTable.AcceptChanges'/> was called.
+        /// </summary>
+        public void AcceptChanges()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.AcceptChanges|API> {0}", ObjectID);
+            try
+            {
+                DataRow[] oldRows = new DataRow[Rows.Count];
+                Rows.CopyTo(oldRows, 0);
+
+                // delay updating of indexes until after all
+                // AcceptChange calls have been completed
+                SuspendIndexEvents();
+                try
+                {
+                    for (int i = 0; i < oldRows.Length; ++i)
+                    {
+                        if (oldRows[i].rowID != -1)
+                        {
+                            oldRows[i].AcceptChanges();
+                        }
+                    }
+                }
+                finally
+                {
+                    RestoreIndexEvents(false);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        // Prevent inlining so that reflection calls are not moved to caller that may be in a different assembly that may have a different grant set.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        protected virtual DataTable CreateInstance() => (DataTable)Activator.CreateInstance(GetType(), true);
+
+        public virtual DataTable Clone() => Clone(null);
+
+        internal DataTable Clone(DataSet cloneDS)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.Clone|INFO> {0}, cloneDS={1}", ObjectID, (cloneDS != null) ? cloneDS.ObjectID : 0);
+            try
+            {
+                DataTable clone = CreateInstance();
+                if (clone.Columns.Count > 0) // To clean up all the schema in strong typed dataset.
+                {
+                    clone.Reset();
+                }
+                return CloneTo(clone, cloneDS, false);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+
+        private DataTable IncrementalCloneTo(DataTable sourceTable, DataTable targetTable)
+        {
+            foreach (DataColumn dc in sourceTable.Columns)
+            {
+                if (targetTable.Columns[dc.ColumnName] == null)
+                {
+                    targetTable.Columns.Add(dc.Clone());
+                }
+            }
+
+            return targetTable;
+        }
+
+        private DataTable CloneHierarchy(DataTable sourceTable, DataSet ds, Hashtable visitedMap)
+        {
+            if (visitedMap == null)
+            {
+                visitedMap = new Hashtable();
+            }
+            if (visitedMap.Contains(sourceTable))
+            {
+                return ((DataTable)visitedMap[sourceTable]);
+            }
+
+            DataTable destinationTable = ds.Tables[sourceTable.TableName, sourceTable.Namespace];
+
+            if ((destinationTable != null && destinationTable.Columns.Count > 0))
+            {
+                destinationTable = IncrementalCloneTo(sourceTable, destinationTable);
+                // get extra columns from source into destination , increamental read
+            }
+            else
+            {
+                if (destinationTable == null)
+                {
+                    destinationTable = new DataTable();
+                    // fxcop: new DataTable values for CaseSensitive, Locale, Namespace will come from CloneTo
+                    ds.Tables.Add(destinationTable);
+                }
+                destinationTable = sourceTable.CloneTo(destinationTable, ds, true);
+            }
+            visitedMap[sourceTable] = destinationTable;
+
+            // start cloning relation
+            foreach (DataRelation r in sourceTable.ChildRelations)
+            {
+                DataTable childTable = CloneHierarchy(r.ChildTable, ds, visitedMap);
+            }
+
+            return destinationTable;
+        }
+
+        private DataTable CloneTo(DataTable clone, DataSet cloneDS, bool skipExpressionColumns)
+        {
+            // we do clone datatables while we do readxmlschema, so we do not want to clone columnexpressions if we call this from ReadXmlSchema
+            // it will cause exception to be thrown in cae expression refers to a table that is not in hirerachy or not created yet
+            Debug.Assert(clone != null, "The table passed in has to be newly created empty DataTable.");
+
+            // set All properties
+            clone._tableName = _tableName;
+
+            clone._tableNamespace = _tableNamespace;
+            clone._tablePrefix = _tablePrefix;
+            clone._fNestedInDataset = _fNestedInDataset;
+
+            clone._culture = _culture;
+            clone._cultureUserSet = _cultureUserSet;
+            clone._compareInfo = _compareInfo;
+            clone._compareFlags = _compareFlags;
+            clone._formatProvider = _formatProvider;
+            clone._hashCodeProvider = _hashCodeProvider;
+            clone._caseSensitive = _caseSensitive;
+            clone._caseSensitiveUserSet = _caseSensitiveUserSet;
+
+            clone._displayExpression = _displayExpression;
+            clone._typeName = _typeName; //enzol
+            clone._repeatableElement = _repeatableElement; //enzol
+            clone.MinimumCapacity = MinimumCapacity;
+            clone.RemotingFormat = RemotingFormat;
+
+            // add all columns
+            DataColumnCollection clmns = Columns;
+            for (int i = 0; i < clmns.Count; i++)
+            {
+                clone.Columns.Add(clmns[i].Clone());
+            }
+
+            // add all expressions if Clone is invoked only on DataTable otherwise DataSet.Clone will assign expressions after creating all relationships.
+            if (!skipExpressionColumns && cloneDS == null)
+            {
+                for (int i = 0; i < clmns.Count; i++)
+                {
+                    clone.Columns[clmns[i].ColumnName].Expression = clmns[i].Expression;
+                }
+            }
+
+            // Create PrimaryKey
+            DataColumn[] pkey = PrimaryKey;
+            if (pkey.Length > 0)
+            {
+                DataColumn[] key = new DataColumn[pkey.Length];
+                for (int i = 0; i < pkey.Length; i++)
+                {
+                    key[i] = clone.Columns[pkey[i].Ordinal];
+                }
+                clone.PrimaryKey = key;
+            }
+
+            // now clone all unique constraints
+            // Rename first
+            for (int j = 0; j < Constraints.Count; j++)
+            {
+                ForeignKeyConstraint foreign = Constraints[j] as ForeignKeyConstraint;
+                UniqueConstraint unique = Constraints[j] as UniqueConstraint;
+                if (foreign != null)
+                {
+                    if (foreign.Table == foreign.RelatedTable)
+                    {
+                        ForeignKeyConstraint clonedConstraint = foreign.Clone(clone);
+                        Constraint oldConstraint = clone.Constraints.FindConstraint(clonedConstraint);
+                        if (oldConstraint != null)
+                        {
+                            oldConstraint.ConstraintName = Constraints[j].ConstraintName;
+                        }
+                    }
+                }
+                else if (unique != null)
+                {
+                    UniqueConstraint clonedConstraint = unique.Clone(clone);
+                    Constraint oldConstraint = clone.Constraints.FindConstraint(clonedConstraint);
+                    if (oldConstraint != null)
+                    {
+                        oldConstraint.ConstraintName = Constraints[j].ConstraintName;
+                        foreach (object key in clonedConstraint.ExtendedProperties.Keys)
+                        {
+                            oldConstraint.ExtendedProperties[key] = clonedConstraint.ExtendedProperties[key];
+                        }
+                    }
+                }
+            }
+
+            // then add
+            for (int j = 0; j < Constraints.Count; j++)
+            {
+                if (!clone.Constraints.Contains(Constraints[j].ConstraintName, true))
+                {
+                    ForeignKeyConstraint foreign = Constraints[j] as ForeignKeyConstraint;
+                    UniqueConstraint unique = Constraints[j] as UniqueConstraint;
+                    if (foreign != null)
+                    {
+                        if (foreign.Table == foreign.RelatedTable)
+                        {
+                            ForeignKeyConstraint newforeign = foreign.Clone(clone);
+                            if (newforeign != null)
+                            { // we cant make sure that we recieve a cloned FKC,since it depends if table and relatedtable be the same
+                                clone.Constraints.Add(newforeign);
+                            }
+                        }
+                    }
+                    else if (unique != null)
+                    {
+                        clone.Constraints.Add(unique.Clone(clone));
+                    }
+                }
+            }
+
+            // ...Extended Properties...
+
+            if (_extendedProperties != null)
+            {
+                foreach (object key in _extendedProperties.Keys)
+                {
+                    clone.ExtendedProperties[key] = _extendedProperties[key];
+                }
+            }
+
+            return clone;
+        }
+
+        public DataTable Copy()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.Copy|API> {0}", ObjectID);
+            try
+            {
+                DataTable destTable = Clone();
+
+                foreach (DataRow row in Rows)
+                {
+                    CopyRow(destTable, row);
+                }
+
+                return destTable;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Occurs when a value has been submitted for this column.
+        /// </summary>
+        public event DataColumnChangeEventHandler ColumnChanging
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_ColumnChanging|API> {0}", ObjectID);
+                _onColumnChangingDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_ColumnChanging|API> {0}", ObjectID);
+                _onColumnChangingDelegate -= value;
+            }
+        }
+
+        public event DataColumnChangeEventHandler ColumnChanged
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_ColumnChanged|API> {0}", ObjectID);
+                _onColumnChangedDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_ColumnChanged|API> {0}", ObjectID);
+                _onColumnChangedDelegate -= value;
+            }
+        }
+
+        public event EventHandler Initialized
+        {
+            add { _onInitialized += value; }
+            remove { _onInitialized -= value; }
+        }
+
+        internal event PropertyChangedEventHandler PropertyChanging
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_PropertyChanging|INFO> {0}", ObjectID);
+                _onPropertyChangingDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_PropertyChanging|INFO> {0}", ObjectID);
+                _onPropertyChangingDelegate -= value;
+            }
+        }
+
+        /// <summary>
+        /// Occurs after a row in the table has been successfully edited.
+        /// </summary>
+        public event DataRowChangeEventHandler RowChanged
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_RowChanged|API> {0}", ObjectID);
+                _onRowChangedDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_RowChanged|API> {0}", ObjectID);
+                _onRowChangedDelegate -= value;
+            }
+        }
+
+        /// <summary>
+        /// Occurs when the <see cref='System.Data.DataRow'/> is changing.
+        /// </summary>
+        public event DataRowChangeEventHandler RowChanging
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_RowChanging|API> {0}", ObjectID);
+                _onRowChangingDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_RowChanging|API> {0}", ObjectID);
+                _onRowChangingDelegate -= value;
+            }
+        }
+
+        /// <summary>
+        /// Occurs before a row in the table is about to be deleted.
+        /// </summary>
+        public event DataRowChangeEventHandler RowDeleting
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_RowDeleting|API> {0}", ObjectID);
+                _onRowDeletingDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_RowDeleting|API> {0}", ObjectID);
+                _onRowDeletingDelegate -= value;
+            }
+        }
+
+        /// <summary>
+        /// Occurs after a row in the table has been deleted.
+        /// </summary>
+        public event DataRowChangeEventHandler RowDeleted
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_RowDeleted|API> {0}", ObjectID);
+                _onRowDeletedDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_RowDeleted|API> {0}", ObjectID);
+                _onRowDeletedDelegate -= value;
+            }
+        }
+
+        public event DataTableClearEventHandler TableClearing
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_TableClearing|API> {0}", ObjectID);
+                _onTableClearingDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_TableClearing|API> {0}", ObjectID);
+                _onTableClearingDelegate -= value;
+            }
+        }
+
+        public event DataTableClearEventHandler TableCleared
+        {
+            add
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.add_TableCleared|API> {0}", ObjectID);
+                _onTableClearedDelegate += value;
+            }
+            remove
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.remove_TableCleared|API> {0}", ObjectID);
+                _onTableClearedDelegate -= value;
+            }
+        }
+
+        public event DataTableNewRowEventHandler TableNewRow
+        {
+            add
+            {
+                _onTableNewRowDelegate += value;
+            }
+            remove
+            {
+                _onTableNewRowDelegate -= value;
+            }
+        }
+
+        [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override ISite Site
+        {
+            get { return base.Site; }
+            set
+            {
+                ISite oldSite = Site;
+                if (value == null && oldSite != null)
+                {
+                    IContainer cont = oldSite.Container;
+
+                    if (cont != null)
+                    {
+                        for (int i = 0; i < Columns.Count; i++)
+                        {
+                            if (Columns[i].Site != null)
+                            {
+                                cont.Remove(Columns[i]);
+                            }
+                        }
+                    }
+                }
+                base.Site = value;
+            }
+        }
+
+        internal DataRow AddRecords(int oldRecord, int newRecord)
+        {
+            DataRow row;
+            if (oldRecord == -1 && newRecord == -1)
+            {
+                row = NewRow(-1);
+                AddRow(row);
+            }
+            else
+            {
+                row = NewEmptyRow();
+                row._oldRecord = oldRecord;
+                row._newRecord = newRecord;
+                InsertRow(row, -1);
+            }
+            return row;
+        }
+
+        internal void AddRow(DataRow row) => AddRow(row, -1);
+
+        internal void AddRow(DataRow row, int proposedID) => InsertRow(row, proposedID, -1);
+
+        internal void InsertRow(DataRow row, int proposedID, int pos) => InsertRow(row, proposedID, pos, fireEvent: true);
+
+        internal void InsertRow(DataRow row, long proposedID, int pos, bool fireEvent)
+        {
+            Exception deferredException = null;
+
+            if (row == null)
+            {
+                throw ExceptionBuilder.ArgumentNull(nameof(row));
+            }
+            if (row.Table != this)
+            {
+                throw ExceptionBuilder.RowAlreadyInOtherCollection();
+            }
+            if (row.rowID != -1)
+            {
+                throw ExceptionBuilder.RowAlreadyInTheCollection();
+            }
+            row.BeginEdit(); // ensure something's there.            
+
+            int record = row._tempRecord;
+            row._tempRecord = -1;
+
+            if (proposedID == -1)
+            {
+                proposedID = _nextRowID;
+            }
+
+            bool rollbackOnException;
+            if (rollbackOnException = (_nextRowID <= proposedID))
+            {
+                _nextRowID = checked(proposedID + 1);
+            }
+
+            try
+            {
+                try
+                {
+                    row.rowID = proposedID;
+                    // this method may cause DataView.OnListChanged in which another row may be added
+                    SetNewRecordWorker(row, record, DataRowAction.Add, false, false, pos, fireEvent, out deferredException); // now we do add the row to collection before OnRowChanged (RaiseRowChanged)
+                }
+                catch
+                {
+                    if (rollbackOnException && (_nextRowID == proposedID + 1))
+                    {
+                        _nextRowID = proposedID;
+                    }
+                    row.rowID = -1;
+                    row._tempRecord = record;
+                    throw;
+                }
+
+                // since expression evaluation occurred in SetNewRecordWorker, there may have been a problem that
+                // was deferred to this point.  If so, throw now since row has already been added.
+                if (deferredException != null)
+                    throw deferredException;
+
+                if (EnforceConstraints && !_inLoad)
+                {
+                    // if we are evaluating expression, we need to validate constraints
+                    int columnCount = _columnCollection.Count;
+                    for (int i = 0; i < columnCount; ++i)
+                    {
+                        DataColumn column = _columnCollection[i];
+                        if (column.Computed)
+                        {
+                            column.CheckColumnConstraint(row, DataRowAction.Add);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                row.ResetLastChangedColumn();// if expression is evaluated while adding, before  return, we want to clear it
+            }
+        }
+
+        internal void CheckNotModifying(DataRow row)
+        {
+            if (row._tempRecord != -1)
+            {
+                row.EndEdit();
+            }
+        }
+
+        /// <summary>
+        /// Clears the table of all data.
+        /// </summary>
+
+        public void Clear() => Clear(true);
+
+        internal void Clear(bool clearAll)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.Clear|INFO> {0}, clearAll={1}", ObjectID, clearAll);
+            try
+            {
+                Debug.Assert(null == _rowDiffId, "wasn't previously cleared");
+                _rowDiffId = null;
+
+                if (_dataSet != null)
+                    _dataSet.OnClearFunctionCalled(this);
+                bool shouldFireClearEvents = (Rows.Count != 0); // if Rows is already empty, this is noop
+
+                DataTableClearEventArgs e = null;
+                if (shouldFireClearEvents)
+                {
+                    e = new DataTableClearEventArgs(this);
+                    OnTableClearing(e);
+                }
+
+                if (_dataSet != null && _dataSet.EnforceConstraints)
+                {
+                    for (ParentForeignKeyConstraintEnumerator constraints = new ParentForeignKeyConstraintEnumerator(_dataSet, this); constraints.GetNext();)
+                    {
+                        ForeignKeyConstraint constraint = constraints.GetForeignKeyConstraint();
+                        constraint.CheckCanClearParentTable(this);
+                    }
+                }
+
+                _recordManager.Clear(clearAll);
+
+                // this improves performance by iterating over rows instead of computing by index
+                foreach (DataRow row in Rows)
+                {
+                    row._oldRecord = -1;
+                    row._newRecord = -1;
+                    row._tempRecord = -1;
+                    row.rowID = -1;
+                    row.RBTreeNodeId = 0;
+                }
+                Rows.ArrayClear();
+
+                ResetIndexes();
+
+                if (shouldFireClearEvents)
+                {
+                    OnTableCleared(e);
+                }
+
+                foreach (DataColumn column in Columns)
+                {
+                    EvaluateDependentExpressions(column);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal void CascadeAll(DataRow row, DataRowAction action)
+        {
+            if (DataSet != null && DataSet._fEnableCascading)
+            {
+                for (ParentForeignKeyConstraintEnumerator constraints = new ParentForeignKeyConstraintEnumerator(_dataSet, this); constraints.GetNext();)
+                {
+                    constraints.GetForeignKeyConstraint().CheckCascade(row, action);
+                }
+            }
+        }
+
+        internal void CommitRow(DataRow row)
+        {
+            // Fire Changing event
+            DataRowChangeEventArgs drcevent = OnRowChanging(null, row, DataRowAction.Commit);
+
+            if (!_inDataLoad)
+            {
+                CascadeAll(row, DataRowAction.Commit);
+            }
+
+            SetOldRecord(row, row._newRecord);
+
+            OnRowChanged(drcevent, row, DataRowAction.Commit);
+        }
+
+        internal int Compare(string s1, string s2) => Compare(s1, s2, null);
+
+        internal int Compare(string s1, string s2, CompareInfo comparer)
+        {
+            object obj1 = s1;
+            object obj2 = s2;
+            if (obj1 == obj2)
+            {
+                return 0;
+            }
+            if (obj1 == null)
+            {
+                return -1;
+            }
+            if (obj2 == null)
+            {
+                return 1;
+            }
+
+            int leng1 = s1.Length;
+            int leng2 = s2.Length;
+
+            for (; leng1 > 0; leng1--)
+            {
+                if (s1[leng1 - 1] != 0x20 && s1[leng1 - 1] != 0x3000) // 0x3000 is Ideographic Whitespace
+                {
+                    break;
+                }
+            }
+            for (; leng2 > 0; leng2--)
+            {
+                if (s2[leng2 - 1] != 0x20 && s2[leng2 - 1] != 0x3000)
+                {
+                    break;
+                }
+            }
+
+            return (comparer ?? CompareInfo).Compare(s1, 0, leng1, s2, 0, leng2, _compareFlags);
+        }
+
+        internal int IndexOf(string s1, string s2) => CompareInfo.IndexOf(s1, s2, _compareFlags);
+
+        internal bool IsSuffix(string s1, string s2) => CompareInfo.IsSuffix(s1, s2, _compareFlags);
+
+        /// <summary>
+        /// Computes the given expression on the current rows that pass the filter criteria.
+        /// </summary>
+        public object Compute(string expression, string filter)
+        {
+            DataRow[] rows = Select(filter, "", DataViewRowState.CurrentRows);
+            DataExpression expr = new DataExpression(this, expression);
+            return expr.Evaluate(rows);
+        }
+
+        bool IListSource.ContainsListCollection => false;
+
+        internal void CopyRow(DataTable table, DataRow row)
+        {
+            int oldRecord = -1, newRecord = -1;
+
+            if (row == null)
+            {
+                return;
+            }
+
+            if (row._oldRecord != -1)
+            {
+                oldRecord = table._recordManager.ImportRecord(row.Table, row._oldRecord);
+            }
+            if (row._newRecord != -1)
+            {
+                if (row._newRecord != row._oldRecord)
+                {
+                    newRecord = table._recordManager.ImportRecord(row.Table, row._newRecord);
+                }
+                else
+                {
+                    newRecord = oldRecord;
+                }
+            }
+
+            DataRow targetRow = table.AddRecords(oldRecord, newRecord);
+
+            if (row.HasErrors)
+            {
+                targetRow.RowError = row.RowError;
+
+                DataColumn[] cols = row.GetColumnsInError();
+
+                for (int i = 0; i < cols.Length; i++)
+                {
+                    DataColumn col = targetRow.Table.Columns[cols[i].ColumnName];
+                    targetRow.SetColumnError(col, row.GetColumnError(cols[i]));
+                }
+            }
+        }
+
+        internal void DeleteRow(DataRow row)
+        {
+            if (row._newRecord == -1)
+            {
+                throw ExceptionBuilder.RowAlreadyDeleted();
+            }
+
+            // Store.PrepareForDelete(row);
+            SetNewRecord(row, -1, DataRowAction.Delete, false, true);
+        }
+
+        private void CheckPrimaryKey()
+        {
+            if (_primaryKey == null) throw ExceptionBuilder.TableMissingPrimaryKey();
+        }
+
+        internal DataRow FindByPrimaryKey(object[] values)
+        {
+            CheckPrimaryKey();
+            return FindRow(_primaryKey.Key, values);
+        }
+
+        internal DataRow FindByPrimaryKey(object value)
+        {
+            CheckPrimaryKey();
+            return FindRow(_primaryKey.Key, value);
+        }
+
+        private DataRow FindRow(DataKey key, object[] values)
+        {
+            Index index = GetIndex(NewIndexDesc(key));
+            Range range = index.FindRecords(values);
+            if (range.IsNull)
+            {
+                return null;
+            }
+            return _recordManager[index.GetRecord(range.Min)];
+        }
+
+        private DataRow FindRow(DataKey key, object value)
+        {
+            Index index = GetIndex(NewIndexDesc(key));
+            Range range = index.FindRecords(value);
+            if (range.IsNull)
+            {
+                return null;
+            }
+            return _recordManager[index.GetRecord(range.Min)];
+        }
+
+        internal string FormatSortString(IndexField[] indexDesc)
+        {
+            var builder = new StringBuilder();
+            foreach (IndexField field in indexDesc)
+            {
+                if (0 < builder.Length)
+                {
+                    builder.Append(", ");
+                }
+                builder.Append(field.Column.ColumnName);
+                if (field.IsDescending)
+                {
+                    builder.Append(" DESC");
+                }
+            }
+            return builder.ToString();
+        }
+
+        internal void FreeRecord(ref int record)
+        {
+            _recordManager.FreeRecord(ref record);
+        }
+
+        public DataTable GetChanges()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.GetChanges|API> {0}", ObjectID);
+            try
+            {
+                DataTable dtChanges = Clone();
+                DataRow row = null;
+
+                for (int i = 0; i < Rows.Count; i++)
+                {
+                    row = Rows[i];
+                    if (row._oldRecord != row._newRecord)
+                    {
+                        dtChanges.ImportRow(row);
+                    }
+                }
+
+                if (dtChanges.Rows.Count == 0)
+                {
+                    return null;
+                }
+
+                return dtChanges;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public DataTable GetChanges(DataRowState rowStates)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.GetChanges|API> {0}, rowStates={1}", ObjectID, rowStates);
+            try
+            {
+                DataTable dtChanges = Clone();
+                DataRow row = null;
+
+                // check that rowStates is valid DataRowState
+                Debug.Assert(Enum.GetUnderlyingType(typeof(DataRowState)) == typeof(int), "Invalid DataRowState type");
+
+                for (int i = 0; i < Rows.Count; i++)
+                {
+                    row = Rows[i];
+                    if ((row.RowState & rowStates) != 0)
+                    {
+                        dtChanges.ImportRow(row);
+                    }
+                }
+
+                if (dtChanges.Rows.Count == 0)
+                {
+                    return null;
+                }
+
+                return dtChanges;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Returns an array of <see cref='System.Data.DataRow'/> objects that contain errors.
+        /// </summary>
+        public DataRow[] GetErrors()
+        {
+            List<DataRow> errorList = new List<DataRow>();
+
+            for (int i = 0; i < Rows.Count; i++)
+            {
+                DataRow row = Rows[i];
+                if (row.HasErrors)
+                {
+                    errorList.Add(row);
+                }
+            }
+
+            DataRow[] temp = NewRowArray(errorList.Count);
+            errorList.CopyTo(temp);
+            return temp;
+        }
+
+        internal Index GetIndex(IndexField[] indexDesc) =>
+            GetIndex(indexDesc, DataViewRowState.CurrentRows, null);
+
+        internal Index GetIndex(string sort, DataViewRowState recordStates, IFilter rowFilter) =>
+            GetIndex(ParseSortString(sort), recordStates, rowFilter);
+
+        internal Index GetIndex(IndexField[] indexDesc, DataViewRowState recordStates, IFilter rowFilter)
+        {
+            _indexesLock.EnterUpgradeableReadLock();
+            try
+            {
+                for (int i = 0; i < _indexes.Count; i++)
+                {
+                    Index index = _indexes[i];
+                    if (index != null)
+                    {
+                        if (index.Equal(indexDesc, recordStates, rowFilter))
+                        {
+                            return index;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                _indexesLock.ExitUpgradeableReadLock();
+            }
+            Index ndx = new Index(this, indexDesc, recordStates, rowFilter);
+            ndx.AddRef();
+            return ndx;
+        }
+
+        IList IListSource.GetList() => DefaultView;
+
+        internal List<DataViewListener> GetListeners() => _dataViewListeners;
+
+        // We need a HashCodeProvider for Case, Kana and Width insensitive
+        internal int GetSpecialHashCode(string name)
+        {
+            int i;
+            for (i = 0; (i < name.Length) && (0x3000 > name[i]); ++i) ;
+
+            if (name.Length == i)
+            {
+                if (null == _hashCodeProvider)
+                {
+                    // it should use the CaseSensitive property, but V1 shipped this way
+                    _hashCodeProvider = StringComparer.Create(Locale, true);
+                }
+                return _hashCodeProvider.GetHashCode(name);
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        public void ImportRow(DataRow row)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.ImportRow|API> {0}", ObjectID);
+            try
+            {
+                int oldRecord = -1, newRecord = -1;
+
+                if (row == null)
+                {
+                    return;
+                }
+
+                if (row._oldRecord != -1)
+                {
+                    oldRecord = _recordManager.ImportRecord(row.Table, row._oldRecord);
+                }
+                if (row._newRecord != -1)
+                {  // row not deleted
+                    if (row.RowState != DataRowState.Unchanged)
+                    { // not unchanged, it means Added or modified
+                        newRecord = _recordManager.ImportRecord(row.Table, row._newRecord);
+                    }
+                    else
+                    {
+                        newRecord = oldRecord;
+                    }
+                }
+
+                if (oldRecord != -1 || newRecord != -1)
+                {
+                    DataRow targetRow = AddRecords(oldRecord, newRecord);
+
+                    if (row.HasErrors)
+                    {
+                        targetRow.RowError = row.RowError;
+
+                        DataColumn[] cols = row.GetColumnsInError();
+
+                        for (int i = 0; i < cols.Length; i++)
+                        {
+                            DataColumn col = targetRow.Table.Columns[cols[i].ColumnName];
+                            targetRow.SetColumnError(col, row.GetColumnError(cols[i]));
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal void InsertRow(DataRow row, long proposedID)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.InsertRow|INFO> {0}, row={1}", ObjectID, row._objectID);
+            try
+            {
+                if (row.Table != this)
+                {
+                    throw ExceptionBuilder.RowAlreadyInOtherCollection();
+                }
+                if (row.rowID != -1)
+                {
+                    throw ExceptionBuilder.RowAlreadyInTheCollection();
+                }
+                if (row._oldRecord == -1 && row._newRecord == -1)
+                {
+                    throw ExceptionBuilder.RowEmpty();
+                }
+
+                if (proposedID == -1)
+                {
+                    proposedID = _nextRowID;
+                }
+
+                row.rowID = proposedID;
+                if (_nextRowID <= proposedID)
+                {
+                    _nextRowID = checked(proposedID + 1);
+                }
+
+                DataRowChangeEventArgs drcevent = null;
+
+                if (row._newRecord != -1)
+                {
+                    row._tempRecord = row._newRecord;
+                    row._newRecord = -1;
+
+                    try
+                    {
+                        drcevent = RaiseRowChanging(null, row, DataRowAction.Add, true);
+                    }
+                    catch
+                    {
+                        row._tempRecord = -1;
+                        throw;
+                    }
+
+                    row._newRecord = row._tempRecord;
+                    row._tempRecord = -1;
+                }
+
+                if (row._oldRecord != -1)
+                {
+                    _recordManager[row._oldRecord] = row;
+                }
+
+                if (row._newRecord != -1)
+                {
+                    _recordManager[row._newRecord] = row;
+                }
+
+                Rows.ArrayAdd(row);
+
+                if (row.RowState == DataRowState.Unchanged)
+                {
+                    //  how about row.oldRecord == row.newRecord both == -1
+                    RecordStateChanged(row._oldRecord, DataViewRowState.None, DataViewRowState.Unchanged);
+                }
+                else
+                {
+                    RecordStateChanged(row._oldRecord, DataViewRowState.None, row.GetRecordState(row._oldRecord),
+                                       row._newRecord, DataViewRowState.None, row.GetRecordState(row._newRecord));
+                }
+
+                if (_dependentColumns != null && _dependentColumns.Count > 0)
+                {
+                    EvaluateExpressions(row, DataRowAction.Add, null);
+                }
+
+                RaiseRowChanged(drcevent, row, DataRowAction.Add);
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        private IndexField[] NewIndexDesc(DataKey key)
+        {
+            Debug.Assert(key.HasValue);
+            IndexField[] indexDesc = key.GetIndexDesc();
+            IndexField[] newIndexDesc = new IndexField[indexDesc.Length];
+            Array.Copy(indexDesc, 0, newIndexDesc, 0, indexDesc.Length);
+            return newIndexDesc;
+        }
+
+        internal int NewRecord() => NewRecord(-1);
+
+        internal int NewUninitializedRecord()
+        {
+            return _recordManager.NewRecordBase();
+        }
+
+        internal int NewRecordFromArray(object[] value)
+        {
+            int colCount = _columnCollection.Count; // Perf: use the readonly columnCollection field directly
+            if (colCount < value.Length)
+            {
+                throw ExceptionBuilder.ValueArrayLength();
+            }
+            int record = _recordManager.NewRecordBase();
+            try
+            {
+                for (int i = 0; i < value.Length; i++)
+                {
+                    if (null != value[i])
+                    {
+                        _columnCollection[i][record] = value[i];
+                    }
+                    else
+                    {
+                        _columnCollection[i].Init(record);  // Increase AutoIncrementCurrent
+                    }
+                }
+                for (int i = value.Length; i < colCount; i++)
+                {
+                    _columnCollection[i].Init(record);
+                }
+                return record;
+            }
+            catch (Exception e) when (ADP.IsCatchableOrSecurityExceptionType(e))
+            {
+                FreeRecord(ref record);
+                throw;
+            }
+        }
+
+        internal int NewRecord(int sourceRecord)
+        {
+            int record = _recordManager.NewRecordBase();
+
+            int count = _columnCollection.Count;
+            if (-1 == sourceRecord)
+            {
+                for (int i = 0; i < count; ++i)
+                {
+                    _columnCollection[i].Init(record);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; ++i)
+                {
+                    _columnCollection[i].Copy(sourceRecord, record);
+                }
+            }
+            return record;
+        }
+
+        internal DataRow NewEmptyRow()
+        {
+            _rowBuilder._record = -1;
+            DataRow dr = NewRowFromBuilder(_rowBuilder);
+            if (_dataSet != null)
+            {
+                DataSet.OnDataRowCreated(dr);
+            }
+            return dr;
+        }
+
+        private DataRow NewUninitializedRow() => NewRow(NewUninitializedRecord());
+
+        /// <summary>
+        /// Creates a new <see cref='System.Data.DataRow'/>
+        /// with the same schema as the table.
+        /// </summary>
+        public DataRow NewRow()
+        {
+            DataRow dr = NewRow(-1);
+            NewRowCreated(dr); // this is the only API we want this event to be fired
+            return dr;
+        }
+
+        // Only initialize DataRelation mapping columns (approximately hidden columns)
+        internal DataRow CreateEmptyRow()
+        {
+            DataRow row = NewUninitializedRow();
+
+            foreach (DataColumn c in Columns)
+            {
+                if (!XmlToDatasetMap.IsMappedColumn(c))
+                {
+                    if (!c.AutoIncrement)
+                    {
+                        if (c.AllowDBNull)
+                        {
+                            row[c] = DBNull.Value;
+                        }
+                        else if (c.DefaultValue != null)
+                        {
+                            row[c] = c.DefaultValue;
+                        }
+                    }
+                    else
+                    {
+                        c.Init(row._tempRecord);
+                    }
+                }
+            }
+            return row;
+        }
+
+        private void NewRowCreated(DataRow row)
+        {
+            if (null != _onTableNewRowDelegate)
+            {
+                DataTableNewRowEventArgs eventArg = new DataTableNewRowEventArgs(row);
+                OnTableNewRow(eventArg);
+            }
+        }
+
+        internal DataRow NewRow(int record)
+        {
+            if (-1 == record)
+            {
+                record = NewRecord(-1);
+            }
+
+            _rowBuilder._record = record;
+            DataRow row = NewRowFromBuilder(_rowBuilder);
+            _recordManager[record] = row;
+
+            if (_dataSet != null)
+            {
+                DataSet.OnDataRowCreated(row);
+            }
+
+            return row;
+        }
+
+        // This is what a subclassed dataSet overrides to create a new row.
+        protected virtual DataRow NewRowFromBuilder(DataRowBuilder builder) => new DataRow(builder);
+
+        /// <summary>
+        /// Gets the row type.
+        /// </summary>
+        protected virtual Type GetRowType() => typeof(DataRow);
+
+        // Prevent inlining so that reflection calls are not moved to caller that may be in a different assembly that may have a different grant set.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        protected internal DataRow[] NewRowArray(int size)
+        {
+            if (IsTypedDataTable)
+            {
+                if (0 == size)
+                {
+                    if (null == _emptyDataRowArray)
+                    {
+                        _emptyDataRowArray = (DataRow[])Array.CreateInstance(GetRowType(), 0);
+                    }
+                    return _emptyDataRowArray;
+                }
+                return (DataRow[])Array.CreateInstance(GetRowType(), size);
+            }
+            else
+            {
+                return ((0 == size) ? Array.Empty<DataRow>() : new DataRow[size]);
+            }
+        }
+
+        internal bool NeedColumnChangeEvents =>
+            (IsTypedDataTable || (null != _onColumnChangingDelegate) || (null != _onColumnChangedDelegate));
+
+        protected internal virtual void OnColumnChanging(DataColumnChangeEventArgs e)
+        {
+            // intentionally allow exceptions to bubble up.  We haven't committed anything yet.
+            Debug.Assert(e != null, "e should not be null");
+            if (_onColumnChangingDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnColumnChanging|INFO> {0}", ObjectID);
+                _onColumnChangingDelegate(this, e);
+            }
+        }
+
+        protected internal virtual void OnColumnChanged(DataColumnChangeEventArgs e)
+        {
+            Debug.Assert(e != null, "e should not be null");
+            if (_onColumnChangedDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnColumnChanged|INFO> {0}", ObjectID);
+                _onColumnChangedDelegate(this, e);
+            }
+        }
+
+        protected virtual void OnPropertyChanging(PropertyChangedEventArgs pcevent)
+        {
+            if (_onPropertyChangingDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnPropertyChanging|INFO> {0}", ObjectID);
+                _onPropertyChangingDelegate(this, pcevent);
+            }
+        }
+
+        internal void OnRemoveColumnInternal(DataColumn column) => OnRemoveColumn(column);
+
+        /// <summary>
+        /// Notifies the <see cref='System.Data.DataTable'/> that a <see cref='System.Data.DataColumn'/> is
+        /// being removed.
+        /// </summary>
+        protected virtual void OnRemoveColumn(DataColumn column) { }
+
+        private DataRowChangeEventArgs OnRowChanged(DataRowChangeEventArgs args, DataRow eRow, DataRowAction eAction)
+        {
+            if ((null != _onRowChangedDelegate) || IsTypedDataTable)
+            {
+                if (null == args)
+                {
+                    args = new DataRowChangeEventArgs(eRow, eAction);
+                }
+                OnRowChanged(args);
+            }
+            return args;
+        }
+
+        private DataRowChangeEventArgs OnRowChanging(DataRowChangeEventArgs args, DataRow eRow, DataRowAction eAction)
+        {
+            if ((null != _onRowChangingDelegate) || IsTypedDataTable)
+            {
+                if (null == args)
+                {
+                    args = new DataRowChangeEventArgs(eRow, eAction);
+                }
+                OnRowChanging(args);
+            }
+            return args;
+        }
+
+        /// <summary>
+        /// Raises the <see cref='System.Data.DataTable.RowChanged'/> event.
+        /// </summary>
+        protected virtual void OnRowChanged(DataRowChangeEventArgs e)
+        {
+            Debug.Assert((null != e) && ((null != _onRowChangedDelegate) || IsTypedDataTable), "OnRowChanged arguments");
+            if (_onRowChangedDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnRowChanged|INFO> {0}", ObjectID);
+                _onRowChangedDelegate(this, e);
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref='System.Data.DataTable.RowChanging'/> event.
+        /// </summary>
+        protected virtual void OnRowChanging(DataRowChangeEventArgs e)
+        {
+            Debug.Assert((null != e) && ((null != _onRowChangingDelegate) || IsTypedDataTable), "OnRowChanging arguments");
+            if (_onRowChangingDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnRowChanging|INFO> {0}", ObjectID);
+                _onRowChangingDelegate(this, e);
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref='System.Data.DataTable.OnRowDeleting'/> event.
+        /// </summary>
+        protected virtual void OnRowDeleting(DataRowChangeEventArgs e)
+        {
+            Debug.Assert((null != e) && ((null != _onRowDeletingDelegate) || IsTypedDataTable), "OnRowDeleting arguments");
+            if (_onRowDeletingDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnRowDeleting|INFO> {0}", ObjectID);
+                _onRowDeletingDelegate(this, e);
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref='System.Data.DataTable.OnRowDeleted'/> event.
+        /// </summary>
+        protected virtual void OnRowDeleted(DataRowChangeEventArgs e)
+        {
+            Debug.Assert((null != e) && ((null != _onRowDeletedDelegate) || IsTypedDataTable), "OnRowDeleted arguments");
+            if (_onRowDeletedDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnRowDeleted|INFO> {0}", ObjectID);
+                _onRowDeletedDelegate(this, e);
+            }
+        }
+
+        protected virtual void OnTableCleared(DataTableClearEventArgs e)
+        {
+            if (_onTableClearedDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnTableCleared|INFO> {0}", ObjectID);
+                _onTableClearedDelegate(this, e);
+            }
+        }
+
+        protected virtual void OnTableClearing(DataTableClearEventArgs e)
+        {
+            if (_onTableClearingDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnTableClearing|INFO> {0}", ObjectID);
+                _onTableClearingDelegate(this, e);
+            }
+        }
+
+        protected virtual void OnTableNewRow(DataTableNewRowEventArgs e)
+        {
+            if (_onTableNewRowDelegate != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnTableNewRow|INFO> {0}", ObjectID);
+                _onTableNewRowDelegate(this, e);
+            }
+        }
+
+        private void OnInitialized()
+        {
+            if (_onInitialized != null)
+            {
+                DataCommonEventSource.Log.Trace("<ds.DataTable.OnInitialized|INFO> {0}", ObjectID);
+                _onInitialized(this, EventArgs.Empty);
+            }
+        }
+
+        internal IndexField[] ParseSortString(string sortString)
+        {
+            IndexField[] indexDesc = Array.Empty<IndexField>();
+            if ((null != sortString) && (0 < sortString.Length))
+            {
+                string[] split = sortString.Split(new char[] { ',' });
+                indexDesc = new IndexField[split.Length];
+
+                for (int i = 0; i < split.Length; i++)
+                {
+                    string current = split[i].Trim();
+
+                    // handle ASC and DESC.
+                    int length = current.Length;
+                    bool descending = false;
+                    if (length >= 5 && string.Compare(current, length - 4, " ASC", 0, 4, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        current = current.Substring(0, length - 4).Trim();
+                    }
+                    else if (length >= 6 && string.Compare(current, length - 5, " DESC", 0, 5, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        descending = true;
+                        current = current.Substring(0, length - 5).Trim();
+                    }
+
+                    // handle brackets.
+                    if (current.StartsWith("[", StringComparison.Ordinal))
+                    {
+                        if (current.EndsWith("]", StringComparison.Ordinal))
+                        {
+                            current = current.Substring(1, current.Length - 2);
+                        }
+                        else
+                        {
+                            throw ExceptionBuilder.InvalidSortString(split[i]);
+                        }
+                    }
+
+                    // find the column.
+                    DataColumn column = Columns[current];
+                    if (column == null)
+                    {
+                        throw ExceptionBuilder.ColumnOutOfRange(current);
+                    }
+                    indexDesc[i] = new IndexField(column, descending);
+                }
+            }
+            return indexDesc;
+        }
+
+        internal void RaisePropertyChanging(string name)
+        {
+            OnPropertyChanging(new PropertyChangedEventArgs(name));
+        }
+
+        // Notify all indexes that record changed.
+        // Only called when Error was changed.
+        internal void RecordChanged(int record)
+        {
+            Debug.Assert(record != -1, "Record number must be given");
+            SetShadowIndexes(); // how about new assert?
+            try
+            {
+                int numIndexes = _shadowIndexes.Count;
+                for (int i = 0; i < numIndexes; i++)
+                {
+                    Index ndx = _shadowIndexes[i];// shadowindexes may change, see ShadowIndexCopy()
+                    if (0 < ndx.RefCount)
+                    {
+                        ndx.RecordChanged(record);
+                    }
+                }
+            }
+            finally
+            {
+                RestoreShadowIndexes();
+            }
+        }
+
+        // for each index in liveindexes invok RecordChanged
+        // oldIndex and newIndex keeps  position of record before delete and after insert in each index in order
+        // LiveIndexes[n-m] will have its information in oldIndex[n-m] and  newIndex[n-m]
+        internal void RecordChanged(int[] oldIndex, int[] newIndex)
+        {
+            SetShadowIndexes();
+            Debug.Assert(oldIndex.Length == newIndex.Length, "Size oldIndexes and newIndexes should be the same");
+            Debug.Assert(oldIndex.Length == _shadowIndexes.Count, "Size of OldIndexes should be the same as size of Live indexes");
+            try
+            {
+                int numIndexes = _shadowIndexes.Count;
+                for (int i = 0; i < numIndexes; i++)
+                {
+                    Index ndx = _shadowIndexes[i];// shadowindexes may change, see ShadowIndexCopy()
+                    if (0 < ndx.RefCount)
+                    {
+                        ndx.RecordChanged(oldIndex[i], newIndex[i]);
+                    }
+                }
+            }
+            finally
+            {
+                RestoreShadowIndexes();
+            }
+        }
+
+        internal void RecordStateChanged(int record, DataViewRowState oldState, DataViewRowState newState)
+        {
+            SetShadowIndexes();
+            try
+            {
+                int numIndexes = _shadowIndexes.Count;
+                for (int i = 0; i < numIndexes; i++)
+                {
+                    Index ndx = _shadowIndexes[i];// shadowindexes may change, see ShadowIndexCopy()
+                    if (0 < ndx.RefCount)
+                    {
+                        ndx.RecordStateChanged(record, oldState, newState);
+                    }
+                }
+            }
+            finally
+            {
+                RestoreShadowIndexes();
+            }
+            // System.Data.XML.Store.Store.OnROMChanged(record, oldState, newState);
+        }
+
+        internal void RecordStateChanged(int record1, DataViewRowState oldState1, DataViewRowState newState1,
+                                         int record2, DataViewRowState oldState2, DataViewRowState newState2)
+        {
+            SetShadowIndexes();
+            try
+            {
+                int numIndexes = _shadowIndexes.Count;
+                for (int i = 0; i < numIndexes; i++)
+                {
+                    Index ndx = _shadowIndexes[i];// shadowindexes may change, see ShadowIndexCopy()
+                    if (0 < ndx.RefCount)
+                    {
+                        if (record1 != -1 && record2 != -1)
+                        {
+                            ndx.RecordStateChanged(record1, oldState1, newState1, record2, oldState2, newState2);
+                        }
+                        else if (record1 != -1)
+                        {
+                            ndx.RecordStateChanged(record1, oldState1, newState1);
+                        }
+                        else if (record2 != -1)
+                        {
+                            ndx.RecordStateChanged(record2, oldState2, newState2);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                RestoreShadowIndexes();
+            }
+            // System.Data.XML.Store.Store.OnROMChanged(record1, oldState1, newState1, record2, oldState2, newState2);
+        }
+
+
+        // RemoveRecordFromIndexes removes the given record (using row and version) from all indexes and it  stores and returns the position of deleted
+        // record from each index
+        // IT SHOULD NOT CAUSE ANY EVENT TO BE FIRED
+        internal int[] RemoveRecordFromIndexes(DataRow row, DataRowVersion version)
+        {
+            int indexCount = LiveIndexes.Count;
+            int[] positionIndexes = new int[indexCount];
+
+            int recordNo = row.GetRecordFromVersion(version);
+            DataViewRowState states = row.GetRecordState(recordNo);
+
+            while (--indexCount >= 0)
+            {
+                if (row.HasVersion(version) && ((states & _indexes[indexCount].RecordStates) != DataViewRowState.None))
+                {
+                    int index = _indexes[indexCount].GetIndex(recordNo);
+                    if (index > -1)
+                    {
+                        positionIndexes[indexCount] = index;
+                        _indexes[indexCount].DeleteRecordFromIndex(index); // this will delete the record from index and MUSt not fire event
+                    }
+                    else
+                    {
+                        positionIndexes[indexCount] = -1; // this means record was not in index
+                    }
+                }
+                else
+                {
+                    positionIndexes[indexCount] = -1; // this means record was not in index
+                }
+            }
+            return positionIndexes;
+        }
+
+        // InsertRecordToIndexes inserts the given record (using row and version) to all indexes and it  stores and returns the position of inserted
+        // record to each index
+        // IT SHOULD NOT CAUSE ANY EVENT TO BE FIRED
+        internal int[] InsertRecordToIndexes(DataRow row, DataRowVersion version)
+        {
+            int indexCount = LiveIndexes.Count;
+            int[] positionIndexes = new int[indexCount];
+
+            int recordNo = row.GetRecordFromVersion(version);
+            DataViewRowState states = row.GetRecordState(recordNo);
+
+            while (--indexCount >= 0)
+            {
+                if (row.HasVersion(version))
+                {
+                    if ((states & _indexes[indexCount].RecordStates) != DataViewRowState.None)
+                    {
+                        positionIndexes[indexCount] = _indexes[indexCount].InsertRecordToIndex(recordNo);
+                    }
+                    else
+                    {
+                        positionIndexes[indexCount] = -1;
+                    }
+                }
+            }
+            return positionIndexes;
+        }
+
+        internal void SilentlySetValue(DataRow dr, DataColumn dc, DataRowVersion version, object newValue)
+        {
+            // get record for version
+            int record = dr.GetRecordFromVersion(version);
+
+            bool equalValues = false;
+            if (DataStorage.IsTypeCustomType(dc.DataType) && newValue != dc[record])
+            {
+                // if UDT storage, need to check if reference changed.
+                equalValues = false;
+            }
+            else
+            {
+                equalValues = dc.CompareValueTo(record, newValue, true);
+            }
+
+            // if expression has changed
+            if (!equalValues)
+            {
+                int[] oldIndex = dr.Table.RemoveRecordFromIndexes(dr, version);// conditional, if it exists it will try to remove with no event fired
+                dc.SetValue(record, newValue);
+                int[] newIndex = dr.Table.InsertRecordToIndexes(dr, version);// conditional, it will insert if it qualifies, no event will be fired
+                if (dr.HasVersion(version))
+                {
+                    if (version != DataRowVersion.Original)
+                    {
+                        dr.Table.RecordChanged(oldIndex, newIndex);
+                    }
+                    if (dc._dependentColumns != null)
+                    {
+                        dc.Table.EvaluateDependentExpressions(dc._dependentColumns, dr, version, null);
+                    }
+                }
+            }
+            dr.ResetLastChangedColumn();
+        }
+
+        /// <summary>
+        /// Rolls back all changes that have been made to the table
+        /// since it was loaded, or the last time <see cref='System.Data.DataTable.AcceptChanges'/> was called.
+        /// </summary>
+        public void RejectChanges()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.RejectChanges|API> {0}", ObjectID);
+            try
+            {
+                DataRow[] oldRows = new DataRow[Rows.Count];
+                Rows.CopyTo(oldRows, 0);
+
+                for (int i = 0; i < oldRows.Length; i++)
+                {
+                    RollbackRow(oldRows[i]);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal void RemoveRow(DataRow row, bool check)
+        {
+            if (row.rowID == -1)
+            {
+                throw ExceptionBuilder.RowAlreadyRemoved();
+            }
+
+            if (check && _dataSet != null)
+            {
+                for (ParentForeignKeyConstraintEnumerator constraints = new ParentForeignKeyConstraintEnumerator(_dataSet, this); constraints.GetNext();)
+                {
+                    constraints.GetForeignKeyConstraint().CheckCanRemoveParentRow(row);
+                }
+            }
+
+            int oldRecord = row._oldRecord;
+            int newRecord = row._newRecord;
+
+            DataViewRowState oldRecordStatePre = row.GetRecordState(oldRecord);
+            DataViewRowState newRecordStatePre = row.GetRecordState(newRecord);
+
+            row._oldRecord = -1;
+            row._newRecord = -1;
+
+            if (oldRecord == newRecord)
+            {
+                oldRecord = -1;
+            }
+
+            RecordStateChanged(oldRecord, oldRecordStatePre, DataViewRowState.None, newRecord, newRecordStatePre, DataViewRowState.None);
+
+            FreeRecord(ref oldRecord);
+            FreeRecord(ref newRecord);
+
+            row.rowID = -1;
+            Rows.ArrayRemove(row);
+        }
+
+        // Resets the table back to its original state.
+        public virtual void Reset()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.Reset|API> {0}", ObjectID);
+            try
+            {
+                Clear();
+                ResetConstraints();
+
+                DataRelationCollection dr = ParentRelations;
+                int count = dr.Count;
+                while (count > 0)
+                {
+                    count--;
+                    dr.RemoveAt(count);
+                }
+
+                dr = ChildRelations;
+                count = dr.Count;
+                while (count > 0)
+                {
+                    count--;
+                    dr.RemoveAt(count);
+                }
+
+                Columns.Clear();
+                _indexes.Clear();
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal void ResetIndexes() => ResetInternalIndexes(null);
+
+        internal void ResetInternalIndexes(DataColumn column)
+        {
+            Debug.Assert(null != _indexes, "unexpected null indexes");
+            SetShadowIndexes();
+            try
+            {
+                // the length of shadowIndexes will not change
+                // but the array instance may change during
+                // events during Index.Reset
+                int numIndexes = _shadowIndexes.Count;
+                for (int i = 0; i < numIndexes; i++)
+                {
+                    Index ndx = _shadowIndexes[i];// shadowindexes may change, see ShadowIndexCopy()
+                    if (0 < ndx.RefCount)
+                    {
+                        if (null == column)
+                        {
+                            ndx.Reset();
+                        }
+                        else
+                        {
+                            bool found = false;
+                            foreach (IndexField field in ndx._indexFields)
+                            {
+                                if (ReferenceEquals(column, field.Column))
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (found)
+                            {
+                                ndx.Reset();
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                RestoreShadowIndexes();
+            }
+        }
+
+        internal void RollbackRow(DataRow row)
+        {
+            row.CancelEdit();
+            SetNewRecord(row, row._oldRecord, DataRowAction.Rollback, false, true);
+        }
+
+        private DataRowChangeEventArgs RaiseRowChanged(DataRowChangeEventArgs args, DataRow eRow, DataRowAction eAction)
+        {
+            try
+            {
+                if (UpdatingCurrent(eRow, eAction) && (IsTypedDataTable || (null != _onRowChangedDelegate)))
+                {
+                    args = OnRowChanged(args, eRow, eAction);
+                }
+                // check if we deleting good row
+                else if (DataRowAction.Delete == eAction && eRow._newRecord == -1 && (IsTypedDataTable || (null != _onRowDeletedDelegate)))
+                {
+                    if (null == args)
+                    {
+                        args = new DataRowChangeEventArgs(eRow, eAction);
+                    }
+                    OnRowDeleted(args);
+                }
+            }
+            catch (Exception f) when (ADP.IsCatchableExceptionType(f))
+            {
+                ExceptionBuilder.TraceExceptionWithoutRethrow(f); // ignore the exception
+            }
+            return args;
+        }
+
+        private DataRowChangeEventArgs RaiseRowChanging(DataRowChangeEventArgs args, DataRow eRow, DataRowAction eAction)
+        {
+            if (UpdatingCurrent(eRow, eAction) && (IsTypedDataTable || (null != _onRowChangingDelegate)))
+            {
+                eRow._inChangingEvent = true;
+
+                // don't catch
+                try
+                {
+                    args = OnRowChanging(args, eRow, eAction);
+                }
+                finally
+                {
+                    eRow._inChangingEvent = false;
+                }
+            }
+            // check if we deleting good row
+            else if (DataRowAction.Delete == eAction && eRow._newRecord != -1 && (IsTypedDataTable || (null != _onRowDeletingDelegate)))
+            {
+                eRow._inDeletingEvent = true;
+                // don't catch
+                try
+                {
+                    if (null == args)
+                    {
+                        args = new DataRowChangeEventArgs(eRow, eAction);
+                    }
+                    OnRowDeleting(args);
+                }
+                finally
+                {
+                    eRow._inDeletingEvent = false;
+                }
+            }
+            return args;
+        }
+
+        private DataRowChangeEventArgs RaiseRowChanging(DataRowChangeEventArgs args, DataRow eRow, DataRowAction eAction, bool fireEvent)
+        {
+            // check all constraints
+            if (EnforceConstraints && !_inLoad)
+            {
+                int columnCount = _columnCollection.Count;
+                for (int i = 0; i < columnCount; ++i)
+                {
+                    DataColumn column = _columnCollection[i];
+                    if (!column.Computed || eAction != DataRowAction.Add)
+                    {
+                        column.CheckColumnConstraint(eRow, eAction);
+                    }
+                }
+
+                int constraintCount = _constraintCollection.Count;
+                for (int i = 0; i < constraintCount; ++i)
+                {
+                    _constraintCollection[i].CheckConstraint(eRow, eAction);
+                }
+            }
+
+            if (fireEvent)
+            {
+                args = RaiseRowChanging(args, eRow, eAction);
+            }
+
+            if (!_inDataLoad)
+            {
+                // cascade things...
+                if (!MergingData && eAction != DataRowAction.Nothing && eAction != DataRowAction.ChangeOriginal)
+                {
+                    CascadeAll(eRow, eAction);
+                }
+            }
+            return args;
+        }
+
+        /// <summary>
+        /// Returns an array of all <see cref='System.Data.DataRow'/> objects.
+        /// </summary>
+        public DataRow[] Select()
+        {
+            DataCommonEventSource.Log.Trace("<ds.DataTable.Select|API> {0}", ObjectID);
+            return new Select(this, "", "", DataViewRowState.CurrentRows).SelectRows();
+        }
+
+        /// <summary>
+        /// Returns an array of all <see cref='System.Data.DataRow'/> objects that match the filter criteria in order of
+        /// primary key (or lacking one, order of addition.)
+        /// </summary>
+        public DataRow[] Select(string filterExpression)
+        {
+            DataCommonEventSource.Log.Trace("<ds.DataTable.Select|API> {0}, filterExpression='{1}'", ObjectID, filterExpression);
+            return new Select(this, filterExpression, "", DataViewRowState.CurrentRows).SelectRows();
+        }
+
+        /// <summary>
+        /// Returns an array of all <see cref='System.Data.DataRow'/> objects that match the filter criteria, in the
+        /// specified sort order.
+        /// </summary>
+        public DataRow[] Select(string filterExpression, string sort)
+        {
+            DataCommonEventSource.Log.Trace("<ds.DataTable.Select|API> {0}, filterExpression='{1}', sort='{2}'", ObjectID, filterExpression, sort);
+            return new Select(this, filterExpression, sort, DataViewRowState.CurrentRows).SelectRows();
+        }
+
+        /// <summary>
+        /// Returns an array of all <see cref='System.Data.DataRow'/> objects that match the filter in the order of the
+        /// sort, that match the specified state.
+        /// </summary>
+        public DataRow[] Select(string filterExpression, string sort, DataViewRowState recordStates)
+        {
+            DataCommonEventSource.Log.Trace("<ds.DataTable.Select|API> {0}, filterExpression='{1}', sort='{2}', recordStates={3}", ObjectID, filterExpression, sort, recordStates);
+            return new Select(this, filterExpression, sort, recordStates).SelectRows();
+        }
+
+        internal void SetNewRecord(DataRow row, int proposedRecord, DataRowAction action = DataRowAction.Change, bool isInMerge = false, bool fireEvent = true, bool suppressEnsurePropertyChanged = false)
+        {
+            Exception deferredException = null;
+            SetNewRecordWorker(row, proposedRecord, action, isInMerge, suppressEnsurePropertyChanged, -1, fireEvent, out deferredException); // we are going to call below overload from insert
+            if (deferredException != null)
+            {
+                throw deferredException;
+            }
+        }
+
+        private void SetNewRecordWorker(DataRow row, int proposedRecord, DataRowAction action, bool isInMerge, bool suppressEnsurePropertyChanged,
+            int position, bool fireEvent, out Exception deferredException)
+        {
+            // this is the event workhorse... it will throw the changing/changed events
+            // and update the indexes. Used by change, add, delete, revert.
+
+            // order of execution is as follows
+            //
+            // 1) set temp record
+            // 2) Check constraints for non-expression columns
+            // 3) Raise RowChanging/RowDeleting with temp record
+            // 4) set the new record in storage
+            // 5) Update indexes with recordStateChanges - this will fire ListChanged & PropertyChanged events on associated views
+            // 6) Evaluate all Expressions (exceptions are deferred)- this will fire ListChanged & PropertyChanged events on associated views
+            // 7) Raise RowChanged/ RowDeleted
+            // 8) Check constraints for expression columns
+
+            Debug.Assert(row != null, "Row can't be null.");
+            deferredException = null;
+
+            if (row._tempRecord != proposedRecord)
+            {
+                // $HACK: for performance reasons, EndUpdate calls SetNewRecord with tempRecord == proposedRecord
+                if (!_inDataLoad)
+                {
+                    row.CheckInTable();
+                    CheckNotModifying(row);
+                }
+                if (proposedRecord == row._newRecord)
+                {
+                    if (isInMerge)
+                    {
+                        Debug.Assert(fireEvent, "SetNewRecord is called with wrong parameter");
+                        RaiseRowChanged(null, row, action);
+                    }
+                    return;
+                }
+
+                Debug.Assert(!row._inChangingEvent, "How can this row be in an infinite loop?");
+
+                row._tempRecord = proposedRecord;
+            }
+            DataRowChangeEventArgs drcevent = null;
+
+            try
+            {
+                row._action = action;
+                drcevent = RaiseRowChanging(null, row, action, fireEvent);
+            }
+            catch
+            {
+                row._tempRecord = -1;
+                throw;
+            }
+            finally
+            {
+                row._action = DataRowAction.Nothing;
+            }
+
+            row._tempRecord = -1;
+
+            int currentRecord = row._newRecord;
+
+            // if we're deleting, then the oldRecord value will change, so need to track that if it's distinct from the newRecord.
+            int secondRecord = (proposedRecord != -1 ?
+                                proposedRecord :
+                                (row.RowState != DataRowState.Unchanged ?
+                                 row._oldRecord :
+                                 -1));
+
+            if (action == DataRowAction.Add)
+            {
+                //if we come here from insert we do insert the row to collection
+                if (position == -1)
+                {
+                    Rows.ArrayAdd(row);
+                }
+                else
+                {
+                    Rows.ArrayInsert(row, position);
+                }
+            }
+
+            List<DataRow> cachedRows = null;
+            if ((action == DataRowAction.Delete || action == DataRowAction.Change) &&
+                _dependentColumns != null && _dependentColumns.Count > 0)
+            {
+                // if there are expression columns, need to cache related rows for deletes and updates (key changes)
+                // before indexes are modified.
+                cachedRows = new List<DataRow>();
+                for (int j = 0; j < ParentRelations.Count; j++)
+                {
+                    DataRelation relation = ParentRelations[j];
+                    if (relation.ChildTable != row.Table)
+                    {
+                        continue;
+                    }
+                    cachedRows.InsertRange(cachedRows.Count, row.GetParentRows(relation));
+                }
+
+                for (int j = 0; j < ChildRelations.Count; j++)
+                {
+                    DataRelation relation = ChildRelations[j];
+                    if (relation.ParentTable != row.Table)
+                    {
+                        continue;
+                    }
+                    cachedRows.InsertRange(cachedRows.Count, row.GetChildRows(relation));
+                }
+            }
+
+            // if the newRecord is changing, the propertychanged event should be allowed to triggered for ListChangedType.Changed or .Moved
+            // unless the specific condition is known that no data has changed, like DataRow.SetModified()
+            if (!suppressEnsurePropertyChanged && !row.HasPropertyChanged && (row._newRecord != proposedRecord)
+                && (-1 != proposedRecord)
+                && (-1 != row._newRecord))
+            {
+                // DataRow will believe multiple edits occurred and
+                // DataView.ListChanged event w/ ListChangedType.ItemChanged will raise DataRowView.PropertyChanged event and
+                // PropertyChangedEventArgs.PropertyName will now be empty string so
+                // WPF will refresh the entire row
+                row.LastChangedColumn = null;
+                row.LastChangedColumn = null;
+            }
+
+            // Check whether we need to update indexes
+            if (LiveIndexes.Count != 0)
+            {
+                if ((-1 == currentRecord) && (-1 != proposedRecord) && (-1 != row._oldRecord) && (proposedRecord != row._oldRecord))
+                {
+                    // the transition from DataRowState.Deleted -> DataRowState.Modified
+                    // with same orginal record but new current record
+                    // needs to raise an ItemChanged or ItemMoved instead of ItemAdded in the ListChanged event.
+                    // for indexes/views listening for both DataViewRowState.Deleted | DataViewRowState.ModifiedCurrent
+                    currentRecord = row._oldRecord;
+                }
+
+                DataViewRowState currentRecordStatePre = row.GetRecordState(currentRecord);
+                DataViewRowState secondRecordStatePre = row.GetRecordState(secondRecord);
+
+                row._newRecord = proposedRecord;
+                if (proposedRecord != -1)
+                    _recordManager[proposedRecord] = row;
+
+                DataViewRowState currentRecordStatePost = row.GetRecordState(currentRecord);
+                DataViewRowState secondRecordStatePost = row.GetRecordState(secondRecord);
+
+                // may raise DataView.ListChanged event
+                RecordStateChanged(currentRecord, currentRecordStatePre, currentRecordStatePost,
+                    secondRecord, secondRecordStatePre, secondRecordStatePost);
+            }
+            else
+            {
+                row._newRecord = proposedRecord;
+                if (proposedRecord != -1)
+                    _recordManager[proposedRecord] = row;
+            }
+
+            // reset the last changed column here, after all
+            // DataViews have raised their DataRowView.PropertyChanged event
+            row.ResetLastChangedColumn();
+
+            // free the 'currentRecord' only after all the indexes have been updated.
+            // Corruption! { if (currentRecord != row.oldRecord) { FreeRecord(ref currentRecord); } }
+            // RecordStateChanged raises ListChanged event at which time user may do work
+            if (-1 != currentRecord)
+            {
+                if (currentRecord != row._oldRecord)
+                {
+                    if ((currentRecord != row._tempRecord) &&   // Delete, AcceptChanges, BeginEdit
+                        (currentRecord != row._newRecord) &&    // RejectChanges & SetAdded
+                        (row == _recordManager[currentRecord])) // AcceptChanges, NewRow
+                    {
+                        FreeRecord(ref currentRecord);
+                    }
+                }
+            }
+
+            if (row.RowState == DataRowState.Detached && row.rowID != -1)
+            {
+                RemoveRow(row, false);
+            }
+
+            if (_dependentColumns != null && _dependentColumns.Count > 0)
+            {
+                try
+                {
+                    EvaluateExpressions(row, action, cachedRows);
+                }
+                catch (Exception exc)
+                {
+                    // For DataRows being added, throwing of exception from expression evaluation is
+                    // deferred until after the row has been completely added.
+                    if (action != DataRowAction.Add)
+                    {
+                        throw exc;
+                    }
+                    else
+                    {
+                        deferredException = exc;
+                    }
+                }
+            }
+
+            try
+            {
+                if (fireEvent)
+                {
+                    RaiseRowChanged(drcevent, row, action);
+                }
+            }
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
+            {
+                ExceptionBuilder.TraceExceptionWithoutRethrow(e); // ignore the exception
+            }
+        }
+
+        // this is the event workhorse... it will throw the changing/changed events
+        // and update the indexes.
+        internal void SetOldRecord(DataRow row, int proposedRecord)
+        {
+            if (!_inDataLoad)
+            {
+                row.CheckInTable();
+                CheckNotModifying(row);
+            }
+
+            if (proposedRecord == row._oldRecord)
+            {
+                return;
+            }
+
+            int originalRecord = row._oldRecord; // cache old record after potential RowChanging event
+            try
+            {
+                // Check whether we need to update indexes
+                if (LiveIndexes.Count != 0)
+                {
+                    if ((-1 == originalRecord) && (-1 != proposedRecord) && (-1 != row._newRecord) && (proposedRecord != row._newRecord))
+                    {
+                        // the transition from DataRowState.Added -> DataRowState.Modified
+                        // with same current record but new original record
+                        // needs to raise an ItemChanged or ItemMoved instead of ItemAdded in the ListChanged event.
+                        // for indexes/views listening for both DataViewRowState.Added | DataViewRowState.ModifiedOriginal
+                        originalRecord = row._newRecord;
+                    }
+
+                    DataViewRowState originalRecordStatePre = row.GetRecordState(originalRecord);
+                    DataViewRowState proposedRecordStatePre = row.GetRecordState(proposedRecord);
+
+                    row._oldRecord = proposedRecord;
+                    if (proposedRecord != -1)
+                    {
+                        _recordManager[proposedRecord] = row;
+                    }
+
+                    DataViewRowState originalRecordStatePost = row.GetRecordState(originalRecord);
+                    DataViewRowState proposedRecordStatePost = row.GetRecordState(proposedRecord);
+
+                    RecordStateChanged(originalRecord, originalRecordStatePre, originalRecordStatePost,
+                                       proposedRecord, proposedRecordStatePre, proposedRecordStatePost);
+                }
+                else
+                {
+                    row._oldRecord = proposedRecord;
+                    if (proposedRecord != -1)
+                    {
+                        _recordManager[proposedRecord] = row;
+                    }
+                }
+            }
+            finally
+            {
+                if ((originalRecord != -1) && (originalRecord != row._tempRecord) &&
+                    (originalRecord != row._oldRecord) && (originalRecord != row._newRecord))
+                {
+                    FreeRecord(ref originalRecord);
+                }
+                // else during an event 'row.AcceptChanges(); row.BeginEdit(); row.EndEdit();'
+
+                if (row.RowState == DataRowState.Detached && row.rowID != -1)
+                {
+                    RemoveRow(row, false);
+                }
+            }
+        }
+
+        private void RestoreShadowIndexes()
+        {
+            Debug.Assert(1 <= _shadowCount, "unexpected negative shadow count");
+            _shadowCount--;
+            if (0 == _shadowCount)
+            {
+                _shadowIndexes = null;
+            }
+        }
+
+        private void SetShadowIndexes()
+        {
+            if (null == _shadowIndexes)
+            {
+                Debug.Assert(0 == _shadowCount, "unexpected count");
+                _shadowIndexes = LiveIndexes;
+                _shadowCount = 1;
+            }
+            else
+            {
+                Debug.Assert(1 <= _shadowCount, "unexpected negative shadow count");
+                _shadowCount++;
+            }
+        }
+
+        internal void ShadowIndexCopy()
+        {
+            if (_shadowIndexes == _indexes)
+            {
+                Debug.Assert(0 < _indexes.Count, "unexpected");
+                _shadowIndexes = new List<Index>(_indexes);
+            }
+        }
+
+        /// <summary>
+        /// Returns the <see cref='System.Data.DataTable.TableName'/> and <see cref='System.Data.DataTable.DisplayExpression'/>, if there is one as a concatenated string.
+        /// </summary>
+        public override string ToString() => _displayExpression == null ?
+            TableName :
+            TableName + " + " + DisplayExpressionInternal;
+
+        public void BeginLoadData()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.BeginLoadData|API> {0}", ObjectID);
+            try
+            {
+                if (_inDataLoad)
+                {
+                    return;
+                }
+
+                _inDataLoad = true;
+                Debug.Assert(null == _loadIndex, "loadIndex should already be null");
+                _loadIndex = null;
+
+                // LoadDataRow may have been called before BeginLoadData and already
+                // initialized loadIndexwithOriginalAdded & loadIndexwithCurrentDeleted 
+
+                _initialLoad = (Rows.Count == 0);
+                if (_initialLoad)
+                {
+                    SuspendIndexEvents();
+                }
+                else
+                {
+                    if (_primaryKey != null)
+                    {
+                        _loadIndex = _primaryKey.Key.GetSortIndex(DataViewRowState.OriginalRows);
+                    }
+                    if (_loadIndex != null)
+                    {
+                        _loadIndex.AddRef();
+                    }
+                }
+
+                if (DataSet != null)
+                {
+                    _savedEnforceConstraints = DataSet.EnforceConstraints;
+                    DataSet.EnforceConstraints = false;
+                }
+                else
+                {
+                    EnforceConstraints = false;
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void EndLoadData()
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.EndLoadData|API> {0}", ObjectID);
+            try
+            {
+                if (!_inDataLoad)
+                {
+                    return;
+                }
+
+                if (_loadIndex != null)
+                {
+                    _loadIndex.RemoveRef();
+                }
+                if (_loadIndexwithOriginalAdded != null)
+                {
+                    _loadIndexwithOriginalAdded.RemoveRef();
+                }
+                if (_loadIndexwithCurrentDeleted != null)
+                {
+                    _loadIndexwithCurrentDeleted.RemoveRef();
+                }
+
+                _loadIndex = null;
+                _loadIndexwithOriginalAdded = null;
+                _loadIndexwithCurrentDeleted = null;
+
+                _inDataLoad = false;
+
+                RestoreIndexEvents(false);
+
+                if (DataSet != null)
+                {
+                    DataSet.EnforceConstraints = _savedEnforceConstraints;
+                }
+                else
+                {
+                    EnforceConstraints = true;
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Finds and updates a specific row. If no matching
+        /// row is found, a new row is created using the given values.
+        /// </summary>
+        public DataRow LoadDataRow(object[] values, bool fAcceptChanges)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.LoadDataRow|API> {0}, fAcceptChanges={1}", ObjectID, fAcceptChanges);
+            try
+            {
+                DataRow row;
+                if (_inDataLoad)
+                {
+                    int record = NewRecordFromArray(values);
+                    if (_loadIndex != null)
+                    {
+                        // not expecting LiveIndexes to clear the index we use between calls to LoadDataRow
+                        Debug.Assert(2 <= _loadIndex.RefCount, "bad loadIndex.RefCount");
+
+                        int result = _loadIndex.FindRecord(record);
+                        if (result != -1)
+                        {
+                            int resultRecord = _loadIndex.GetRecord(result);
+                            row = _recordManager[resultRecord];
+                            Debug.Assert(row != null, "Row can't be null for index record");
+                            row.CancelEdit();
+                            if (row.RowState == DataRowState.Deleted)
+                            {
+                                SetNewRecord(row, row._oldRecord, DataRowAction.Rollback, false, true);
+                            }
+                            SetNewRecord(row, record, DataRowAction.Change, false, true);
+                            if (fAcceptChanges)
+                            {
+                                row.AcceptChanges();
+                            }
+                            return row;
+                        }
+                    }
+                    row = NewRow(record);
+                    AddRow(row);
+                    if (fAcceptChanges)
+                    {
+                        row.AcceptChanges();
+                    }
+                    return row;
+                }
+                else
+                {
+                    // In case, BeginDataLoad is not called yet
+                    row = UpdatingAdd(values);
+                    if (fAcceptChanges)
+                    {
+                        row.AcceptChanges();
+                    }
+                    return row;
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        /// <summary>
+        /// Finds and updates a specific row. If no matching row is found, a new row is created using the given values.
+        /// </summary>
+        public DataRow LoadDataRow(object[] values, LoadOption loadOption)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.LoadDataRow|API> {0}, loadOption={1}", ObjectID, loadOption);
+            try
+            {
+                Index indextoUse = null;
+                if (_primaryKey != null)
+                {
+                    if (loadOption == LoadOption.Upsert)
+                    {
+                        // CurrentVersion, and Deleted
+                        if (_loadIndexwithCurrentDeleted == null)
+                        {
+                            _loadIndexwithCurrentDeleted = _primaryKey.Key.GetSortIndex(DataViewRowState.CurrentRows | DataViewRowState.Deleted);
+                            Debug.Assert(_loadIndexwithCurrentDeleted != null, "loadIndexwithCurrentDeleted should not be null");
+                            if (_loadIndexwithCurrentDeleted != null)
+                            {
+                                _loadIndexwithCurrentDeleted.AddRef();
+                            }
+                        }
+                        indextoUse = _loadIndexwithCurrentDeleted;
+                    }
+                    else
+                    {
+                        // CurrentVersion, and Deleted : OverwriteRow, PreserveCurrentValues
+                        if (_loadIndexwithOriginalAdded == null)
+                        {
+                            _loadIndexwithOriginalAdded = _primaryKey.Key.GetSortIndex(DataViewRowState.OriginalRows | DataViewRowState.Added);
+                            Debug.Assert(_loadIndexwithOriginalAdded != null, "loadIndexwithOriginalAdded should not be null");
+                            if (_loadIndexwithOriginalAdded != null)
+                            {
+                                _loadIndexwithOriginalAdded.AddRef();
+                            }
+                        }
+                        indextoUse = _loadIndexwithOriginalAdded;
+                    }
+                    // not expecting LiveIndexes to clear the index we use between calls to LoadDataRow
+                    Debug.Assert(2 <= indextoUse.RefCount, "bad indextoUse.RefCount");
+                }
+                if (_inDataLoad && !AreIndexEventsSuspended)
+                {
+                    // we do not want to fire any listchanged in new Load/Fill
+                    SuspendIndexEvents();// so suspend events here(not suspended == table already has some rows initially)
+                }
+
+                DataRow dataRow = LoadRow(values, loadOption, indextoUse);// if indextoUse == null, it means we dont have PK,
+                                                                          // so LoadRow will take care of just adding the row to end
+
+                return dataRow;
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal DataRow UpdatingAdd(object[] values)
+        {
+            Index index = null;
+            if (_primaryKey != null)
+            {
+                index = _primaryKey.Key.GetSortIndex(DataViewRowState.OriginalRows);
+            }
+
+            if (index != null)
+            {
+                int record = NewRecordFromArray(values);
+                int result = index.FindRecord(record);
+                if (result != -1)
+                {
+                    int resultRecord = index.GetRecord(result);
+                    DataRow row = _recordManager[resultRecord];
+                    Debug.Assert(row != null, "Row can't be null for index record");
+                    row.RejectChanges();
+                    SetNewRecord(row, record);
+                    return row;
+                }
+                DataRow row2 = NewRow(record);
+                Rows.Add(row2);
+                return row2;
+            }
+
+            return Rows.Add(values);
+        }
+
+        internal bool UpdatingCurrent(DataRow row, DataRowAction action)
+        {
+            return (action == DataRowAction.Add || action == DataRowAction.Change ||
+                   action == DataRowAction.Rollback || action == DataRowAction.ChangeOriginal ||
+                   action == DataRowAction.ChangeCurrentAndOriginal);
+        }
+
+        internal DataColumn AddUniqueKey(int position)
+        {
+            if (_colUnique != null)
+                return _colUnique;
+
+            // check to see if we can use already existent PrimaryKey
+            DataColumn[] pkey = PrimaryKey;
+            if (pkey.Length == 1)
+            {
+                // We have one-column primary key, so we can use it in our heirarchical relation
+                return pkey[0];
+            }
+
+            // add Unique, but not primaryKey to the table
+
+            string keyName = XMLSchema.GenUniqueColumnName(TableName + "_Id", this);
+            DataColumn key = new DataColumn(keyName, typeof(int), null, MappingType.Hidden);
+            key.Prefix = _tablePrefix;
+            key.AutoIncrement = true;
+            key.AllowDBNull = false;
+            key.Unique = true;
+
+            if (position == -1)
+            {
+                Columns.Add(key);
+            }
+            else
+            { // we do have a problem and Imy idea is it is bug. Ask Enzo while Code review. Why we do not set ordinal when we call AddAt?
+                for (int i = Columns.Count - 1; i >= position; i--)
+                {
+                    Columns[i].SetOrdinalInternal(i + 1);
+                }
+                Columns.AddAt(position, key);
+                key.SetOrdinalInternal(position);
+            }
+
+            if (pkey.Length == 0)
+            {
+                PrimaryKey = new DataColumn[] { key };
+            }
+
+            _colUnique = key;
+            return _colUnique;
+        }
+
+        internal DataColumn AddUniqueKey() => AddUniqueKey(-1);
+
+        internal DataColumn AddForeignKey(DataColumn parentKey)
+        {
+            Debug.Assert(parentKey != null, "AddForeignKey: Invalid paramter.. related primary key is null");
+
+            string keyName = XMLSchema.GenUniqueColumnName(parentKey.ColumnName, this);
+            DataColumn foreignKey = new DataColumn(keyName, parentKey.DataType, null, MappingType.Hidden);
+            Columns.Add(foreignKey);
+
+            return foreignKey;
+        }
+
+        internal void UpdatePropertyDescriptorCollectionCache()
+        {
+            _propertyDescriptorCollectionCache = null;
+        }
+
+        /// <summary>
+        /// Retrieves an array of properties that the given component instance
+        /// provides.  This may differ from the set of properties the class
+        /// provides.  If the component is sited, the site may add or remove
+        /// additional properties.  The returned array of properties will be
+        /// filtered by the given set of attributes.
+        /// </summary>
+        internal PropertyDescriptorCollection GetPropertyDescriptorCollection(Attribute[] attributes)
+        {
+            if (_propertyDescriptorCollectionCache == null)
+            {
+                int columnsCount = Columns.Count;
+                int relationsCount = ChildRelations.Count;
+                PropertyDescriptor[] props = new PropertyDescriptor[columnsCount + relationsCount];
+                {
+                    for (int i = 0; i < columnsCount; i++)
+                    {
+                        props[i] = new DataColumnPropertyDescriptor(Columns[i]);
+                    }
+                    for (int i = 0; i < relationsCount; i++)
+                    {
+                        props[columnsCount + i] = new DataRelationPropertyDescriptor(ChildRelations[i]);
+                    }
+                }
+                _propertyDescriptorCollectionCache = new PropertyDescriptorCollection(props);
+            }
+            return _propertyDescriptorCollectionCache;
+        }
+
+        internal XmlQualifiedName TypeName
+        {
+            get { return ((_typeName == null) ? XmlQualifiedName.Empty : (XmlQualifiedName)_typeName); }
+            set { _typeName = value; }
+        }
+
+        public void Merge(DataTable table) =>
+            Merge(table, false, MissingSchemaAction.Add);
+
+        public void Merge(DataTable table, bool preserveChanges) =>
+            Merge(table, preserveChanges, MissingSchemaAction.Add);
+
+        public void Merge(DataTable table, bool preserveChanges, MissingSchemaAction missingSchemaAction)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.Merge|API> {0}, table={1}, preserveChanges={2}, missingSchemaAction={3}", ObjectID, (table != null) ? table.ObjectID : 0, preserveChanges, missingSchemaAction);
+            try
+            {
+                if (table == null)
+                {
+                    throw ExceptionBuilder.ArgumentNull(nameof(table));
+                }
+
+                switch (missingSchemaAction)
+                {
+                    case MissingSchemaAction.Add:
+                    case MissingSchemaAction.Ignore:
+                    case MissingSchemaAction.Error:
+                    case MissingSchemaAction.AddWithKey:
+                        Merger merger = new Merger(this, preserveChanges, missingSchemaAction);
+                        merger.MergeTable(table);
+                        break;
+                    default:
+                        throw ADP.InvalidMissingSchemaAction(missingSchemaAction);
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void Load(IDataReader reader) => Load(reader, LoadOption.PreserveChanges, null);
+
+        public void Load(IDataReader reader, LoadOption loadOption) => Load(reader, loadOption, null);
+
+        public virtual void Load(IDataReader reader, LoadOption loadOption, FillErrorEventHandler errorHandler)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.Load|API> {0}, loadOption={1}", ObjectID, loadOption);
+            try
+            {
+                if (PrimaryKey.Length == 0)
+                {
+                    DataTableReader dtReader = reader as DataTableReader;
+                    if (dtReader != null && dtReader.CurrentDataTable == this)
+                    {
+                        return; // if not return, it will go to infinite loop
+                    }
+                }
+                Common.LoadAdapter adapter = new Common.LoadAdapter();
+                adapter.FillLoadOption = loadOption;
+                adapter.MissingSchemaAction = MissingSchemaAction.AddWithKey;
+                if (null != errorHandler)
+                {
+                    adapter.FillError += errorHandler;
+                }
+                adapter.FillFromReader(new DataTable[] { this }, reader, 0, 0);
+
+                if (!reader.IsClosed && !reader.NextResult())
+                {
+                    reader.Close();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        private DataRow LoadRow(object[] values, LoadOption loadOption, Index searchIndex)
+        {
+            int recordNo;
+            DataRow dataRow = null;
+
+            if (searchIndex != null)
+            {
+                int[] primaryKeyIndex = Array.Empty<int>();
+                if (_primaryKey != null)
+                {
+                    // we do check above for PK, but in case if someone else gives us some index unrelated to PK
+                    primaryKeyIndex = new int[_primaryKey.ColumnsReference.Length];
+                    for (int i = 0; i < _primaryKey.ColumnsReference.Length; i++)
+                    {
+                        primaryKeyIndex[i] = _primaryKey.ColumnsReference[i].Ordinal;
+                    }
+                }
+
+                object[] keys = new object[primaryKeyIndex.Length];
+                for (int i = 0; i < primaryKeyIndex.Length; i++)
+                {
+                    keys[i] = values[primaryKeyIndex[i]];
+                }
+
+                Range result = searchIndex.FindRecords(keys);
+
+                if (!result.IsNull)
+                {
+                    int deletedRowUpsertCount = 0;
+                    for (int i = result.Min; i <= result.Max; i++)
+                    {
+                        int resultRecord = searchIndex.GetRecord(i);
+                        dataRow = _recordManager[resultRecord];
+                        recordNo = NewRecordFromArray(values);
+
+                        // values array is being reused by DataAdapter, do not modify the values array
+                        for (int count = 0; count < values.Length; count++)
+                        {
+                            if (null == values[count])
+                            {
+                                _columnCollection[count].Copy(resultRecord, recordNo);
+                            }
+                        }
+                        for (int count = values.Length; count < _columnCollection.Count; count++)
+                        {
+                            _columnCollection[count].Copy(resultRecord, recordNo); // if there are missing values
+                        }
+
+                        if (loadOption != LoadOption.Upsert || dataRow.RowState != DataRowState.Deleted)
+                        {
+                            SetDataRowWithLoadOption(dataRow, recordNo, loadOption, true);
+                        }
+                        else
+                        {
+                            deletedRowUpsertCount++;
+                        }
+                    }
+                    if (0 == deletedRowUpsertCount)
+                    {
+                        return dataRow;
+                    }
+                }
+            }
+
+            recordNo = NewRecordFromArray(values);
+            dataRow = NewRow(recordNo);
+
+            // fire rowChanging event here
+            DataRowAction action;
+            DataRowChangeEventArgs drcevent = null;
+            switch (loadOption)
+            {
+                case LoadOption.OverwriteChanges:
+                case LoadOption.PreserveChanges:
+                    action = DataRowAction.ChangeCurrentAndOriginal;
+                    break;
+                case LoadOption.Upsert:
+                    action = DataRowAction.Add;
+                    break;
+                default:
+                    throw ExceptionBuilder.ArgumentOutOfRange(nameof(LoadOption));
+            }
+
+            drcevent = RaiseRowChanging(null, dataRow, action);
+
+            InsertRow(dataRow, -1, -1, false);
+            switch (loadOption)
+            {
+                case LoadOption.OverwriteChanges:
+                case LoadOption.PreserveChanges:
+                    SetOldRecord(dataRow, recordNo);
+                    break;
+                case LoadOption.Upsert:
+                    break;
+                default:
+                    throw ExceptionBuilder.ArgumentOutOfRange(nameof(LoadOption));
+            }
+            RaiseRowChanged(drcevent, dataRow, action);
+
+            return dataRow;
+        }
+
+        private void SetDataRowWithLoadOption(DataRow dataRow, int recordNo, LoadOption loadOption, bool checkReadOnly)
+        {
+            bool hasError = false;
+            if (checkReadOnly)
+            {
+                foreach (DataColumn dc in Columns)
+                {
+                    if (dc.ReadOnly && !dc.Computed)
+                    {
+                        switch (loadOption)
+                        {
+                            case LoadOption.OverwriteChanges:
+                                if ((dataRow[dc, DataRowVersion.Current] != dc[recordNo]) || (dataRow[dc, DataRowVersion.Original] != dc[recordNo]))
+                                    hasError = true;
+                                break;
+                            case LoadOption.Upsert:
+                                if (dataRow[dc, DataRowVersion.Current] != dc[recordNo])
+                                    hasError = true;
+                                break;
+                            case LoadOption.PreserveChanges:
+                                if (dataRow[dc, DataRowVersion.Original] != dc[recordNo])
+                                    hasError = true;
+                                break;
+                        }
+                    }
+                }
+            } // No Event should be fired  in SenNewRecord and SetOldRecord
+            // fire rowChanging event here
+
+            DataRowChangeEventArgs drcevent = null;
+            DataRowAction action = DataRowAction.Nothing;
+            int cacheTempRecord = dataRow._tempRecord;
+            dataRow._tempRecord = recordNo;
+
+            switch (loadOption)
+            {
+                case LoadOption.OverwriteChanges:
+                    action = DataRowAction.ChangeCurrentAndOriginal;
+                    break;
+                case LoadOption.Upsert:
+                    switch (dataRow.RowState)
+                    {
+                        case DataRowState.Unchanged:
+                            // let see if the incomming value has the same values as existing row, so compare records
+                            foreach (DataColumn dc in dataRow.Table.Columns)
+                            {
+                                if (0 != dc.Compare(dataRow._newRecord, recordNo))
+                                {
+                                    action = DataRowAction.Change;
+                                    break;
+                                }
+                            }
+                            break;
+                        case DataRowState.Deleted:
+                            Debug.Assert(false, "LoadOption.Upsert with deleted row, should not be here");
+                            break;
+                        default:
+                            action = DataRowAction.Change;
+                            break;
+                    }
+                    break;
+                case LoadOption.PreserveChanges:
+                    switch (dataRow.RowState)
+                    {
+                        case DataRowState.Unchanged:
+                            action = DataRowAction.ChangeCurrentAndOriginal;
+                            break;
+                        default:
+                            action = DataRowAction.ChangeOriginal;
+                            break;
+                    }
+                    break;
+                default:
+                    throw ExceptionBuilder.ArgumentOutOfRange(nameof(LoadOption));
+            }
+
+            try
+            {
+                drcevent = RaiseRowChanging(null, dataRow, action);
+                if (action == DataRowAction.Nothing)
+                { // RaiseRowChanging does not fire for DataRowAction.Nothing
+                    dataRow._inChangingEvent = true;
+                    try
+                    {
+                        drcevent = OnRowChanging(drcevent, dataRow, action);
+                    }
+                    finally
+                    {
+                        dataRow._inChangingEvent = false;
+                    }
+                }
+            }
+            finally
+            {
+                Debug.Assert(dataRow._tempRecord == recordNo, "tempRecord has been changed in event handler");
+                if (DataRowState.Detached == dataRow.RowState)
+                {
+                    // 'row.Table.Remove(row);'
+                    if (-1 != cacheTempRecord)
+                    {
+                        FreeRecord(ref cacheTempRecord);
+                    }
+                }
+                else
+                {
+                    if (dataRow._tempRecord != recordNo)
+                    {
+                        // 'row.EndEdit(); row.BeginEdit(); '
+                        if (-1 != cacheTempRecord)
+                        {
+                            FreeRecord(ref cacheTempRecord);
+                        }
+                        if (-1 != recordNo)
+                        {
+                            FreeRecord(ref recordNo);
+                        }
+                        recordNo = dataRow._tempRecord;
+                    }
+                    else
+                    {
+                        dataRow._tempRecord = cacheTempRecord;
+                    }
+                }
+            }
+            if (dataRow._tempRecord != -1)
+            {
+                dataRow.CancelEdit();
+            }
+
+            switch (loadOption)
+            {
+                case LoadOption.OverwriteChanges:
+                    SetNewRecord(dataRow, recordNo, DataRowAction.Change, false, false);
+                    SetOldRecord(dataRow, recordNo);
+                    break;
+                case LoadOption.Upsert:
+                    if (dataRow.RowState == DataRowState.Unchanged)
+                    {
+                        SetNewRecord(dataRow, recordNo, DataRowAction.Change, false, false);
+                        if (!dataRow.HasChanges())
+                        {
+                            SetOldRecord(dataRow, recordNo);
+                        }
+                    }
+                    else
+                    {
+                        if (dataRow.RowState == DataRowState.Deleted)
+                            dataRow.RejectChanges();
+                        SetNewRecord(dataRow, recordNo, DataRowAction.Change, false, false);
+                    }
+                    break;
+                case LoadOption.PreserveChanges:
+                    if (dataRow.RowState == DataRowState.Unchanged)
+                    {
+                        // if ListChanged event deletes dataRow
+                        SetOldRecord(dataRow, recordNo); // do not fire event
+                        SetNewRecord(dataRow, recordNo, DataRowAction.Change, false, false);
+                    }
+                    else
+                    {
+                        // if modified/ added / deleted we want this operation to fire event (just for LoadOption.PreserveCurrentValues)
+                        SetOldRecord(dataRow, recordNo);
+                    }
+                    break;
+                default:
+                    throw ExceptionBuilder.ArgumentOutOfRange(nameof(LoadOption));
+            }
+
+            if (hasError)
+            {
+                string error = SR.Load_ReadOnlyDataModified;
+                if (dataRow.RowError.Length == 0)
+                {
+                    dataRow.RowError = error;
+                }
+                else
+                {
+                    dataRow.RowError += " ]:[ " + error;
+                }
+
+                foreach (DataColumn dc in Columns)
+                {
+                    if (dc.ReadOnly && !dc.Computed)
+                    {
+                        dataRow.SetColumnError(dc, error);
+                    }
+                }
+            }
+
+            drcevent = RaiseRowChanged(drcevent, dataRow, action);
+            if (action == DataRowAction.Nothing)
+            {
+                // RaiseRowChanged does not fire for DataRowAction.Nothing
+                dataRow._inChangingEvent = true;
+                try
+                {
+                    OnRowChanged(drcevent, dataRow, action);
+                }
+                finally
+                {
+                    dataRow._inChangingEvent = false;
+                }
+            }
+        }
+
+        public DataTableReader CreateDataReader() => new DataTableReader(this);
+
+        public void WriteXml(Stream stream) => WriteXml(stream, XmlWriteMode.IgnoreSchema, false);
+
+        public void WriteXml(Stream stream, bool writeHierarchy) => WriteXml(stream, XmlWriteMode.IgnoreSchema, writeHierarchy);
+
+        public void WriteXml(TextWriter writer) => WriteXml(writer, XmlWriteMode.IgnoreSchema, false);
+
+        public void WriteXml(TextWriter writer, bool writeHierarchy) => WriteXml(writer, XmlWriteMode.IgnoreSchema, writeHierarchy);
+
+        public void WriteXml(XmlWriter writer) => WriteXml(writer, XmlWriteMode.IgnoreSchema, false);
+
+        public void WriteXml(XmlWriter writer, bool writeHierarchy) => WriteXml(writer, XmlWriteMode.IgnoreSchema, writeHierarchy);
+
+        public void WriteXml(string fileName) => WriteXml(fileName, XmlWriteMode.IgnoreSchema, false);
+
+        public void WriteXml(string fileName, bool writeHierarchy) => WriteXml(fileName, XmlWriteMode.IgnoreSchema, writeHierarchy);
+
+        public void WriteXml(Stream stream, XmlWriteMode mode) => WriteXml(stream, mode, false);
+
+        public void WriteXml(Stream stream, XmlWriteMode mode, bool writeHierarchy)
+        {
+            if (stream != null)
+            {
+                XmlTextWriter w = new XmlTextWriter(stream, null);
+                w.Formatting = Formatting.Indented;
+
+                WriteXml(w, mode, writeHierarchy);
+            }
+        }
+
+        public void WriteXml(TextWriter writer, XmlWriteMode mode)
+        {
+            WriteXml(writer, mode, false);
+        }
+
+        public void WriteXml(TextWriter writer, XmlWriteMode mode, bool writeHierarchy)
+        {
+            if (writer != null)
+            {
+                XmlTextWriter w = new XmlTextWriter(writer);
+                w.Formatting = Formatting.Indented;
+
+                WriteXml(w, mode, writeHierarchy);
+            }
+        }
+
+        public void WriteXml(XmlWriter writer, XmlWriteMode mode)
+        {
+            WriteXml(writer, mode, false);
+        }
+        public void WriteXml(XmlWriter writer, XmlWriteMode mode, bool writeHierarchy)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.WriteXml|API> {0}, mode={1}", ObjectID, mode);
+            try
+            {
+                if (_tableName.Length == 0)
+                {
+                    throw ExceptionBuilder.CanNotSerializeDataTableWithEmptyName();
+                }
+                // Generate SchemaTree and write it out
+                if (writer != null)
+                {
+                    if (mode == XmlWriteMode.DiffGram)
+                    {
+                        // Create and save the updates
+                        new NewDiffgramGen(this, writeHierarchy).Save(writer, this);
+                    }
+                    else
+                    {
+                        // Create and save xml data
+                        if (mode == XmlWriteMode.WriteSchema)
+                        {
+                            DataSet ds = null;
+                            string tablenamespace = _tableNamespace;
+                            if (null == DataSet)
+                            {
+                                ds = new DataSet();
+
+                                // if user set values on DataTable, it isn't necessary
+                                // to set them on the DataSet because they won't be inherited
+                                // but it is simpler to set them in both places
+
+                                // if user did not set values on DataTable, it is required
+                                // to set them on the DataSet so the table will inherit
+                                // the value already on the Datatable
+                                ds.SetLocaleValue(_culture, _cultureUserSet);
+                                ds.CaseSensitive = CaseSensitive;
+                                ds.Namespace = Namespace;
+                                ds.RemotingFormat = RemotingFormat;
+                                ds.Tables.Add(this);
+                            }
+
+                            if (writer != null)
+                            {
+                                XmlDataTreeWriter xmldataWriter = new XmlDataTreeWriter(this, writeHierarchy);
+                                xmldataWriter.Save(writer, /*mode == XmlWriteMode.WriteSchema*/true);
+                            }
+                            if (null != ds)
+                            {
+                                ds.Tables.Remove(this);
+                                _tableNamespace = tablenamespace;
+                            }
+                        }
+                        else
+                        {
+                            XmlDataTreeWriter xmldataWriter = new XmlDataTreeWriter(this, writeHierarchy);
+                            xmldataWriter.Save(writer,/*mode == XmlWriteMode.WriteSchema*/ false);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void WriteXml(string fileName, XmlWriteMode mode) => WriteXml(fileName, mode, false);
+
+        public void WriteXml(string fileName, XmlWriteMode mode, bool writeHierarchy)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.WriteXml|API> {0}, fileName='{1}', mode={2}", ObjectID, fileName, mode);
+            try
+            {
+                using (XmlTextWriter xw = new XmlTextWriter(fileName, null))
+                {
+                    xw.Formatting = Formatting.Indented;
+                    xw.WriteStartDocument(true);
+
+                    WriteXml(xw, mode, writeHierarchy);
+
+                    xw.WriteEndDocument();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void WriteXmlSchema(Stream stream) => WriteXmlSchema(stream, false);
+
+        public void WriteXmlSchema(Stream stream, bool writeHierarchy)
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            XmlTextWriter w = new XmlTextWriter(stream, null);
+            w.Formatting = Formatting.Indented;
+
+            WriteXmlSchema(w, writeHierarchy);
+        }
+
+        public void WriteXmlSchema(TextWriter writer) => WriteXmlSchema(writer, false);
+
+        public void WriteXmlSchema(TextWriter writer, bool writeHierarchy)
+        {
+            if (writer == null)
+            {
+                return;
+            }
+
+            XmlTextWriter w = new XmlTextWriter(writer);
+            w.Formatting = Formatting.Indented;
+
+            WriteXmlSchema(w, writeHierarchy);
+        }
+
+        private bool CheckForClosureOnExpressions(DataTable dt, bool writeHierarchy)
+        {
+            List<DataTable> tableList = new List<DataTable>();
+            tableList.Add(dt);
+            if (writeHierarchy)
+            {
+                CreateTableList(dt, tableList);
+            }
+            return CheckForClosureOnExpressionTables(tableList);
+        }
+
+        private bool CheckForClosureOnExpressionTables(List<DataTable> tableList)
+        {
+            Debug.Assert(tableList != null, "tableList shouldnot be null");
+
+            foreach (DataTable datatable in tableList)
+            {
+                foreach (DataColumn dc in datatable.Columns)
+                {
+                    if (dc.Expression.Length != 0)
+                    {
+                        DataColumn[] dependency = dc.DataExpression.GetDependency();
+                        for (int j = 0; j < dependency.Length; j++)
+                        {
+                            if (!(tableList.Contains(dependency[j].Table)))
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        public void WriteXmlSchema(XmlWriter writer) => WriteXmlSchema(writer, false);
+
+        public void WriteXmlSchema(XmlWriter writer, bool writeHierarchy)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.WriteXmlSchema|API> {0}", ObjectID);
+            try
+            {
+                if (_tableName.Length == 0)
+                {
+                    throw ExceptionBuilder.CanNotSerializeDataTableWithEmptyName();
+                }
+
+                if (!CheckForClosureOnExpressions(this, writeHierarchy))
+                {
+                    throw ExceptionBuilder.CanNotSerializeDataTableHierarchy();
+                }
+
+                DataSet ds = null;
+                string tablenamespace = _tableNamespace;//SQL BU Defect Tracking 286968
+
+                // Generate SchemaTree and write it out
+                if (null == DataSet)
+                {
+                    ds = new DataSet();
+                    // if user set values on DataTable, it isn't necessary
+                    // to set them on the DataSet because they won't be inherited
+                    // but it is simpler to set them in both places
+
+                    // if user did not set values on DataTable, it is required
+                    // to set them on the DataSet so the table will inherit
+                    // the value already on the Datatable
+                    ds.SetLocaleValue(_culture, _cultureUserSet);
+                    ds.CaseSensitive = CaseSensitive;
+                    ds.Namespace = Namespace;
+                    ds.RemotingFormat = RemotingFormat;
+                    ds.Tables.Add(this);
+                }
+
+                if (writer != null)
+                {
+                    XmlTreeGen treeGen = new XmlTreeGen(SchemaFormat.Public);
+                    treeGen.Save(null, this, writer, writeHierarchy);
+                }
+                if (null != ds)
+                {
+                    ds.Tables.Remove(this);
+                    _tableNamespace = tablenamespace;
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        public void WriteXmlSchema(string fileName) => WriteXmlSchema(fileName, false);
+
+        public void WriteXmlSchema(string fileName, bool writeHierarchy)
+        {
+            XmlTextWriter xw = new XmlTextWriter(fileName, null);
+            try
+            {
+                xw.Formatting = Formatting.Indented;
+                xw.WriteStartDocument(true);
+                WriteXmlSchema(xw, writeHierarchy);
+                xw.WriteEndDocument();
+            }
+            finally
+            {
+                xw.Close();
+            }
+        }
+
+        public XmlReadMode ReadXml(Stream stream)
+        {
+            if (stream == null)
+            {
+                return XmlReadMode.Auto;
+            }
+
+            XmlTextReader xr = new XmlTextReader(stream);
+
+            // Prevent Dtd entity in DataTable 
+            xr.XmlResolver = null;
+
+            return ReadXml(xr, false);
+        }
+
+        public XmlReadMode ReadXml(TextReader reader)
+        {
+            if (reader == null)
+            {
+                return XmlReadMode.Auto;
+            }
+
+            XmlTextReader xr = new XmlTextReader(reader);
+
+            // Prevent Dtd entity in DataTable 
+            xr.XmlResolver = null;
+
+            return ReadXml(xr, false);
+        }
+
+        public XmlReadMode ReadXml(string fileName)
+        {
+            XmlTextReader xr = new XmlTextReader(fileName);
+
+            // Prevent Dtd entity in DataTable 
+            xr.XmlResolver = null;
+
+            try
+            {
+                return ReadXml(xr, false);
+            }
+            finally
+            {
+                xr.Close();
+            }
+        }
+
+        public XmlReadMode ReadXml(XmlReader reader) => ReadXml(reader, false);
+
+        private void RestoreConstraint(bool originalEnforceConstraint)
+        {
+            if (DataSet != null)
+            {
+                DataSet.EnforceConstraints = originalEnforceConstraint;
+            }
+            else
+            {
+                EnforceConstraints = originalEnforceConstraint;
+            }
+        }
+
+        private bool IsEmptyXml(XmlReader reader)
+        {
+            if (reader.IsEmptyElement)
+            {
+                if (reader.AttributeCount == 0 || (reader.LocalName == Keywords.DIFFGRAM && reader.NamespaceURI == Keywords.DFFNS))
+                {
+                    return true;
+                }
+                if (reader.AttributeCount == 1)
+                {
+                    reader.MoveToAttribute(0);
+                    if ((Namespace == reader.Value) &&
+                        (Prefix == reader.LocalName) &&
+                        (reader.Prefix == Keywords.XMLNS) &&
+                        (reader.NamespaceURI == Keywords.XSD_XMLNS_NS))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        internal XmlReadMode ReadXml(XmlReader reader, bool denyResolving)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.ReadXml|INFO> {0}, denyResolving={1}", ObjectID, denyResolving);
+            try
+            {
+                RowDiffIdUsageSection rowDiffIdUsage = new RowDiffIdUsageSection();
+                try
+                {
+                    bool fDataFound = false;
+                    bool fSchemaFound = false;
+                    bool fDiffsFound = false;
+                    bool fIsXdr = false;
+                    int iCurrentDepth = -1;
+                    XmlReadMode ret = XmlReadMode.Auto;
+
+                    // clear the hashtable to avoid conflicts between diffgrams, SqlHotFix 782
+                    rowDiffIdUsage.Prepare(this);
+
+                    if (reader == null)
+                    {
+                        return ret;
+                    }
+
+                    bool originalEnforceConstraint = false;
+                    if (DataSet != null)
+                    {
+                        originalEnforceConstraint = DataSet.EnforceConstraints;
+                        DataSet.EnforceConstraints = false;
+                    }
+                    else
+                    {
+                        originalEnforceConstraint = EnforceConstraints;
+                        EnforceConstraints = false;
+                    }
+
+                    if (reader is XmlTextReader)
+                    {
+                        ((XmlTextReader)reader).WhitespaceHandling = WhitespaceHandling.Significant;
+                    }
+
+                    XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+                    XmlDataLoader xmlload = null;
+
+                    reader.MoveToContent();
+                    if (Columns.Count == 0)
+                    {
+                        if (IsEmptyXml(reader))
+                        {
+                            reader.Read();
+                            return ret;
+                        }
+                    }
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        iCurrentDepth = reader.Depth;
+
+                        if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                        {
+                            if (Columns.Count == 0)
+                            {
+                                if (reader.IsEmptyElement)
+                                {
+                                    reader.Read();
+                                    return XmlReadMode.DiffGram;
+                                }
+                                throw ExceptionBuilder.DataTableInferenceNotSupported();
+                            }
+                            ReadXmlDiffgram(reader);
+                            // read the closing tag of the current element
+                            ReadEndElement(reader);
+
+                            RestoreConstraint(originalEnforceConstraint);
+                            return XmlReadMode.DiffGram;
+                        }
+
+                        // if reader points to the schema load it
+                        if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                        {
+                            // load XDR schema and exit
+                            ReadXDRSchema(reader);
+
+                            RestoreConstraint(originalEnforceConstraint);
+                            return XmlReadMode.ReadSchema; //since the top level element is a schema return
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                        {
+                            // load XSD schema and exit
+                            ReadXmlSchema(reader, denyResolving);
+                            RestoreConstraint(originalEnforceConstraint);
+                            return XmlReadMode.ReadSchema; //since the top level element is a schema return
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                        {
+                            if (DataSet != null)
+                            { // we should not throw for constraint, we already will throw for unsupported schema, so restore enforce cost, but not via property
+                                DataSet.RestoreEnforceConstraints(originalEnforceConstraint);
+                            }
+                            else
+                            {
+                                _enforceConstraints = originalEnforceConstraint;
+                            }
+
+                            throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                        }
+
+                        // now either the top level node is a table and we load it through dataReader...
+
+                        // ... or backup the top node and all its attributes because we may need to InferSchema
+                        XmlElement topNode = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                        if (reader.HasAttributes)
+                        {
+                            int attrCount = reader.AttributeCount;
+                            for (int i = 0; i < attrCount; i++)
+                            {
+                                reader.MoveToAttribute(i);
+                                if (reader.NamespaceURI.Equals(Keywords.XSD_XMLNS_NS))
+                                {
+                                    topNode.SetAttribute(reader.Name, reader.GetAttribute(i));
+                                }
+                                else
+                                {
+                                    XmlAttribute attr = topNode.SetAttributeNode(reader.LocalName, reader.NamespaceURI);
+                                    attr.Prefix = reader.Prefix;
+                                    attr.Value = reader.GetAttribute(i);
+                                }
+                            }
+                        }
+                        reader.Read();
+
+                        while (MoveToElement(reader, iCurrentDepth))
+                        {
+                            if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                            {
+                                ReadXmlDiffgram(reader);
+                                // read the closing tag of the current element
+                                ReadEndElement(reader);
+                                RestoreConstraint(originalEnforceConstraint);
+                                return XmlReadMode.DiffGram;
+                            }
+
+                            // if reader points to the schema load it...
+
+
+                            if (!fSchemaFound && !fDataFound && reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                            {
+                                // load XDR schema and exit
+                                ReadXDRSchema(reader);
+                                fSchemaFound = true;
+                                fIsXdr = true;
+                                continue;
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                            {
+                                // load XSD schema and exit
+                                ReadXmlSchema(reader, denyResolving);
+                                fSchemaFound = true;
+                                continue;
+                            }
+
+                            if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                            {
+                                if (DataSet != null)
+                                {
+                                    // we should not throw for constraint, we already will throw for unsupported schema, so restore enforce cost, but not via property
+                                    DataSet.RestoreEnforceConstraints(originalEnforceConstraint);
+                                }
+                                else
+                                {
+                                    _enforceConstraints = originalEnforceConstraint;
+                                }
+                                throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                            }
+
+                            if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                            {
+                                ReadXmlDiffgram(reader);
+                                fDiffsFound = true;
+                                ret = XmlReadMode.DiffGram;
+                            }
+                            else
+                            {
+                                // we found data here
+                                fDataFound = true;
+
+                                if (!fSchemaFound && Columns.Count == 0)
+                                {
+                                    XmlNode node = xdoc.ReadNode(reader);
+                                    topNode.AppendChild(node);
+                                }
+                                else
+                                {
+                                    if (xmlload == null)
+                                    {
+                                        xmlload = new XmlDataLoader(this, fIsXdr, topNode, false);
+                                    }
+                                    xmlload.LoadData(reader);
+                                    ret = fSchemaFound ? XmlReadMode.ReadSchema : XmlReadMode.IgnoreSchema;
+                                }
+                            }
+                        }
+                        // read the closing tag of the current element
+                        ReadEndElement(reader);
+
+                        // now top node contains the data part
+                        xdoc.AppendChild(topNode);
+
+                        if (!fSchemaFound && Columns.Count == 0)
+                        {
+                            if (IsEmptyXml(reader))
+                            {
+                                reader.Read();
+                                return ret;
+                            }
+                            throw ExceptionBuilder.DataTableInferenceNotSupported();
+                        }
+
+                        if (xmlload == null)
+                            xmlload = new XmlDataLoader(this, fIsXdr, false);
+
+                        // so we InferSchema
+                        if (!fDiffsFound)
+                        {
+                            // we need to add support for inference here
+                        }
+                    }
+                    RestoreConstraint(originalEnforceConstraint);
+                    return ret;
+                }
+                finally
+                {
+                    rowDiffIdUsage.Cleanup();
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        internal XmlReadMode ReadXml(XmlReader reader, XmlReadMode mode, bool denyResolving)
+        {
+            RowDiffIdUsageSection rowDiffIdUsage = new RowDiffIdUsageSection();
+            try
+            {
+                bool fSchemaFound = false;
+                bool fDataFound = false;
+                bool fIsXdr = false;
+                int iCurrentDepth = -1;
+                XmlReadMode ret = mode;
+
+                // prepare and cleanup rowDiffId hashtable
+                rowDiffIdUsage.Prepare(this);
+
+                if (reader == null)
+                {
+                    return ret;
+                }
+
+                bool originalEnforceConstraint = false;
+                if (DataSet != null)
+                {
+                    originalEnforceConstraint = DataSet.EnforceConstraints;
+                    DataSet.EnforceConstraints = false;
+                }
+                else
+                {
+                    originalEnforceConstraint = EnforceConstraints;
+                    EnforceConstraints = false;
+                }
+
+                if (reader is XmlTextReader)
+                    ((XmlTextReader)reader).WhitespaceHandling = WhitespaceHandling.Significant;
+
+                XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+
+                if ((mode != XmlReadMode.Fragment) && (reader.NodeType == XmlNodeType.Element))
+                {
+                    iCurrentDepth = reader.Depth;
+                }
+
+                reader.MoveToContent();
+                if (Columns.Count == 0)
+                {
+                    if (IsEmptyXml(reader))
+                    {
+                        reader.Read();
+                        return ret;
+                    }
+                }
+
+                XmlDataLoader xmlload = null;
+
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    XmlElement topNode = null;
+                    if (mode == XmlReadMode.Fragment)
+                    {
+                        xdoc.AppendChild(xdoc.CreateElement("ds_sqlXmlWraPPeR"));
+                        topNode = xdoc.DocumentElement;
+                    }
+                    else
+                    {
+                        //handle the top node
+                        if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                        {
+                            if ((mode == XmlReadMode.DiffGram) || (mode == XmlReadMode.IgnoreSchema))
+                            {
+                                if (Columns.Count == 0)
+                                {
+                                    if (reader.IsEmptyElement)
+                                    {
+                                        reader.Read();
+                                        return XmlReadMode.DiffGram;
+                                    }
+                                    throw ExceptionBuilder.DataTableInferenceNotSupported();
+                                }
+                                ReadXmlDiffgram(reader);
+                                // read the closing tag of the current element
+                                ReadEndElement(reader);
+                            }
+                            else
+                            {
+                                reader.Skip();
+                            }
+                            RestoreConstraint(originalEnforceConstraint);
+                            return ret;
+                        }
+
+                        if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                        {
+                            // load XDR schema and exit
+                            if ((mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema))
+                            {
+                                ReadXDRSchema(reader);
+                            }
+                            else
+                            {
+                                reader.Skip();
+                            }
+                            RestoreConstraint(originalEnforceConstraint);
+                            return ret; //since the top level element is a schema return
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                        {
+                            // load XSD schema and exit
+                            if ((mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema))
+                            {
+                                ReadXmlSchema(reader, denyResolving);
+                            }
+                            else
+                            {
+                                reader.Skip();
+                            }
+
+                            RestoreConstraint(originalEnforceConstraint);
+                            return ret; //since the top level element is a schema return
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                        {
+                            if (DataSet != null)
+                            {
+                                // we should not throw for constraint, we already will throw for unsupported schema, so restore enforce cost, but not via property
+                                DataSet.RestoreEnforceConstraints(originalEnforceConstraint);
+                            }
+                            else
+                            {
+                                _enforceConstraints = originalEnforceConstraint;
+                            }
+                            throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                        }
+
+                        // now either the top level node is a table and we load it through dataReader...
+                        // ... or backup the top node and all its attributes
+                        topNode = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                        if (reader.HasAttributes)
+                        {
+                            int attrCount = reader.AttributeCount;
+                            for (int i = 0; i < attrCount; i++)
+                            {
+                                reader.MoveToAttribute(i);
+                                if (reader.NamespaceURI.Equals(Keywords.XSD_XMLNS_NS))
+                                {
+                                    topNode.SetAttribute(reader.Name, reader.GetAttribute(i));
+                                }
+                                else
+                                {
+                                    XmlAttribute attr = topNode.SetAttributeNode(reader.LocalName, reader.NamespaceURI);
+                                    attr.Prefix = reader.Prefix;
+                                    attr.Value = reader.GetAttribute(i);
+                                }
+                            }
+                        }
+                        reader.Read();
+                    }
+
+                    while (MoveToElement(reader, iCurrentDepth))
+                    {
+                        if (reader.LocalName == Keywords.XDR_SCHEMA && reader.NamespaceURI == Keywords.XDRNS)
+                        {
+                            // load XDR schema
+                            if (!fSchemaFound && !fDataFound && (mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema))
+                            {
+                                ReadXDRSchema(reader);
+                                fSchemaFound = true;
+                                fIsXdr = true;
+                            }
+                            else
+                            {
+                                reader.Skip();
+                            }
+                            continue;
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+                        {
+                            // load XSD schema and exit
+                            if ((mode != XmlReadMode.IgnoreSchema) && (mode != XmlReadMode.InferSchema))
+                            {
+                                ReadXmlSchema(reader, denyResolving);
+                                fSchemaFound = true;
+                            }
+                            else
+                            {
+                                reader.Skip();
+                            }
+                            continue;
+                        }
+
+                        if ((reader.LocalName == Keywords.DIFFGRAM) && (reader.NamespaceURI == Keywords.DFFNS))
+                        {
+                            if ((mode == XmlReadMode.DiffGram) || (mode == XmlReadMode.IgnoreSchema))
+                            {
+                                if (Columns.Count == 0)
+                                {
+                                    if (reader.IsEmptyElement)
+                                    {
+                                        reader.Read();
+                                        return XmlReadMode.DiffGram;
+                                    }
+                                    throw ExceptionBuilder.DataTableInferenceNotSupported();
+                                }
+                                ReadXmlDiffgram(reader);
+                                ret = XmlReadMode.DiffGram;
+                            }
+                            else
+                            {
+                                reader.Skip();
+                            }
+                            continue;
+                        }
+
+                        if (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI.StartsWith(Keywords.XSD_NS_START, StringComparison.Ordinal))
+                        {
+                            if (DataSet != null)
+                            {
+                                // we should not throw for constraint, we already will throw for unsupported schema, so restore enforce cost, but not via property
+                                DataSet.RestoreEnforceConstraints(originalEnforceConstraint);
+                            }
+                            else
+                            {
+                                _enforceConstraints = originalEnforceConstraint;
+                            }
+                            throw ExceptionBuilder.DataSetUnsupportedSchema(Keywords.XSDNS);
+                        }
+
+                        if (mode == XmlReadMode.DiffGram)
+                        {
+                            reader.Skip();
+                            continue; // we do not read data in diffgram mode
+                        }
+
+                        // if we are here we found some data
+                        fDataFound = true;
+
+                        if (mode == XmlReadMode.InferSchema)
+                        {
+                            //save the node in DOM until the end;
+                            XmlNode node = xdoc.ReadNode(reader);
+                            topNode.AppendChild(node);
+                        }
+                        else
+                        {
+                            if (Columns.Count == 0)
+                            {
+                                throw ExceptionBuilder.DataTableInferenceNotSupported();
+                            }
+                            if (xmlload == null)
+                            {
+                                xmlload = new XmlDataLoader(this, fIsXdr, topNode, mode == XmlReadMode.IgnoreSchema);
+                            }
+                            xmlload.LoadData(reader);
+                        }
+                    } //end of the while
+
+                    // read the closing tag of the current element
+                    ReadEndElement(reader);
+
+                    // now top node contains the data part
+                    xdoc.AppendChild(topNode);
+
+                    if (xmlload == null)
+                    {
+                        xmlload = new XmlDataLoader(this, fIsXdr, mode == XmlReadMode.IgnoreSchema);
+                    }
+
+                    if (mode == XmlReadMode.DiffGram)
+                    {
+                        // we already got the diffs through XmlReader interface
+                        RestoreConstraint(originalEnforceConstraint);
+                        return ret;
+                    }
+
+                    // Load Data
+                    if (mode == XmlReadMode.InferSchema)
+                    {
+                        if (Columns.Count == 0)
+                        {
+                            throw ExceptionBuilder.DataTableInferenceNotSupported();
+                        }
+                    }
+                }
+                RestoreConstraint(originalEnforceConstraint);
+
+                return ret;
+            }
+            finally
+            {
+                // prepare and cleanup rowDiffId hashtable
+                rowDiffIdUsage.Cleanup();
+            }
+        }
+
+        internal void ReadEndElement(XmlReader reader)
+        {
+            while (reader.NodeType == XmlNodeType.Whitespace)
+            {
+                reader.Skip();
+            }
+            if (reader.NodeType == XmlNodeType.None)
+            {
+                reader.Skip();
+            }
+            else if (reader.NodeType == XmlNodeType.EndElement)
+            {
+                reader.ReadEndElement();
+            }
+        }
+        internal void ReadXDRSchema(XmlReader reader)
+        {
+            XmlDocument xdoc = new XmlDocument(); // we may need this to infer the schema
+            XmlNode schNode = xdoc.ReadNode(reader); ;
+            //consume and ignore it - No support
+        }
+
+        internal bool MoveToElement(XmlReader reader, int depth)
+        {
+            while (!reader.EOF && reader.NodeType != XmlNodeType.EndElement && reader.NodeType != XmlNodeType.Element && reader.Depth > depth)
+            {
+                reader.Read();
+            }
+            return (reader.NodeType == XmlNodeType.Element);
+        }
+        private void ReadXmlDiffgram(XmlReader reader)
+        {
+            // fill correctly
+            int d = reader.Depth;
+            bool fEnforce = EnforceConstraints;
+            EnforceConstraints = false;
+            DataTable newDt;
+            bool isEmpty;
+
+            if (Rows.Count == 0)
+            {
+                isEmpty = true;
+                newDt = this;
+            }
+            else
+            {
+                isEmpty = false;
+                newDt = Clone();
+                newDt.EnforceConstraints = false;
+            }
+
+            newDt.Rows._nullInList = 0;
+
+            reader.MoveToContent();
+
+            if ((reader.LocalName != Keywords.DIFFGRAM) && (reader.NamespaceURI != Keywords.DFFNS))
+            {
+                return;
+            }
+
+            reader.Read();
+            if (reader.NodeType == XmlNodeType.Whitespace)
+            {
+                MoveToElement(reader, reader.Depth - 1 /*iCurrentDepth*/); // skip over whitespace.
+            }
+
+            newDt._fInLoadDiffgram = true;
+
+            if (reader.Depth > d)
+            {
+                if ((reader.NamespaceURI != Keywords.DFFNS) && (reader.NamespaceURI != Keywords.MSDNS))
+                {
+                    //we should be inside the dataset part
+                    XmlDocument xdoc = new XmlDocument();
+                    XmlElement node = xdoc.CreateElement(reader.Prefix, reader.LocalName, reader.NamespaceURI);
+                    reader.Read();
+                    if (reader.Depth - 1 > d)
+                    {
+                        XmlDataLoader xmlload = new XmlDataLoader(newDt, false, node, false);
+                        xmlload._isDiffgram = true; // turn on the special processing
+                        xmlload.LoadData(reader);
+                    }
+                    ReadEndElement(reader);
+                }
+
+                if (((reader.LocalName == Keywords.SQL_BEFORE) && (reader.NamespaceURI == Keywords.DFFNS)) ||
+                    ((reader.LocalName == Keywords.MSD_ERRORS) && (reader.NamespaceURI == Keywords.DFFNS)))
+                {
+                    //this will consume the changes and the errors part
+                    XMLDiffLoader diffLoader = new XMLDiffLoader();
+                    diffLoader.LoadDiffGram(newDt, reader);
+                }
+
+                // get to the closing diff tag
+                while (reader.Depth > d)
+                {
+                    reader.Read();
+                }
+
+                // read the closing tag
+                ReadEndElement(reader);
+            }
+
+            if (newDt.Rows._nullInList > 0)
+            {
+                throw ExceptionBuilder.RowInsertMissing(newDt.TableName);
+            }
+
+            newDt._fInLoadDiffgram = false;
+            List<DataTable> tableList = new List<DataTable>();
+            tableList.Add(this);
+            CreateTableList(this, tableList);
+
+            // this is terrible, optimize it
+            for (int i = 0; i < tableList.Count; i++)
+            {
+                DataRelation[] relations = tableList[i].NestedParentRelations;
+                foreach (DataRelation rel in relations)
+                {
+                    if (rel != null && rel.ParentTable == tableList[i])
+                    {
+                        foreach (DataRow r in tableList[i].Rows)
+                        {
+                            foreach (DataRelation rel2 in relations)
+                            {
+                                r.CheckForLoops(rel2);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!isEmpty)
+            {
+                Merge(newDt);
+            }
+            EnforceConstraints = fEnforce;
+        }
+
+        internal void ReadXSDSchema(XmlReader reader, bool denyResolving)
+        {
+            XmlSchemaSet sSet = new XmlSchemaSet();
+            while (reader.LocalName == Keywords.XSD_SCHEMA && reader.NamespaceURI == Keywords.XSDNS)
+            {
+                XmlSchema s = XmlSchema.Read(reader, null);
+                sSet.Add(s);
+                //read the end tag
+                ReadEndElement(reader);
+            }
+            sSet.Compile();
+
+            XSDSchema schema = new XSDSchema();
+            schema.LoadSchema(sSet, this);
+        }
+
+        public void ReadXmlSchema(Stream stream)
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            ReadXmlSchema(new XmlTextReader(stream), false);
+        }
+
+        public void ReadXmlSchema(TextReader reader)
+        {
+            if (reader == null)
+            {
+                return;
+            }
+
+            ReadXmlSchema(new XmlTextReader(reader), false);
+        }
+
+        public void ReadXmlSchema(string fileName)
+        {
+            XmlTextReader xr = new XmlTextReader(fileName);
+            try
+            {
+                ReadXmlSchema(xr, false);
+            }
+            finally
+            {
+                xr.Close();
+            }
+        }
+
+        public void ReadXmlSchema(XmlReader reader)
+        {
+            ReadXmlSchema(reader, false);
+        }
+
+        internal void ReadXmlSchema(XmlReader reader, bool denyResolving)
+        {
+            long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.ReadXmlSchema|INFO> {0}, denyResolving={1}", ObjectID, denyResolving);
+            try
+            {
+                DataSet ds = new DataSet();
+                SerializationFormat cachedRemotingFormat = RemotingFormat;
+                // fxcop: ReadXmlSchema will provide the CaseSensitive, Locale, Namespace information
+                ds.ReadXmlSchema(reader, denyResolving);
+
+                string CurrentTableFullName = ds.MainTableName;
+
+                if (string.IsNullOrEmpty(_tableName) && string.IsNullOrEmpty(CurrentTableFullName))
+                {
+                    return;
+                }
+
+                DataTable currentTable = null;
+
+                if (!string.IsNullOrEmpty(_tableName))
+                {
+                    if (!string.IsNullOrEmpty(Namespace))
+                    {
+                        currentTable = ds.Tables[_tableName, Namespace];
+                    }
+                    else
+                    {
+                        int tableIndex = ds.Tables.InternalIndexOf(_tableName);
+                        if (tableIndex > -1)
+                        {
+                            currentTable = ds.Tables[tableIndex];
+                        }
+                    }
+                }
+                else
+                {
+                    string CurrentTableNamespace = string.Empty;
+                    int nsSeperator = CurrentTableFullName.IndexOf(':');
+                    if (nsSeperator > -1)
+                    {
+                        CurrentTableNamespace = CurrentTableFullName.Substring(0, nsSeperator);
+                    }
+                    string CurrentTableName = CurrentTableFullName.Substring(nsSeperator + 1, CurrentTableFullName.Length - nsSeperator - 1);
+
+                    currentTable = ds.Tables[CurrentTableName, CurrentTableNamespace];
+                }
+
+                if (currentTable == null)
+                {
+                    string qTableName = string.Empty;
+                    if (!string.IsNullOrEmpty(_tableName))
+                    {
+                        qTableName = (Namespace.Length > 0) ? (Namespace + ":" + _tableName) : _tableName;
+                    }
+                    else
+                    {
+                        qTableName = CurrentTableFullName;
+                    }
+                    throw ExceptionBuilder.TableNotFound(qTableName);
+                }
+
+                currentTable._remotingFormat = cachedRemotingFormat;
+
+                List<DataTable> tableList = new List<DataTable>();
+                tableList.Add(currentTable);
+                CreateTableList(currentTable, tableList);
+                List<DataRelation> relationList = new List<DataRelation>();
+                CreateRelationList(tableList, relationList);
+
+                if (relationList.Count == 0)
+                {
+                    if (Columns.Count == 0)
+                    {
+                        DataTable tempTable = currentTable;
+                        if (tempTable != null)
+                        {
+                            tempTable.CloneTo(this, null, false); // we may have issue Amir
+                        }
+
+                        if (DataSet == null && _tableNamespace == null)
+                        {
+                            // for standalone table, clone won't get these correctly, since they may come with inheritance
+                            _tableNamespace = tempTable.Namespace;
+                        }
+                    }
+                    return;
+                }
+                else
+                {
+                    if (string.IsNullOrEmpty(TableName))
+                    {
+                        TableName = currentTable.TableName;
+                        if (!string.IsNullOrEmpty(currentTable.Namespace))
+                        {
+                            Namespace = currentTable.Namespace;
+                        }
+                    }
+                    if (DataSet == null)
+                    {
+                        DataSet dataset = new DataSet(ds.DataSetName);
+
+                        // if user set values on DataTable, it isn't necessary
+                        // to set them on the DataSet because they won't be inherited
+                        // but it is simpler to set them in both places
+
+                        // if user did not set values on DataTable, it is required
+                        // to set them on the DataSet so the table will inherit
+                        // the value already on the Datatable
+                        dataset.SetLocaleValue(ds.Locale, ds.ShouldSerializeLocale());
+                        dataset.CaseSensitive = ds.CaseSensitive;
+                        dataset.Namespace = ds.Namespace;
+                        dataset._mainTableName = ds._mainTableName;
+                        dataset.RemotingFormat = ds.RemotingFormat;
+
+                        dataset.Tables.Add(this);
+                    }
+
+                    DataTable targetTable = CloneHierarchy(currentTable, DataSet, null);
+
+                    foreach (DataTable tempTable in tableList)
+                    {
+                        DataTable destinationTable = DataSet.Tables[tempTable._tableName, tempTable.Namespace];
+                        DataTable sourceTable = ds.Tables[tempTable._tableName, tempTable.Namespace];
+                        foreach (Constraint tempConstrain in sourceTable.Constraints)
+                        {
+                            ForeignKeyConstraint fkc = tempConstrain as ForeignKeyConstraint;  // we have already cloned the UKC when cloning the datatable
+                            if (fkc != null)
+                            {
+                                if (fkc.Table != fkc.RelatedTable)
+                                {
+                                    if (tableList.Contains(fkc.Table) && tableList.Contains(fkc.RelatedTable))
+                                    {
+                                        ForeignKeyConstraint newFKC = (ForeignKeyConstraint)fkc.Clone(destinationTable.DataSet);
+                                        if (!destinationTable.Constraints.Contains(newFKC.ConstraintName))
+                                        {
+                                            destinationTable.Constraints.Add(newFKC); // we know that the dest table is already in the table
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    foreach (DataRelation rel in relationList)
+                    {
+                        if (!DataSet.Relations.Contains(rel.RelationName))
+                        {
+                            DataSet.Relations.Add(rel.Clone(DataSet));
+                        }
+                    }
+
+                    bool hasExternaldependency = false;
+
+                    foreach (DataTable tempTable in tableList)
+                    {
+                        foreach (DataColumn dc in tempTable.Columns)
+                        {
+                            hasExternaldependency = false;
+                            if (dc.Expression.Length != 0)
+                            {
+                                DataColumn[] dependency = dc.DataExpression.GetDependency();
+                                for (int j = 0; j < dependency.Length; j++)
+                                {
+                                    if (!tableList.Contains(dependency[j].Table))
+                                    {
+                                        hasExternaldependency = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (!hasExternaldependency)
+                            {
+                                DataSet.Tables[tempTable.TableName, tempTable.Namespace].Columns[dc.ColumnName].Expression = dc.Expression;
+                            }
+                        }
+                        hasExternaldependency = false;
+                    }
+                }
+            }
+            finally
+            {
+                DataCommonEventSource.Log.ExitScope(logScopeId);
+            }
+        }
+
+        private void CreateTableList(DataTable currentTable, List<DataTable> tableList)
+        {
+            foreach (DataRelation r in currentTable.ChildRelations)
+            {
+                if (!tableList.Contains(r.ChildTable))
+                {
+                    tableList.Add(r.ChildTable);
+                    CreateTableList(r.ChildTable, tableList);
+                }
+            }
+        }
+        private void CreateRelationList(List<DataTable> tableList, List<DataRelation> relationList)
+        {
+            foreach (DataTable table in tableList)
+            {
+                foreach (DataRelation r in table.ChildRelations)
+                {
+                    if (tableList.Contains(r.ChildTable) && tableList.Contains(r.ParentTable))
+                    {
+                        relationList.Add(r);
+                    }
+                }
+            }
+        }
+
+        public static XmlSchemaComplexType GetDataTableSchema(XmlSchemaSet schemaSet)
+        {
+            XmlSchemaComplexType type = new XmlSchemaComplexType();
+            XmlSchemaSequence sequence = new XmlSchemaSequence();
+            XmlSchemaAny any = new XmlSchemaAny();
+            any.Namespace = XmlSchema.Namespace;
+            any.MinOccurs = 0;
+            any.MaxOccurs = decimal.MaxValue;
+            any.ProcessContents = XmlSchemaContentProcessing.Lax;
+            sequence.Items.Add(any);
+
+            any = new XmlSchemaAny();
+            any.Namespace = Keywords.DFFNS;
+            any.MinOccurs = 1; // when recognizing WSDL - MinOccurs="0" denotes DataSet, a MinOccurs="1" for DataTable
+            any.ProcessContents = XmlSchemaContentProcessing.Lax;
+            sequence.Items.Add(any);
+
+            type.Particle = sequence;
+
+            return type;
+        }
+
+        XmlSchema IXmlSerializable.GetSchema() => GetSchema();
+
+        protected virtual XmlSchema GetSchema()
+        {
+            if (GetType() == typeof(DataTable))
+            {
+                return null;
+            }
+            MemoryStream stream = new MemoryStream();
+
+            XmlWriter writer = new XmlTextWriter(stream, null);
+            if (writer != null)
+            {
+                (new XmlTreeGen(SchemaFormat.WebService)).Save(this, writer);
+            }
+            stream.Position = 0;
+            return XmlSchema.Read(new XmlTextReader(stream), null);
+        }
+
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            IXmlTextParser textReader = reader as IXmlTextParser;
+            bool fNormalization = true;
+            if (textReader != null)
+            {
+                fNormalization = textReader.Normalized;
+                textReader.Normalized = false;
+            }
+            ReadXmlSerializable(reader);
+
+            if (textReader != null)
+            {
+                textReader.Normalized = fNormalization;
+            }
+        }
+
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            WriteXmlSchema(writer, false);
+            WriteXml(writer, XmlWriteMode.DiffGram, false);
+        }
+
+        protected virtual void ReadXmlSerializable(XmlReader reader) => ReadXml(reader, XmlReadMode.DiffGram, true);
+
+        // RowDiffIdUsageSection & DSRowDiffIdUsageSection Usage:
+        //
+        //        DataTable.[DS]RowDiffIdUsageSection rowDiffIdUsage = new DataTable.[DS]RowDiffIdUsageSection();
+        //        try {
+        //            rowDiffIdUsage.Prepare(DataTable or DataSet, depending on type);
+        //
+        //            // code that requires RowDiffId usage
+        //
+        //        }
+        //        finally {
+        //            rowDiffIdUsage.Cleanup();
+        //        }
+        // 
+        // Nested calls are allowed on different tables. For example, user can register to row change events and trigger 
+        // ReadXml on different table/ds). But, if user code will try to call ReadXml on table that is already in the scope,
+        // this code will assert since nested calls on same table are unsupported.
+        internal struct RowDiffIdUsageSection
+        {
+#if DEBUG
+            // This list contains tables currently used in diffgram processing, not including new tables that might be added later during.
+            // if diffgram processing is not started, this value must be null. when it starts, relevant method should call Prepare.
+            // Notes:
+            // * in case of ReadXml on empty DataSet, this list can be initialized as empty (so empty list != null).
+            // * only one scope is allowed on single thread, either for datatable or dataset
+            // * assert is triggered if same table is added to this list twice
+            // 
+            // do not allocate TLS data in RETAIL bits!
+            [ThreadStatic]
+            internal static List<DataTable> t_usedTables;
+#endif //DEBUG
+
+            private DataTable _targetTable;
+
+            internal void Prepare(DataTable table)
+            {
+                Debug.Assert(_targetTable == null, "do not reuse this section");
+                Debug.Assert(table != null);
+                Debug.Assert(table._rowDiffId == null, "rowDiffId wasn't previously cleared");
+#if DEBUG
+                Debug.Assert(t_usedTables == null || !t_usedTables.Contains(table),
+                    "Nested call with same table can cause data corruption!");
+#endif
+
+#if DEBUG
+                if (t_usedTables == null)
+                    t_usedTables = new List<DataTable>();
+                t_usedTables.Add(table);
+#endif
+                _targetTable = table;
+                table._rowDiffId = null;
+            }
+
+            [Conditional("DEBUG")]
+            internal void Cleanup()
+            {
+                // cannot assume target table was set
+                if (_targetTable != null)
+                {
+#if DEBUG
+                    Debug.Assert(t_usedTables != null && t_usedTables.Contains(_targetTable), "missing Prepare before Cleanup");
+                    if (t_usedTables != null)
+                    {
+                        t_usedTables.Remove(_targetTable);
+                        if (t_usedTables.Count == 0)
+                            t_usedTables = null;
+                    }
+#endif
+                    _targetTable._rowDiffId = null;
+                }
+            }
+
+            [Conditional("DEBUG")]
+            internal static void Assert(string message)
+            {
+#if DEBUG
+                // this code asserts scope was created, but it does not assert that the table was included in it
+                // note that in case of DataSet, new tables might be added to the list in which case they won't appear in t_usedTables.
+                Debug.Assert(t_usedTables != null, message);
+#endif
+            }
+        }
+
+        internal struct DSRowDiffIdUsageSection
+        {
+            private DataSet _targetDS;
+
+            internal void Prepare(DataSet ds)
+            {
+                Debug.Assert(_targetDS == null, "do not reuse this section");
+                Debug.Assert(ds != null);
+
+                _targetDS = ds;
+#if DEBUG
+                // initialize list of tables out of current tables
+                // note: it might remain empty (still initialization is needed for assert to operate)
+                if (RowDiffIdUsageSection.t_usedTables == null)
+                    RowDiffIdUsageSection.t_usedTables = new List<DataTable>();
+#endif 
+                for (int tableIndex = 0; tableIndex < ds.Tables.Count; ++tableIndex)
+                {
+                    DataTable table = ds.Tables[tableIndex];
+#if DEBUG
+                    Debug.Assert(!RowDiffIdUsageSection.t_usedTables.Contains(table), "Nested call with same table can cause data corruption!");
+                    RowDiffIdUsageSection.t_usedTables.Add(table);
+#endif
+                    Debug.Assert(table._rowDiffId == null, "rowDiffId wasn't previously cleared");
+                    table._rowDiffId = null;
+                }
+            }
+
+            [Conditional("DEBUG")]
+            internal void Cleanup()
+            {
+                // cannot assume target was set
+                if (_targetDS != null)
+                {
+#if DEBUG
+                    Debug.Assert(RowDiffIdUsageSection.t_usedTables != null, "missing Prepare before Cleanup");
+#endif
+
+                    for (int tableIndex = 0; tableIndex < _targetDS.Tables.Count; ++tableIndex)
+                    {
+                        DataTable table = _targetDS.Tables[tableIndex];
+#if DEBUG
+                        // cannot assert that table exists in the usedTables - new tables might be 
+                        // created during diffgram processing in DataSet.ReadXml.
+                        if (RowDiffIdUsageSection.t_usedTables != null)
+                            RowDiffIdUsageSection.t_usedTables.Remove(table);
+#endif
+                        table._rowDiffId = null;
+                    }
+#if DEBUG
+                    if (RowDiffIdUsageSection.t_usedTables != null && RowDiffIdUsageSection.t_usedTables.Count == 0)
+                        RowDiffIdUsageSection.t_usedTables = null; // out-of-scope
+#endif
+                }
+            }
+        }
+
+        internal Hashtable RowDiffId
+        {
+            get
+            {
+                // assert scope has been created either with RowDiffIdUsageSection.Prepare or DSRowDiffIdUsageSection.Prepare
+                RowDiffIdUsageSection.Assert("missing call to RowDiffIdUsageSection.Prepare or DSRowDiffIdUsageSection.Prepare");
+
+                if (_rowDiffId == null)
+                {
+                    _rowDiffId = new Hashtable();
+                }
+                return _rowDiffId;
+            }
+        }
+
+        internal int ObjectID => _objectID;
+
+        internal void AddDependentColumn(DataColumn expressionColumn)
+        {
+            if (_dependentColumns == null)
+            {
+                _dependentColumns = new List<DataColumn>();
+            }
+
+            if (!_dependentColumns.Contains(expressionColumn))
+            {
+                // only remember unique columns but expect non-unique columns to be added
+                _dependentColumns.Add(expressionColumn);
+            }
+        }
+
+        internal void RemoveDependentColumn(DataColumn expressionColumn)
+        {
+            if (_dependentColumns != null && _dependentColumns.Contains(expressionColumn))
+            {
+                _dependentColumns.Remove(expressionColumn);
+            }
+        }
+
+        internal void EvaluateExpressions()
+        {
+            // evaluates all expressions for all rows in table
+            // this improves performance by only computing expressions when they are present
+            // and iterating over the rows instead of computing their position multiple times
+            if ((null != _dependentColumns) && (0 < _dependentColumns.Count))
+            {
+                foreach (DataRow row in Rows)
+                {
+                    // only evaluate original values if different from current.
+                    if (row._oldRecord != -1 && row._oldRecord != row._newRecord)
+                    {
+                        EvaluateDependentExpressions(_dependentColumns, row, DataRowVersion.Original, null);
+                    }
+                    if (row._newRecord != -1)
+                    {
+                        EvaluateDependentExpressions(_dependentColumns, row, DataRowVersion.Current, null);
+                    }
+                    if (row._tempRecord != -1)
+                    {
+                        EvaluateDependentExpressions(_dependentColumns, row, DataRowVersion.Proposed, null);
+                    }
+                }
+            }
+        }
+
+        internal void EvaluateExpressions(DataRow row, DataRowAction action, List<DataRow> cachedRows)
+        {
+            // evaluate all expressions for specified row
+            if (action == DataRowAction.Add ||
+                action == DataRowAction.Change ||
+                (action == DataRowAction.Rollback && (row._oldRecord != -1 || row._newRecord != -1)))
+            {
+                // only evaluate original values if different from current.
+                if (row._oldRecord != -1 && row._oldRecord != row._newRecord)
+                {
+                    EvaluateDependentExpressions(_dependentColumns, row, DataRowVersion.Original, cachedRows);
+                }
+                if (row._newRecord != -1)
+                {
+                    EvaluateDependentExpressions(_dependentColumns, row, DataRowVersion.Current, cachedRows);
+                }
+                if (row._tempRecord != -1)
+                {
+                    EvaluateDependentExpressions(_dependentColumns, row, DataRowVersion.Proposed, cachedRows);
+                }
+                return;
+            }
+            else if ((action == DataRowAction.Delete || (action == DataRowAction.Rollback && row._oldRecord == -1 && row._newRecord == -1)) && _dependentColumns != null)
+            {
+                foreach (DataColumn col in _dependentColumns)
+                {
+                    if (col.DataExpression != null && col.DataExpression.HasLocalAggregate() && col.Table == this)
+                    {
+                        for (int j = 0; j < Rows.Count; j++)
+                        {
+                            DataRow tableRow = Rows[j];
+
+                            if (tableRow._oldRecord != -1 && tableRow._oldRecord != tableRow._newRecord)
+                            {
+                                EvaluateDependentExpressions(_dependentColumns, tableRow, DataRowVersion.Original, null);
+                            }
+                        }
+                        for (int j = 0; j < Rows.Count; j++)
+                        {
+                            DataRow tableRow = Rows[j];
+
+                            if (tableRow._tempRecord != -1)
+                            {
+                                EvaluateDependentExpressions(_dependentColumns, tableRow, DataRowVersion.Proposed, null);
+                            }
+                        }
+                        // Order is important here - we need to update proposed before current
+                        // Oherwise rows that are in edit state will get ListChanged/PropertyChanged event before default value is changed
+                        // It is also the reason why we are not doping it in the single loop: EvaluateDependentExpression can update the
+                        // whole table, if it happens, current for all but first row is updated before proposed value
+                        for (int j = 0; j < Rows.Count; j++)
+                        {
+                            DataRow tableRow = Rows[j];
+
+                            if (tableRow._newRecord != -1)
+                            {
+                                EvaluateDependentExpressions(_dependentColumns, tableRow, DataRowVersion.Current, null);
+                            }
+                        }
+                        break;
+                    }
+                }
+
+                if (cachedRows != null)
+                {
+                    foreach (DataRow relatedRow in cachedRows)
+                    {
+                        if (relatedRow._oldRecord != -1 && relatedRow._oldRecord != relatedRow._newRecord)
+                        {
+                            relatedRow.Table.EvaluateDependentExpressions(relatedRow.Table._dependentColumns, relatedRow, DataRowVersion.Original, null);
+                        }
+                        if (relatedRow._newRecord != -1)
+                        {
+                            relatedRow.Table.EvaluateDependentExpressions(relatedRow.Table._dependentColumns, relatedRow, DataRowVersion.Current, null);
+                        }
+                        if (relatedRow._tempRecord != -1)
+                        {
+                            relatedRow.Table.EvaluateDependentExpressions(relatedRow.Table._dependentColumns, relatedRow, DataRowVersion.Proposed, null);
+                        }
+                    }
+                }
+            }
+        }
+
+        internal void EvaluateExpressions(DataColumn column)
+        {
+            // evaluates all rows for expression from specified column
+            Debug.Assert(column.Computed, "Only computed columns should be re-evaluated.");
+            int count = column._table.Rows.Count;
+            if (column.DataExpression.IsTableAggregate() && count > 0)
+            {
+                // this value is a constant across the table.
+                object aggCurrent = column.DataExpression.Evaluate();
+                for (int j = 0; j < count; j++)
+                {
+                    DataRow row = column._table.Rows[j];
+                    // only evaluate original values if different from current.
+                    if (row._oldRecord != -1 && row._oldRecord != row._newRecord)
+                    {
+                        column[row._oldRecord] = aggCurrent;
+                    }
+                    if (row._newRecord != -1)
+                    {
+                        column[row._newRecord] = aggCurrent;
+                    }
+                    if (row._tempRecord != -1)
+                    {
+                        column[row._tempRecord] = aggCurrent;
+                    }
+                }
+            }
+            else
+            {
+                for (int j = 0; j < count; j++)
+                {
+                    DataRow row = column._table.Rows[j];
+
+                    if (row._oldRecord != -1 && row._oldRecord != row._newRecord)
+                    {
+                        column[row._oldRecord] = column.DataExpression.Evaluate(row, DataRowVersion.Original);
+                    }
+                    if (row._newRecord != -1)
+                    {
+                        column[row._newRecord] = column.DataExpression.Evaluate(row, DataRowVersion.Current);
+                    }
+                    if (row._tempRecord != -1)
+                    {
+                        column[row._tempRecord] = column.DataExpression.Evaluate(row, DataRowVersion.Proposed);
+                    }
+                }
+            }
+
+            column.Table.ResetInternalIndexes(column);
+            EvaluateDependentExpressions(column);
+        }
+
+        internal void EvaluateDependentExpressions(DataColumn column)
+        {
+            // DataTable.Clear(), DataRowCollection.Clear() & DataColumn.set_Expression
+            if (column._dependentColumns != null)
+            {
+                foreach (DataColumn dc in column._dependentColumns)
+                {
+                    if ((dc._table != null) && !ReferenceEquals(column, dc))
+                    {
+                        EvaluateExpressions(dc);
+                    }
+                }
+            }
+        }
+
+        internal void EvaluateDependentExpressions(List<DataColumn> columns, DataRow row, DataRowVersion version, List<DataRow> cachedRows)
+        {
+            if (columns == null)
+            {
+                return;
+            }
+
+            //Expression evaluation is done first over same table expressions.
+            int count = columns.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (columns[i].Table == this)
+                {
+                    // if this column is in my table
+                    DataColumn dc = columns[i];
+                    if (dc.DataExpression != null && dc.DataExpression.HasLocalAggregate())
+                    {
+                        // if column expression references a local Table aggregate we need to recalc it for the each row in the local table
+                        DataRowVersion expressionVersion = (version == DataRowVersion.Proposed) ? DataRowVersion.Default : version;
+                        bool isConst = dc.DataExpression.IsTableAggregate(); //is expression constant for entire table?
+                        object newValue = null;
+                        if (isConst)
+                        {
+                            //if new value, just compute once
+                            newValue = dc.DataExpression.Evaluate(row, expressionVersion);
+                        }
+                        for (int j = 0; j < Rows.Count; j++)
+                        {
+                            //evaluate for all rows in the table
+                            DataRow dr = Rows[j];
+                            if (dr.RowState == DataRowState.Deleted)
+                            {
+                                continue;
+                            }
+                            else if (expressionVersion == DataRowVersion.Original && (dr._oldRecord == -1 || dr._oldRecord == dr._newRecord))
+                            {
+                                continue;
+                            }
+
+                            if (!isConst)
+                            {
+                                newValue = dc.DataExpression.Evaluate(dr, expressionVersion);
+                            }
+                            SilentlySetValue(dr, dc, expressionVersion, newValue);
+                        }
+                    }
+                    else
+                    {
+                        if (row.RowState == DataRowState.Deleted)
+                        {
+                            continue;
+                        }
+                        else if (version == DataRowVersion.Original && (row._oldRecord == -1 || row._oldRecord == row._newRecord))
+                        {
+                            continue;
+                        }
+                        SilentlySetValue(row, dc, version, dc.DataExpression == null ? dc.DefaultValue : dc.DataExpression.Evaluate(row, version));
+                    }
+                }
+            }
+            // now do expression evaluation for expression columns other tables.
+            count = columns.Count;
+            for (int i = 0; i < count; i++)
+            {
+                DataColumn dc = columns[i];
+                // if this column is NOT in my table or it is in the table and is not a local aggregate (self refs)
+                if (dc.Table != this || (dc.DataExpression != null && !dc.DataExpression.HasLocalAggregate()))
+                {
+                    DataRowVersion foreignVer = (version == DataRowVersion.Proposed) ? DataRowVersion.Default : version;
+
+                    // first - evaluate expressions for cachedRows (deletes & updates)
+                    if (cachedRows != null)
+                    {
+                        foreach (DataRow cachedRow in cachedRows)
+                        {
+                            if (cachedRow.Table != dc.Table)
+                            {
+                                continue;
+                            }
+
+                            // don't update original version if child row doesn't have an oldRecord.
+                            if (foreignVer == DataRowVersion.Original && cachedRow._newRecord == cachedRow._oldRecord)
+                            {
+                                continue;
+                            }
+
+                            if (cachedRow != null && ((cachedRow.RowState != DataRowState.Deleted) && (version != DataRowVersion.Original || cachedRow._oldRecord != -1)))
+                            {
+                                // if deleted GetRecordFromVersion will throw
+                                object newValue = dc.DataExpression.Evaluate(cachedRow, foreignVer);
+                                SilentlySetValue(cachedRow, dc, foreignVer, newValue);
+                            }
+                        }
+                    }
+
+                    // next check parent relations
+                    for (int j = 0; j < ParentRelations.Count; j++)
+                    {
+                        DataRelation relation = ParentRelations[j];
+                        if (relation.ParentTable != dc.Table)
+                        {
+                            continue;
+                        }
+
+                        foreach (DataRow parentRow in row.GetParentRows(relation, version))
+                        {
+                            if (cachedRows != null && cachedRows.Contains(parentRow))
+                            {
+                                continue;
+                            }
+
+                            // don't update original version if child row doesn't have an oldRecord.
+                            if (foreignVer == DataRowVersion.Original && parentRow._newRecord == parentRow._oldRecord)
+                            {
+                                continue;
+                            }
+
+                            if (parentRow != null && ((parentRow.RowState != DataRowState.Deleted) && (version != DataRowVersion.Original || parentRow._oldRecord != -1)))
+                            {
+                                // if deleted GetRecordFromVersion will throw
+                                object newValue = dc.DataExpression.Evaluate(parentRow, foreignVer);
+                                SilentlySetValue(parentRow, dc, foreignVer, newValue);
+                            }
+                        }
+                    }
+
+                    // next check child relations
+                    for (int j = 0; j < ChildRelations.Count; j++)
+                    {
+                        DataRelation relation = ChildRelations[j];
+                        if (relation.ChildTable != dc.Table)
+                        {
+                            continue;
+                        }
+
+                        foreach (DataRow childRow in row.GetChildRows(relation, version))
+                        {
+                            // don't update original version if child row doesn't have an oldRecord.
+                            if (cachedRows != null && cachedRows.Contains(childRow))
+                            {
+                                continue;
+                            }
+
+                            if (foreignVer == DataRowVersion.Original && childRow._newRecord == childRow._oldRecord)
+                            {
+                                continue;
+                            }
+
+                            if (childRow != null && ((childRow.RowState != DataRowState.Deleted) && (version != DataRowVersion.Original || childRow._oldRecord != -1)))
+                            {
+                                // if deleted GetRecordFromVersion will throw
+                                object newValue = dc.DataExpression.Evaluate(childRow, foreignVer);
+                                SilentlySetValue(childRow, dc, foreignVer, newValue);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataTable.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataTable.cs
@@ -5669,9 +5669,11 @@ namespace System.Data
 
         internal XmlReadMode ReadXml(XmlReader reader, bool denyResolving)
         {
+            IDisposable? restrictedScope = null;
             long logScopeId = DataCommonEventSource.Log.EnterScope("<ds.DataTable.ReadXml|INFO> {0}, denyResolving={1}", ObjectID, denyResolving);
             try
             {
+                restrictedScope = TypeLimiter.EnterRestrictedScope(this);
                 RowDiffIdUsageSection rowDiffIdUsage = new RowDiffIdUsageSection();
                 try
                 {
@@ -5906,15 +5908,18 @@ namespace System.Data
             }
             finally
             {
+                restrictedScope?.Dispose();
                 DataCommonEventSource.Log.ExitScope(logScopeId);
             }
         }
 
         internal XmlReadMode ReadXml(XmlReader reader, XmlReadMode mode, bool denyResolving)
         {
+            IDisposable? restrictedScope = null;
             RowDiffIdUsageSection rowDiffIdUsage = new RowDiffIdUsageSection();
             try
             {
+                restrictedScope = TypeLimiter.EnterRestrictedScope(this);
                 bool fSchemaFound = false;
                 bool fDataFound = false;
                 bool fIsXdr = false;
@@ -6201,6 +6206,7 @@ namespace System.Data
             finally
             {
                 // prepare and cleanup rowDiffId hashtable
+                restrictedScope?.Dispose();
                 rowDiffIdUsage.Cleanup();
             }
         }

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
@@ -1,0 +1,721 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.SqlTypes;
+using System.Diagnostics;
+
+namespace System.Data
+{
+    internal sealed class FunctionNode : ExpressionNode
+    {
+        internal readonly string _name;
+        internal readonly int _info = -1;
+        internal int _argumentCount = 0;
+        internal const int initialCapacity = 1;
+        internal ExpressionNode[] _arguments;
+
+        private static readonly Function[] s_funcs = new Function[] {
+            new Function("Abs", FunctionId.Abs, typeof(object), true, false, 1, typeof(object), null, null),
+            new Function("IIf", FunctionId.Iif, typeof(object), false, false, 3, typeof(object), typeof(object), typeof(object)),
+            new Function("In", FunctionId.In, typeof(bool), false, true, 1, null, null, null),
+            new Function("IsNull", FunctionId.IsNull, typeof(object), false, false, 2, typeof(object), typeof(object), null),
+            new Function("Len", FunctionId.Len, typeof(int), true, false, 1, typeof(string), null, null),
+            new Function("Substring", FunctionId.Substring, typeof(string), true, false, 3, typeof(string), typeof(int), typeof(int)),
+            new Function("Trim", FunctionId.Trim, typeof(string), true, false, 1, typeof(string), null, null),
+            // convert
+            new Function("Convert", FunctionId.Convert, typeof(object), false, true, 1, typeof(object), null, null),
+            new Function("DateTimeOffset", FunctionId.DateTimeOffset, typeof(DateTimeOffset), false, true, 3, typeof(DateTime), typeof(int), typeof(int)),
+            // store aggregates here
+            new Function("Max", FunctionId.Max, typeof(object), false, false, 1, null, null, null),
+            new Function("Min", FunctionId.Min, typeof(object), false, false, 1, null, null, null),
+            new Function("Sum", FunctionId.Sum, typeof(object), false, false, 1, null, null, null),
+            new Function("Count", FunctionId.Count, typeof(object), false, false, 1, null, null, null),
+            new Function("Var", FunctionId.Var, typeof(object), false, false, 1, null, null, null),
+            new Function("StDev", FunctionId.StDev, typeof(object), false, false, 1, null, null, null),
+            new Function("Avg", FunctionId.Avg, typeof(object), false, false, 1, null, null, null),
+        };
+
+        internal FunctionNode(DataTable table, string name) : base(table)
+        {
+            _name = name;
+            for (int i = 0; i < s_funcs.Length; i++)
+            {
+                if (string.Compare(s_funcs[i]._name, name, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    // we found the reserved word..
+                    _info = i;
+                    break;
+                }
+            }
+            if (_info < 0)
+            {
+                throw ExprException.UndefinedFunction(_name);
+            }
+        }
+
+        internal void AddArgument(ExpressionNode argument)
+        {
+            if (!s_funcs[_info]._isVariantArgumentList && _argumentCount >= s_funcs[_info]._argumentCount)
+                throw ExprException.FunctionArgumentCount(_name);
+
+            if (_arguments == null)
+            {
+                _arguments = new ExpressionNode[initialCapacity];
+            }
+            else if (_argumentCount == _arguments.Length)
+            {
+                ExpressionNode[] bigger = new ExpressionNode[_argumentCount * 2];
+                Array.Copy(_arguments, 0, bigger, 0, _argumentCount);
+                _arguments = bigger;
+            }
+            _arguments[_argumentCount++] = argument;
+        }
+
+        internal override void Bind(DataTable table, List<DataColumn> list)
+        {
+            BindTable(table);
+            Check();
+
+            // special case for the Convert function bind only the first argument:
+            // the second argument should be a Type stored as a name node, replace it with constant.
+            if (s_funcs[_info]._id == FunctionId.Convert)
+            {
+                if (_argumentCount != 2)
+                    throw ExprException.FunctionArgumentCount(_name);
+                _arguments[0].Bind(table, list);
+
+                if (_arguments[1].GetType() == typeof(NameNode))
+                {
+                    NameNode type = (NameNode)_arguments[1];
+                    _arguments[1] = new ConstNode(table, ValueType.Str, type._name);
+                }
+                _arguments[1].Bind(table, list);
+            }
+            else
+            {
+                for (int i = 0; i < _argumentCount; i++)
+                {
+                    _arguments[i].Bind(table, list);
+                }
+            }
+        }
+
+        internal override object Eval()
+        {
+            return Eval(null, DataRowVersion.Default);
+        }
+
+        internal override object Eval(DataRow row, DataRowVersion version)
+        {
+            Debug.Assert(_info < s_funcs.Length && _info >= 0, "Invalid function info.");
+
+            object[] argumentValues = new object[_argumentCount];
+
+            Debug.Assert(_argumentCount == s_funcs[_info]._argumentCount || s_funcs[_info]._isVariantArgumentList, "Invalid argument argumentCount.");
+
+            // special case of the Convert function
+            if (s_funcs[_info]._id == FunctionId.Convert)
+            {
+                if (_argumentCount != 2)
+                    throw ExprException.FunctionArgumentCount(_name);
+
+                argumentValues[0] = _arguments[0].Eval(row, version);
+                argumentValues[1] = GetDataType(_arguments[1]);
+            }
+            else if (s_funcs[_info]._id != FunctionId.Iif)
+            { // We do not want to evaluate arguments of IIF, we will already do it in EvalFunction/ second point: we may go to div by 0
+                for (int i = 0; i < _argumentCount; i++)
+                {
+                    argumentValues[i] = _arguments[i].Eval(row, version);
+
+                    if (s_funcs[_info]._isValidateArguments)
+                    {
+                        if ((argumentValues[i] == DBNull.Value) || (typeof(object) == s_funcs[_info]._parameters[i]))
+                        {
+                            // currently all supported functions with IsValidateArguments set to true
+                            // NOTE: for IIF and ISNULL IsValidateArguments set to false
+                            return DBNull.Value;
+                        }
+
+                        if (argumentValues[i].GetType() != s_funcs[_info]._parameters[i])
+                        {
+                            // We are allowing conversions in one very specific case: int, int64,...'nice' numeric to numeric..
+
+                            if (s_funcs[_info]._parameters[i] == typeof(int) && ExpressionNode.IsInteger(DataStorage.GetStorageType(argumentValues[i].GetType())))
+                            {
+                                argumentValues[i] = Convert.ToInt32(argumentValues[i], FormatProvider);
+                            }
+                            else if ((s_funcs[_info]._id == FunctionId.Trim) || (s_funcs[_info]._id == FunctionId.Substring) || (s_funcs[_info]._id == FunctionId.Len))
+                            {
+                                if ((typeof(string) != (argumentValues[i].GetType())) && (typeof(SqlString) != (argumentValues[i].GetType())))
+                                {
+                                    throw ExprException.ArgumentType(s_funcs[_info]._name, i + 1, s_funcs[_info]._parameters[i]);
+                                }
+                            }
+                            else
+                            {
+                                throw ExprException.ArgumentType(s_funcs[_info]._name, i + 1, s_funcs[_info]._parameters[i]);
+                            }
+                        }
+                    }
+                }
+            }
+            return EvalFunction(s_funcs[_info]._id, argumentValues, row, version);
+        }
+
+        internal override object Eval(int[] recordNos)
+        {
+            throw ExprException.ComputeNotAggregate(ToString());
+        }
+
+        internal override bool IsConstant()
+        {
+            // Currently all function calls with const arguments return constant.
+            // That could change in the future (if we implement Rand()...)
+            // CONSIDER: We could be smarter for Iif.
+
+            bool constant = true;
+
+            for (int i = 0; i < _argumentCount; i++)
+            {
+                constant = constant && _arguments[i].IsConstant();
+            }
+
+            Debug.Assert(_info > -1, "All function nodes should be bound at this point.");  // default info is -1, it means if not bounded, it should be -1, not 0!!
+
+            return (constant);
+        }
+
+        internal override bool IsTableConstant()
+        {
+            for (int i = 0; i < _argumentCount; i++)
+            {
+                if (!_arguments[i].IsTableConstant())
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal override bool HasLocalAggregate()
+        {
+            for (int i = 0; i < _argumentCount; i++)
+            {
+                if (_arguments[i].HasLocalAggregate())
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        internal override bool HasRemoteAggregate()
+        {
+            for (int i = 0; i < _argumentCount; i++)
+            {
+                if (_arguments[i].HasRemoteAggregate())
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        internal override bool DependsOn(DataColumn column)
+        {
+            for (int i = 0; i < _argumentCount; i++)
+            {
+                if (_arguments[i].DependsOn(column))
+                    return true;
+            }
+            return false;
+        }
+
+        internal override ExpressionNode Optimize()
+        {
+            for (int i = 0; i < _argumentCount; i++)
+            {
+                _arguments[i] = _arguments[i].Optimize();
+            }
+
+            Debug.Assert(_info > -1, "Optimizing unbound function "); // default info is -1, it means if not bounded, it should be -1, not 0!!
+
+            if (s_funcs[_info]._id == FunctionId.In)
+            {
+                // we can not optimize the in node, just check that it has all constant arguments
+
+                if (!IsConstant())
+                {
+                    throw ExprException.NonConstantArgument();
+                }
+            }
+            else
+            {
+                if (IsConstant())
+                {
+                    return new ConstNode(table, ValueType.Object, Eval(), false);
+                }
+            }
+            return this;
+        }
+
+        private Type GetDataType(ExpressionNode node)
+        {
+            Type nodeType = node.GetType();
+            string typeName = null;
+
+            if (nodeType == typeof(NameNode))
+            {
+                typeName = ((NameNode)node)._name;
+            }
+            if (nodeType == typeof(ConstNode))
+            {
+                typeName = ((ConstNode)node)._val.ToString();
+            }
+
+            if (typeName == null)
+            {
+                throw ExprException.ArgumentType(s_funcs[_info]._name, 2, typeof(Type));
+            }
+
+            Type dataType = Type.GetType(typeName);
+
+            if (dataType == null)
+            {
+                throw ExprException.InvalidType(typeName);
+            }
+
+            return dataType;
+        }
+
+        private object EvalFunction(FunctionId id, object[] argumentValues, DataRow row, DataRowVersion version)
+        {
+            StorageType storageType;
+            switch (id)
+            {
+                case FunctionId.Abs:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+
+                    storageType = DataStorage.GetStorageType(argumentValues[0].GetType());
+                    if (ExpressionNode.IsInteger(storageType))
+                        return (Math.Abs((long)argumentValues[0]));
+                    if (ExpressionNode.IsNumeric(storageType))
+                        return (Math.Abs((double)argumentValues[0]));
+
+                    throw ExprException.ArgumentTypeInteger(s_funcs[_info]._name, 1);
+
+                case FunctionId.cBool:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+
+                    storageType = DataStorage.GetStorageType(argumentValues[0].GetType());
+                    switch (storageType)
+                    {
+                        case StorageType.Boolean:
+                            return (bool)argumentValues[0];
+                        case StorageType.Int32:
+                            return ((int)argumentValues[0] != 0);
+                        case StorageType.Double:
+                            return ((double)argumentValues[0] != 0.0);
+                        case StorageType.String:
+                            return bool.Parse((string)argumentValues[0]);
+                        default:
+                            throw ExprException.DatatypeConvertion(argumentValues[0].GetType(), typeof(bool));
+                    }
+
+                case FunctionId.cInt:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+                    return Convert.ToInt32(argumentValues[0], FormatProvider);
+
+                case FunctionId.cDate:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+                    return Convert.ToDateTime(argumentValues[0], FormatProvider);
+
+                case FunctionId.cDbl:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+                    return Convert.ToDouble(argumentValues[0], FormatProvider);
+
+                case FunctionId.cStr:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+                    return Convert.ToString(argumentValues[0], FormatProvider);
+
+                case FunctionId.Charindex:
+                    Debug.Assert(_argumentCount == 2, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+
+                    Debug.Assert(argumentValues[0] is string, "Invalid argument type for " + s_funcs[_info]._name);
+                    Debug.Assert(argumentValues[1] is string, "Invalid argument type for " + s_funcs[_info]._name);
+
+                    if (DataStorage.IsObjectNull(argumentValues[0]) || DataStorage.IsObjectNull(argumentValues[1]))
+                        return DBNull.Value;
+
+                    if (argumentValues[0] is SqlString)
+                        argumentValues[0] = ((SqlString)argumentValues[0]).Value;
+
+                    if (argumentValues[1] is SqlString)
+                        argumentValues[1] = ((SqlString)argumentValues[1]).Value;
+
+                    return ((string)argumentValues[1]).IndexOf((string)argumentValues[0], StringComparison.Ordinal);
+
+                case FunctionId.Iif:
+                    Debug.Assert(_argumentCount == 3, "Invalid argument argumentCount: " + _argumentCount.ToString(FormatProvider));
+
+                    object first = _arguments[0].Eval(row, version);
+
+                    if (DataExpression.ToBoolean(first) != false)
+                    {
+                        return _arguments[1].Eval(row, version);
+                    }
+                    else
+                    {
+                        return _arguments[2].Eval(row, version);
+                    }
+
+                case FunctionId.In:
+                    // we never evaluate IN directly: IN as a binary operator, so evaluation of this should be in
+                    // BinaryNode class
+                    throw ExprException.NYI(s_funcs[_info]._name);
+
+                case FunctionId.IsNull:
+                    Debug.Assert(_argumentCount == 2, "Invalid argument argumentCount: ");
+
+                    if (DataStorage.IsObjectNull(argumentValues[0]))
+                        return argumentValues[1];
+                    else
+                        return argumentValues[0];
+
+                case FunctionId.Len:
+                    Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+                    Debug.Assert((argumentValues[0] is string) || (argumentValues[0] is SqlString), "Invalid argument type for " + s_funcs[_info]._name);
+
+                    if (argumentValues[0] is SqlString)
+                    {
+                        if (((SqlString)argumentValues[0]).IsNull)
+                        {
+                            return DBNull.Value;
+                        }
+                        else
+                        {
+                            argumentValues[0] = ((SqlString)argumentValues[0]).Value;
+                        }
+                    }
+
+                    return ((string)argumentValues[0]).Length;
+
+
+                case FunctionId.Substring:
+                    Debug.Assert(_argumentCount == 3, "Invalid argument argumentCount: " + _argumentCount.ToString(FormatProvider));
+                    Debug.Assert((argumentValues[0] is string) || (argumentValues[0] is SqlString), "Invalid first argument " + argumentValues[0].GetType().FullName + " in " + s_funcs[_info]._name);
+                    Debug.Assert(argumentValues[1] is int, "Invalid second argument " + argumentValues[1].GetType().FullName + " in " + s_funcs[_info]._name);
+                    Debug.Assert(argumentValues[2] is int, "Invalid third argument " + argumentValues[2].GetType().FullName + " in " + s_funcs[_info]._name);
+
+                    // work around the differences in .NET and VBA implementation of the Substring function
+                    // 1. The <index> Argument is 0-based in .NET, and 1-based in VBA
+                    // 2. If the <Length> argument is longer then the string length .NET throws an ArgumentException
+                    //    but our users still want to get a result.
+
+                    int start = (int)argumentValues[1] - 1;
+
+                    int length = (int)argumentValues[2];
+
+                    if (start < 0)
+                        throw ExprException.FunctionArgumentOutOfRange("index", "Substring");
+
+                    if (length < 0)
+                        throw ExprException.FunctionArgumentOutOfRange("length", "Substring");
+
+                    if (length == 0)
+                        return string.Empty;
+
+                    if (argumentValues[0] is SqlString)
+                        argumentValues[0] = ((SqlString)argumentValues[0]).Value;
+
+                    int src_length = ((string)argumentValues[0]).Length;
+
+                    if (start > src_length)
+                    {
+                        return DBNull.Value;
+                    }
+
+                    if (start + length > src_length)
+                    {
+                        length = src_length - start;
+                    }
+
+                    return ((string)argumentValues[0]).Substring(start, length);
+
+                case FunctionId.Trim:
+                    {
+                        Debug.Assert(_argumentCount == 1, "Invalid argument argumentCount for " + s_funcs[_info]._name + " : " + _argumentCount.ToString(FormatProvider));
+                        Debug.Assert((argumentValues[0] is string) || (argumentValues[0] is SqlString), "Invalid argument type for " + s_funcs[_info]._name);
+
+                        if (DataStorage.IsObjectNull(argumentValues[0]))
+                            return DBNull.Value;
+
+                        if (argumentValues[0] is SqlString)
+                            argumentValues[0] = ((SqlString)argumentValues[0]).Value;
+
+                        return (((string)argumentValues[0]).Trim());
+                    }
+
+                case FunctionId.Convert:
+                    if (_argumentCount != 2)
+                        throw ExprException.FunctionArgumentCount(_name);
+
+                    if (argumentValues[0] == DBNull.Value)
+                    {
+                        return DBNull.Value;
+                    }
+
+                    Type type = (Type)argumentValues[1];
+                    StorageType mytype = DataStorage.GetStorageType(type);
+                    storageType = DataStorage.GetStorageType(argumentValues[0].GetType());
+
+                    if (mytype == StorageType.DateTimeOffset)
+                    {
+                        if (storageType == StorageType.String)
+                        {
+                            return SqlConvert.ConvertStringToDateTimeOffset((string)argumentValues[0], FormatProvider);
+                        }
+                    }
+
+                    if (StorageType.Object != mytype)
+                    {
+                        if ((mytype == StorageType.Guid) && (storageType == StorageType.String))
+                            return new Guid((string)argumentValues[0]);
+
+                        if (ExpressionNode.IsFloatSql(storageType) && ExpressionNode.IsIntegerSql(mytype))
+                        {
+                            if (StorageType.Single == storageType)
+                            {
+                                return SqlConvert.ChangeType2((float)SqlConvert.ChangeType2(argumentValues[0], StorageType.Single, typeof(float), FormatProvider), mytype, type, FormatProvider);
+                            }
+                            else if (StorageType.Double == storageType)
+                            {
+                                return SqlConvert.ChangeType2((double)SqlConvert.ChangeType2(argumentValues[0], StorageType.Double, typeof(double), FormatProvider), mytype, type, FormatProvider);
+                            }
+                            else if (StorageType.Decimal == storageType)
+                            {
+                                return SqlConvert.ChangeType2((decimal)SqlConvert.ChangeType2(argumentValues[0], StorageType.Decimal, typeof(decimal), FormatProvider), mytype, type, FormatProvider);
+                            }
+                            return SqlConvert.ChangeType2(argumentValues[0], mytype, type, FormatProvider);
+                        }
+
+                        return SqlConvert.ChangeType2(argumentValues[0], mytype, type, FormatProvider);
+                    }
+
+                    return argumentValues[0];
+
+                case FunctionId.DateTimeOffset:
+                    if (argumentValues[0] == DBNull.Value || argumentValues[1] == DBNull.Value || argumentValues[2] == DBNull.Value)
+                        return DBNull.Value;
+                    switch (((DateTime)argumentValues[0]).Kind)
+                    {
+                        case DateTimeKind.Utc:
+                            if ((int)argumentValues[1] != 0 && (int)argumentValues[2] != 0)
+                            {
+                                throw ExprException.MismatchKindandTimeSpan();
+                            }
+                            break;
+                        case DateTimeKind.Local:
+                            if (DateTimeOffset.Now.Offset.Hours != (int)argumentValues[1] && DateTimeOffset.Now.Offset.Minutes != (int)argumentValues[2])
+                            {
+                                throw ExprException.MismatchKindandTimeSpan();
+                            }
+                            break;
+                        case DateTimeKind.Unspecified: break;
+                    }
+                    if ((int)argumentValues[1] < -14 || (int)argumentValues[1] > 14)
+                        throw ExprException.InvalidHoursArgument();
+                    if ((int)argumentValues[2] < -59 || (int)argumentValues[2] > 59)
+                        throw ExprException.InvalidMinutesArgument();
+                    // range should be within -14 hours and  +14 hours
+                    if ((int)argumentValues[1] == 14 && (int)argumentValues[2] > 0)
+                        throw ExprException.InvalidTimeZoneRange();
+                    if ((int)argumentValues[1] == -14 && (int)argumentValues[2] < 0)
+                        throw ExprException.InvalidTimeZoneRange();
+
+                    return new DateTimeOffset((DateTime)argumentValues[0], new TimeSpan((int)argumentValues[1], (int)argumentValues[2], 0));
+
+                default:
+                    throw ExprException.UndefinedFunction(s_funcs[_info]._name);
+            }
+        }
+
+        internal FunctionId Aggregate
+        {
+            get
+            {
+                if (IsAggregate)
+                {
+                    return s_funcs[_info]._id;
+                }
+                return FunctionId.none;
+            }
+        }
+
+        internal bool IsAggregate
+        {
+            get
+            {
+                bool aggregate = (s_funcs[_info]._id == FunctionId.Sum) ||
+                                 (s_funcs[_info]._id == FunctionId.Avg) ||
+                                 (s_funcs[_info]._id == FunctionId.Min) ||
+                                 (s_funcs[_info]._id == FunctionId.Max) ||
+                                 (s_funcs[_info]._id == FunctionId.Count) ||
+                                 (s_funcs[_info]._id == FunctionId.StDev) ||
+                                 (s_funcs[_info]._id == FunctionId.Var);
+                return aggregate;
+            }
+        }
+
+        internal void Check()
+        {
+            Function f = s_funcs[_info];
+            if (_info < 0)
+                throw ExprException.UndefinedFunction(_name);
+
+            if (s_funcs[_info]._isVariantArgumentList)
+            {
+                // for finctions with variabls argument list argumentCount is a minimal number of arguments
+                if (_argumentCount < s_funcs[_info]._argumentCount)
+                {
+                    // Special case for the IN operator
+                    if (s_funcs[_info]._id == FunctionId.In)
+                        throw ExprException.InWithoutList();
+
+                    throw ExprException.FunctionArgumentCount(_name);
+                }
+            }
+            else
+            {
+                if (_argumentCount != s_funcs[_info]._argumentCount)
+                    throw ExprException.FunctionArgumentCount(_name);
+            }
+        }
+    }
+    internal enum FunctionId
+    {
+        none = -1,
+        Ascii = 0,
+        Char = 1,
+        Charindex = 2,
+        Difference = 3,
+        Len = 4,
+        Lower = 5,
+        LTrim = 6,
+        Patindex = 7,
+        Replicate = 8,
+        Reverse = 9,
+        Right = 10,
+        RTrim = 11,
+        Soundex = 12,
+        Space = 13,
+        Str = 14,
+        Stuff = 15,
+        Substring = 16,
+        Upper = 17,
+        IsNull = 18,
+        Iif = 19,
+        Convert = 20,
+        cInt = 21,
+        cBool = 22,
+        cDate = 23,
+        cDbl = 24,
+        cStr = 25,
+        Abs = 26,
+        Acos = 27,
+        In = 28,
+        Trim = 29,
+        Sum = 30,
+        Avg = 31,
+        Min = 32,
+        Max = 33,
+        Count = 34,
+        StDev = 35,  // Statistical standard deviation
+        Var = 37,    // Statistical variance
+        DateTimeOffset = 38,
+    }
+
+    internal sealed class Function
+    {
+        internal readonly string _name;
+        internal readonly FunctionId _id;
+        internal readonly Type _result;
+        internal readonly bool _isValidateArguments;
+        internal readonly bool _isVariantArgumentList;
+        internal readonly int _argumentCount;
+        internal readonly Type[] _parameters = new Type[] { null, null, null };
+
+        internal Function()
+        {
+            _name = null;
+            _id = FunctionId.none;
+            _result = null;
+            _isValidateArguments = false;
+            _argumentCount = 0;
+        }
+
+        internal Function(string name, FunctionId id, Type result, bool IsValidateArguments,
+                          bool IsVariantArgumentList, int argumentCount, Type a1, Type a2, Type a3)
+        {
+            _name = name;
+            _id = id;
+            _result = result;
+            _isValidateArguments = IsValidateArguments;
+            _isVariantArgumentList = IsVariantArgumentList;
+            _argumentCount = argumentCount;
+
+            if (a1 != null)
+                _parameters[0] = a1;
+            if (a2 != null)
+                _parameters[1] = a2;
+            if (a3 != null)
+                _parameters[2] = a3;
+        }
+
+        internal static string[] s_functionName = new string[] {
+            "Unknown",
+            "Ascii",
+            "Char",
+            "CharIndex",
+            "Difference",
+            "Len",
+            "Lower",
+            "LTrim",
+            "Patindex",
+            "Replicate",
+            "Reverse",
+            "Right",
+            "RTrim",
+            "Soundex",
+            "Space",
+            "Str",
+            "Stuff",
+            "Substring",
+            "Upper",
+            "IsNull",
+            "Iif",
+            "Convert",
+            "cInt",
+            "cBool",
+            "cDate",
+            "cDbl",
+            "cStr",
+            "Abs",
+            "Acos",
+            "In",
+            "Trim",
+            "Sum",
+            "Avg",
+            "Min",
+            "Max",
+            "Count",
+            "StDev",
+            "Var",
+            "DateTimeOffset",
+        };
+    }
+}

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
@@ -16,6 +16,7 @@ namespace System.Data
         internal int _argumentCount = 0;
         internal const int initialCapacity = 1;
         internal ExpressionNode[] _arguments;
+        private readonly TypeLimiter? _capturedLimiter;
 
         private static readonly Function[] s_funcs = new Function[] {
             new Function("Abs", FunctionId.Abs, typeof(object), true, false, 1, typeof(object), null, null),
@@ -40,6 +41,12 @@ namespace System.Data
 
         internal FunctionNode(DataTable table, string name) : base(table)
         {
+            // Because FunctionNode instances are created eagerly but evaluated lazily,
+            // we need to capture the deserialization scope here. The scope could be
+            // null if no deserialization is in progress.
+
+            _capturedLimiter = TypeLimiter.Capture();
+
             _name = name;
             for (int i = 0; i < s_funcs.Length; i++)
             {
@@ -289,6 +296,11 @@ namespace System.Data
                 throw ExprException.InvalidType(typeName);
             }
 
+            // ReadXml might not be on the current call stack. So we'll use the TypeLimiter
+            // that was captured when this FunctionNode instance was created.
+
+            TypeLimiter.EnsureTypeIsAllowed(dataType, _capturedLimiter);
+
             return dataType;
         }
 
@@ -500,10 +512,17 @@ namespace System.Data
                             {
                                 return SqlConvert.ChangeType2((decimal)SqlConvert.ChangeType2(argumentValues[0], StorageType.Decimal, typeof(decimal), FormatProvider), mytype, type, FormatProvider);
                             }
-                            return SqlConvert.ChangeType2(argumentValues[0], mytype, type, FormatProvider);
                         }
 
-                        return SqlConvert.ChangeType2(argumentValues[0], mytype, type, FormatProvider);
+                        // The Convert function can be called lazily, outside of a previous Serialization Guard scope.
+                        // If there was a type limiter scope on the stack at the time this Convert function was created,
+                        // we must manually re-enter the Serialization Guard scope.
+
+                        //DeserializationToken deserializationToken = (_capturedLimiter != null) ? SerializationInfo.StartDeserialization() : default;
+                        //using (deserializationToken)
+                        {
+                            return SqlConvert.ChangeType2(argumentValues[0], mytype, type, FormatProvider);
+                        }
                     }
 
                     return argumentValues[0];

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/LocalAppContextSwitches.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/LocalAppContextSwitches.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    internal static partial class LocalAppContextSwitches
+    {
+        private static int s_allowArbitraryTypeInstantiation;
+        public static bool AllowArbitraryTypeInstantiation
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get =>LocalAppContext.GetCachedSwitchValue("Switch.System.Data.AllowArbitraryDataSetTypeInstantiation", ref s_allowArbitraryTypeInstantiation);
+        }
+    }
+}

--- a/external/corefx-bugfix/src/System.Data.Common/src/System/Data/TypeLimiter.cs
+++ b/external/corefx-bugfix/src/System.Data.Common/src/System/Data/TypeLimiter.cs
@@ -1,0 +1,304 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.Serialization;
+
+namespace System.Data
+{
+    internal sealed class TypeLimiter
+    {
+        [ThreadStatic]
+        private static Scope? s_activeScope;
+
+        private Scope m_instanceScope;
+
+        private const string AppDomainDataSetDefaultAllowedTypesKey = "System.Data.DataSetDefaultAllowedTypes";
+
+        private TypeLimiter(Scope scope)
+        {
+            Debug.Assert(scope != null);
+            m_instanceScope = scope;
+        }
+
+        private static bool IsTypeLimitingDisabled
+            => LocalAppContextSwitches.AllowArbitraryTypeInstantiation;
+
+        /// <summary>
+        /// Captures the current <see cref="TypeLimiter"/> instance so that future
+        /// type checks can be performed against the allow list that was active during
+        /// the current deserialization scope.
+        /// </summary>
+        /// <remarks>
+        /// Returns null if no limiter is active.
+        /// </remarks>
+        public static TypeLimiter? Capture()
+        {
+            Scope? activeScope = s_activeScope;
+            return (activeScope != null) ? new TypeLimiter(activeScope) : null;
+        }
+
+        /// <summary>
+        /// Ensures the requested type is allowed by the rules of the active
+        /// deserialization scope. If a captured scope is provided, we'll use
+        /// that previously captured scope rather than the thread-static active
+        /// scope.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// If <paramref name="type"/> is not allowed.
+        /// </exception>
+        public static void EnsureTypeIsAllowed(Type? type, TypeLimiter? capturedLimiter = null)
+        {
+            if (type is null)
+            {
+                return; // nothing to check
+            }
+
+            Scope? capturedScope = capturedLimiter?.m_instanceScope ?? s_activeScope;
+            if (capturedScope is null)
+            {
+                return; // we're not in a restricted scope
+            }
+
+            if (capturedScope.IsAllowedType(type))
+            {
+                return; // type was explicitly allowed
+            }
+
+            // We encountered a type that wasn't in the allow list.
+            // Throw an exception to fail the current operation.
+
+            throw ExceptionBuilder.TypeNotAllowed(type);
+        }
+
+        public static IDisposable? EnterRestrictedScope(DataSet dataSet)
+        {
+            if (IsTypeLimitingDisabled)
+            {
+                return null; // protections aren't enabled
+            }
+
+            Scope newScope = new Scope(s_activeScope, GetPreviouslyDeclaredDataTypes(dataSet));
+            s_activeScope = newScope;
+            return newScope;
+        }
+
+        public static IDisposable? EnterRestrictedScope(DataTable dataTable)
+        {
+            if (IsTypeLimitingDisabled)
+            {
+                return null; // protections aren't enabled
+            }
+
+            Scope newScope = new Scope(s_activeScope, GetPreviouslyDeclaredDataTypes(dataTable));
+            s_activeScope = newScope;
+            return newScope;
+        }
+
+        /// <summary>
+        /// Given a <see cref="DataTable"/>, returns all of the <see cref="DataColumn.DataType"/>
+        /// values declared on the instance.
+        /// </summary>
+        private static IEnumerable<Type> GetPreviouslyDeclaredDataTypes(DataTable dataTable)
+        {
+            return (dataTable != null)
+                ? dataTable.Columns.Cast<DataColumn>().Select(column => column.DataType)
+                : Enumerable.Empty<Type>();
+        }
+
+        /// <summary>
+        /// Given a <see cref="DataSet"/>, returns all of the <see cref="DataColumn.DataType"/>
+        /// values declared on the instance.
+        /// </summary>
+        private static IEnumerable<Type> GetPreviouslyDeclaredDataTypes(DataSet dataSet)
+        {
+            return (dataSet != null)
+                ? dataSet.Tables.Cast<DataTable>().SelectMany(table => GetPreviouslyDeclaredDataTypes(table))
+                : Enumerable.Empty<Type>();
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            /// <summary>
+            /// Types which are always allowed, unconditionally.
+            /// </summary>
+            private static readonly HashSet<Type> s_allowedTypes = new HashSet<Type>()
+            {
+                /* primitives */
+                typeof(bool),
+                typeof(char),
+                typeof(sbyte),
+                typeof(byte),
+                typeof(short),
+                typeof(ushort),
+                typeof(int),
+                typeof(uint),
+                typeof(long),
+                typeof(ulong),
+                typeof(float),
+                typeof(double),
+                typeof(decimal),
+                typeof(DateTime),
+                typeof(DateTimeOffset),
+                typeof(TimeSpan),
+                typeof(string),
+                typeof(Guid),
+                typeof(SqlBinary),
+                typeof(SqlBoolean),
+                typeof(SqlByte),
+                typeof(SqlBytes),
+                typeof(SqlChars),
+                typeof(SqlDateTime),
+                typeof(SqlDecimal),
+                typeof(SqlDouble),
+                typeof(SqlGuid),
+                typeof(SqlInt16),
+                typeof(SqlInt32),
+                typeof(SqlInt64),
+                typeof(SqlMoney),
+                typeof(SqlSingle),
+                typeof(SqlString),
+
+                /* non-primitives, but common */
+                typeof(object),
+                typeof(Type),
+                typeof(BigInteger),
+                typeof(Uri),
+
+                /* frequently used System.Drawing types */
+                typeof(Color),
+                typeof(Point),
+                typeof(PointF),
+                typeof(Rectangle),
+                typeof(RectangleF),
+                typeof(Size),
+                typeof(SizeF),
+            };
+
+            /// <summary>
+            /// Types which are allowed within the context of this scope.
+            /// </summary>
+            private HashSet<Type> m_allowedTypes;
+
+            /// <summary>
+            /// This thread's previous scope.
+            /// </summary>
+            private readonly Scope? m_previousScope;
+
+            /// <summary>
+            /// The Serialization Guard token associated with this scope.
+            /// </summary>
+            //private readonly DeserializationToken m_deserializationToken;
+
+            internal Scope(Scope? previousScope, IEnumerable<Type> allowedTypes)
+            {
+                Debug.Assert(allowedTypes != null);
+
+                m_previousScope = previousScope;
+                m_allowedTypes = new HashSet<Type>(allowedTypes.Where(type => type != null));
+               // m_deserializationToken = SerializationInfo.StartDeserialization();
+            }
+
+            public void Dispose()
+            {
+                if (this != s_activeScope)
+                {
+                    // Stacks should never be popped out of order.
+                    // We want to trap this condition in production.
+                    Debug.Fail("Scope was popped out of order.");
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
+                //m_deserializationToken.Dispose(); // it's a readonly struct, but Dispose still works properly
+                s_activeScope = m_previousScope; // could be null
+            }
+
+            public bool IsAllowedType(Type type)
+            {
+                Debug.Assert(type != null);
+
+                // Is the incoming type unconditionally allowed?
+
+                if (IsTypeUnconditionallyAllowed(type))
+                {
+                    return true;
+                }
+
+                // The incoming type is allowed if the current scope or any nested inner
+                // scope allowed it.
+
+                for (Scope? currentScope = this; currentScope != null; currentScope = currentScope.m_previousScope)
+                {
+                    if (currentScope.m_allowedTypes.Contains(type))
+                    {
+                        return true;
+                    }
+                }
+
+                // Did the application programmatically allow this type to be deserialized?
+
+                Type[]? appDomainAllowedTypes = (Type[]?)AppDomain.CurrentDomain.GetData(AppDomainDataSetDefaultAllowedTypesKey);
+                if (appDomainAllowedTypes != null)
+                {
+                    for (int i = 0; i < appDomainAllowedTypes.Length; i++)
+                    {
+                        if (type == appDomainAllowedTypes[i])
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                // All checks failed
+
+                return false;
+            }
+
+            private static bool IsTypeUnconditionallyAllowed(Type type)
+            {
+            TryAgain:
+                Debug.Assert(type != null);
+
+                // Check the list of unconditionally allowed types.
+
+                if (s_allowedTypes.Contains(type))
+                {
+                    return true;
+                }
+
+                // Enums are also always allowed, as we optimistically assume the app
+                // developer didn't define a dangerous enum type.
+
+                if (type.IsEnum)
+                {
+                    return true;
+                }
+
+                // Allow single-dimensional arrays of any unconditionally allowed type.
+
+                if (type.IsSZArray)
+                {
+                    type = type.GetElementType()!;
+                    goto TryAgain;
+                }
+
+                // Allow generic lists of any unconditionally allowed type.
+
+                if (type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition() == typeof(List<>))
+                {
+                    type = type.GetGenericArguments()[0];
+                    goto TryAgain;
+                }
+
+                // All checks failed.
+
+                return false;
+            }
+        }
+    }
+}

--- a/mcs/class/System.Data/Makefile
+++ b/mcs/class/System.Data/Makefile
@@ -4,7 +4,7 @@ include ../../build/rules.make
 
 LIBRARY = System.Data.dll
 
-LIB_REFS = System System.Xml System.Core System.Numerics System.Transactions
+LIB_REFS = System System.Xml System.Core System.Numerics System.Transactions System.Drawing
 KEYFILE = ../ecma.pub
 LIB_MCS_FLAGS = \
 	-nowarn:219,414,649,619,436 \

--- a/mcs/class/System.Data/corefx.common.sources
+++ b/mcs/class/System.Data/corefx.common.sources
@@ -5,6 +5,8 @@ Assembly/AssemblyInfo.cs
 ../../build/common/AssemblyRef.cs
 ../../build/common/SR.cs
 
+../../../external/corefx/src/Common/src/System/LocalAppContext.cs
+
 #
 # corefx doesn't fully cover our API yet, these files fill the gaps:
 #
@@ -119,13 +121,13 @@ corefx/DataReaderExtensions.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/ConstraintCollection.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/ConstraintConverter.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/ConstraintEnumerator.cs
-../../../external/corefx/src/System.Data.Common/src/System/Data/DataColumn.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataColumn.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataColumnChangeEvent.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataColumnChangeEventHandler.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataColumnCollection.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataColumnPropertyDescriptor.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataError.cs
-../../../external/corefx/src/System.Data.Common/src/System/Data/DataException.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataException.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataKey.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataRelation.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataRelationCollection.cs
@@ -140,10 +142,10 @@ corefx/DataReaderExtensions.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataRowVersion.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataRowView.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataSerializationFormat.cs
-../../../external/corefx/src/System.Data.Common/src/System/Data/DataSet.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataSet.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataSetDateTime.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataSysAttribute.cs
-../../../external/corefx/src/System.Data.Common/src/System/Data/DataTable.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/DataTable.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataTableClearEvent.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataTableClearEventHandler.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/DataTableCollection.cs
@@ -182,6 +184,7 @@ corefx/DataReaderExtensions.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/ITableMapping.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/ITableMappingCollection.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/KeyRestrictionBehavior.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/LocalAppContextSwitches.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/LoadOption.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/MappingType.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/MergeFailedEvent.cs
@@ -210,6 +213,7 @@ corefx/DataReaderExtensions.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/StateChangeEventHandler.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/StatementType.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/StrongTypingException.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/TypeLimiter.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/UniqueConstraint.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/UpdateRowSource.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/UInt64Storage.cs
@@ -258,7 +262,7 @@ corefx/DataReaderExtensions.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/Int16Storage.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/Int32Storage.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/Int64Storage.cs
-../../../external/corefx/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/RowUpdatedEventArgs.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/RowUpdatingEventArgs.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Common/SByteStorage.cs
@@ -291,7 +295,7 @@ corefx/DataReaderExtensions.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/ExpressionNode.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/ExpressionParser.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/FilterException.cs
-../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
+../../../external/corefx-bugfix/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/IFilter.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/LookupNode.cs
 ../../../external/corefx/src/System.Data.Common/src/System/Data/Filter/NameNode.cs

--- a/mcs/class/System.Data/corefx/SR.cs
+++ b/mcs/class/System.Data/corefx/SR.cs
@@ -112,6 +112,7 @@ partial class SR
 	public const string Data_ArgumentOutOfRange = "'{0}' argument is out of range.";
 	public const string Data_ArgumentNull = "'{0}' argument cannot be null.";
 	public const string Data_ArgumentContainsNull = "'{0}' argument contains null value.";
+	public const string Data_TypeNotAllowed = "Type '{0}' is not allowed here. See https://go.microsoft.com/fwlink/?linkid=2132227 for more details.";
 	public const string DataColumns_OutOfRange = "Cannot find column {0}.";
 	public const string DataColumns_Add1 = "Column '{0}' already belongs to this DataTable.";
 	public const string DataColumns_Add2 = "Column '{0}' already belongs to another DataTable.";


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

> Fixes CVE-2020-1147
> https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-1147
> See also https://go.microsoft.com/fwlink/?linkid=2132227.
> 
> This is a backport of the [patch](https://github.com/dotnet/runtime/pull/39304) from CoreCLR
> 
> When reviewing it is easier to ignore the first commit, as that commit simply copies the corefx files to the corefx-bugfix directory.
> 

Backport of #1963

Parent bug: UUM-62270
2023.2 port: UUM-63986

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-62270 @bholmes :
Mono: Disallow unrestricted polymorphic deserialization in DataSet.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->