### PR TITLE
[2023.3] Add new "checked" APIs for class & methods

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -1108,6 +1108,16 @@ void* mono_unity_get_field_address(MonoObject *obj, MonoVTable *vt, MonoClassFie
 	return src;
 }
 
+MONO_API MonoClass* mono_unity_class_get_checked(MonoImage *image, guint32 token, MonoError *error)
+{
+	return mono_class_get_checked(image, token, error);
+}
+
+MONO_API MonoMethod* mono_unity_get_method_checked(MonoImage *image, guint32 token, MonoClass *klass, MonoGenericContext *context, MonoError *error)
+{
+	return mono_get_method_checked(image, token, klass, context, error);
+}
+
 MONO_API MonoClassField* mono_unity_field_from_token_checked(MonoImage *image, guint32 token, MonoClass **retklass, MonoGenericContext *context, MonoError *error)
 {
 	return mono_field_from_token_checked(image, token, retklass, context, error);

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -218,7 +218,11 @@ MonoException* mono_unity_thread_check_exception();
 MonoObject* mono_unity_delegate_get_target(MonoDelegate *delegate);
 gchar* mono_unity_get_runtime_build_info(const char *date, const char *time);
 void* mono_unity_get_field_address(MonoObject *obj, MonoVTable *vt, MonoClassField *field);
+
+MONO_API MonoClass* mono_unity_class_get_checked(MonoImage* image, guint32 token, MonoError* error);
+MONO_API MonoMethod* mono_unity_get_method_checked(MonoImage* image, guint32 token, MonoClass* klass, MonoGenericContext* context, MonoError* error);
 MONO_API MonoClassField* mono_unity_field_from_token_checked(MonoImage *image, guint32 token, MonoClass **retklass, MonoGenericContext *context, MonoError *error);
+
 gboolean mono_unity_thread_state_init_from_handle(MonoThreadUnwindState *tctx, MonoThreadInfo *info, void* fixme);
 void mono_unity_stackframe_set_method(MonoStackFrame *sf, MonoMethod *method);
 MonoType* mono_unity_reflection_type_get_type(MonoReflectionType *type);


### PR DESCRIPTION
The Unity Editor in trying to report some load issues would call the non-checked versions of these APIs and crash in a failed assert.  To fix that we will add new checked API's to allow Unity to handle the error cases and report a useful error.

This is a backport of https://github.com/Unity-Technologies/mono/pull/1973

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Backports**
2023.3
2023.2
2022.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->