### PR TITLE
Fix client certificate validation

### DIFF
--- a/external/corefx-bugfix/src/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/external/corefx-bugfix/src/Common/src/System/Net/Security/CertificateHelper.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    internal static partial class CertificateHelper
+    {
+        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+
+        internal static X509Certificate2 GetEligibleClientCertificate(X509CertificateCollection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            var certs = new X509Certificate2Collection();
+            certs.AddRange(candidateCerts);
+
+            return GetEligibleClientCertificate(certs);
+        }
+
+        internal static X509Certificate2 GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Build a new collection with certs that have a private key. We need to do this manually because there is
+            // no X509FindType to match this criteria.
+            // Find(...) returns a collection of clones instead of a filtered collection, so do this before calling
+            // Find(...) to minimize the number of unnecessary allocations and finalizations.
+            var eligibleCerts = new X509Certificate2Collection();
+            foreach (X509Certificate2 cert in candidateCerts)
+            {
+                if (cert.HasPrivateKey)
+                {
+                    eligibleCerts.Add(cert);
+                }
+            }
+
+            // Don't call Find(...) if we don't need to.
+            if (eligibleCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Reduce the set of certificates to match the proper 'Client Authentication' criteria.
+            // Client EKU is probably more rare than the DigitalSignature KU. Filter by ClientAuthOid first to reduce
+            // the candidate space as quickly as possible.
+            eligibleCerts = eligibleCerts.Find(X509FindType.FindByApplicationPolicy, ClientAuthenticationOID, false);
+            eligibleCerts = eligibleCerts.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
+
+            if (eligibleCerts.Count > 0)
+            {
+                return eligibleCerts[0];
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -824,7 +824,7 @@ ReferenceSources/Win32Exception.cs
 
 ../../../external/corefx/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
 
-../../../external/corefx/src/Common/src/System/Net/Security/CertificateHelper.cs
+../../../external/corefx-bugfix/src/Common/src/System/Net/Security/CertificateHelper.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/CertificateHelper.Unix.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/SecurityBufferType.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/SecurityBuffer.cs


### PR DESCRIPTION
A fix (for all OSes) also needed to be made to CoreFX's certificate validation to make it less restrictive as well as optimized. This fix was taken from: https://github.com/dotnet/corefx/commit/ef3418c6b6e9dd525b273f8e7cb271804b56c678

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-57031 @UnityAlex :
Mono: Fixed issue where custom client and server certificates were not correctly being validated by HttpClient.

**Backports**
2022.3, 2023.2, 2023.3