### PR TITLE
Declaring inlined function as static to fix debug optimized builds on MacOS

### DIFF
--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -364,7 +364,7 @@ mono_arch_unwindinfo_emit_epilog_codes(guint64 saved_regset, guint64 restore_reg
       //
 #define MONO_TRAMPOLINE_UNWINDINFO_SIZE 0
 
-inline gboolean
+static inline gboolean
 mono_arch_unwindinfo_emit_epilog_codes (guint64 saved_regset, guint64 restore_regset) {
 	return FALSE;
 }


### PR DESCRIPTION
Similar to other inlined functions in mono, they need to be declared static in order for a symbol to be generated and picked up by the linker. Reference: https://stackoverflow.com/a/16245669



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

Needs to be backported to 2023.3