### PR TITLE
[2022.3] Fix client certificate validation

### DIFF
--- a/external/corefx-bugfix/src/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/external/corefx-bugfix/src/Common/src/System/Net/Security/CertificateHelper.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    internal static partial class CertificateHelper
+    {
+        private const string ClientAuthenticationOID = "1.3.6.1.5.5.7.3.2";
+
+        internal static X509Certificate2 GetEligibleClientCertificate(X509CertificateCollection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            var certs = new X509Certificate2Collection();
+            certs.AddRange(candidateCerts);
+
+            return GetEligibleClientCertificate(certs);
+        }
+
+        internal static X509Certificate2 GetEligibleClientCertificate(X509Certificate2Collection candidateCerts)
+        {
+            if (candidateCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Build a new collection with certs that have a private key. We need to do this manually because there is
+            // no X509FindType to match this criteria.
+            // Find(...) returns a collection of clones instead of a filtered collection, so do this before calling
+            // Find(...) to minimize the number of unnecessary allocations and finalizations.
+            var eligibleCerts = new X509Certificate2Collection();
+            foreach (X509Certificate2 cert in candidateCerts)
+            {
+                if (cert.HasPrivateKey)
+                {
+                    eligibleCerts.Add(cert);
+                }
+            }
+
+            // Don't call Find(...) if we don't need to.
+            if (eligibleCerts.Count == 0)
+            {
+                return null;
+            }
+
+            // Reduce the set of certificates to match the proper 'Client Authentication' criteria.
+            // Client EKU is probably more rare than the DigitalSignature KU. Filter by ClientAuthOid first to reduce
+            // the candidate space as quickly as possible.
+            eligibleCerts = eligibleCerts.Find(X509FindType.FindByApplicationPolicy, ClientAuthenticationOID, false);
+            eligibleCerts = eligibleCerts.Find(X509FindType.FindByKeyUsage, X509KeyUsageFlags.DigitalSignature, false);
+
+            if (eligibleCerts.Count > 0)
+            {
+                return eligibleCerts[0];
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    internal static class ConnectHelper
+    {
+        /// <summary>Pool of event args to use to establish connections.</summary>
+        private static readonly ConcurrentQueue<ConnectEventArgs>.Segment s_connectEventArgs =
+            new ConcurrentQueue<ConnectEventArgs>.Segment(
+                ConcurrentQueue<ConnectEventArgs>.Segment.RoundUpToPowerOf2(Math.Max(2, Environment.ProcessorCount)));
+
+        /// <summary>
+        /// Helper type used by HttpClientHandler when wrapping SocketsHttpHandler to map its
+        /// certificate validation callback to the one used by SslStream.
+        /// </summary>
+        internal sealed class CertificateCallbackMapper
+        {
+            public readonly Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> FromHttpClientHandler;
+            public readonly RemoteCertificateValidationCallback ForSocketsHttpHandler;
+
+            public CertificateCallbackMapper(Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> fromHttpClientHandler)
+            {
+                FromHttpClientHandler = fromHttpClientHandler;
+                ForSocketsHttpHandler = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+                    FromHttpClientHandler(sender as HttpRequestMessage, certificate as X509Certificate2, chain, sslPolicyErrors);
+            }
+        }
+
+        public static async ValueTask<(Socket, Stream)> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+        {
+            // Rather than creating a new Socket and calling ConnectAsync on it, we use the static
+            // Socket.ConnectAsync with a SocketAsyncEventArgs, as we can then use Socket.CancelConnectAsync
+            // to cancel it if needed. Rent or allocate one.
+            ConnectEventArgs saea;
+            if (!s_connectEventArgs.TryDequeue(out saea))
+            {
+                saea = new ConnectEventArgs();
+            }
+
+            try
+            {
+                saea.Initialize(cancellationToken);
+
+                // Configure which server to which to connect.
+                saea.RemoteEndPoint = new DnsEndPoint(host, port);
+
+                // Initiate the connection.
+                if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, saea))
+                {
+                    // Connect completing asynchronously. Enable it to be canceled and wait for it.
+                    using (cancellationToken.Register(s => Socket.CancelConnectAsync((SocketAsyncEventArgs)s), saea))
+                    {
+                        await saea.Builder.Task.ConfigureAwait(false);
+                    }
+                }
+                else if (saea.SocketError != SocketError.Success)
+                {
+                    // Connect completed synchronously but unsuccessfully.
+                    throw new SocketException((int)saea.SocketError);
+                }
+
+                Debug.Assert(saea.SocketError == SocketError.Success, $"Expected Success, got {saea.SocketError}.");
+                Debug.Assert(saea.ConnectSocket != null, "Expected non-null socket");
+
+                // Configure the socket and return a stream for it.
+                Socket socket = saea.ConnectSocket;
+                socket.NoDelay = true;
+                return (socket, new NetworkStream(socket, ownsSocket: true));
+            }
+            catch (Exception error)
+            {
+                throw CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
+                    CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
+                    new HttpRequestException(error.Message, error);
+            }
+            finally
+            {
+                // Pool the event args, or if the pool is full, dispose of it.
+                saea.Clear();
+                if (!s_connectEventArgs.TryEnqueue(saea))
+                {
+                    saea.Dispose();
+                }
+            }
+        }
+
+        /// <summary>SocketAsyncEventArgs that carries with it additional state for a Task builder and a CancellationToken.</summary>
+        private sealed class ConnectEventArgs : SocketAsyncEventArgs
+        {
+            public AsyncTaskMethodBuilder Builder { get; private set; }
+            public CancellationToken CancellationToken { get; private set; }
+
+            public void Initialize(CancellationToken cancellationToken)
+            {
+                CancellationToken = cancellationToken;
+                var b = new AsyncTaskMethodBuilder();
+                var ignored = b.Task; // force initialization
+                Builder = b;
+            }
+
+            public void Clear() => CancellationToken = default;
+
+            protected override void OnCompleted(SocketAsyncEventArgs _)
+            {
+                switch (SocketError)
+                {
+                    case SocketError.Success:
+                        Builder.SetResult();
+                        break;
+
+                    case SocketError.OperationAborted:
+                    case SocketError.ConnectionAborted:
+                        if (CancellationToken.IsCancellationRequested)
+                        {
+                            Builder.SetException(CancellationHelper.CreateOperationCanceledException(null, CancellationToken));
+                            break;
+                        }
+                        goto default;
+
+                    default:
+                        Builder.SetException(new SocketException((int)SocketError));
+                        break;
+                }
+            }
+        }
+
+        public static ValueTask<SslStream> EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Stream stream, CancellationToken cancellationToken)
+        {
+            // If there's a cert validation callback, and if it came from HttpClientHandler,
+            // wrap the original delegate in order to change the sender to be the request message (expected by HttpClientHandler's delegate).
+            RemoteCertificateValidationCallback callback = sslOptions.RemoteCertificateValidationCallback;
+            if (callback != null && callback.Target is CertificateCallbackMapper mapper)
+            {
+                sslOptions = sslOptions.ShallowClone(); // Clone as we're about to mutate it and don't want to affect the cached copy
+                Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> localFromHttpClientHandler = mapper.FromHttpClientHandler;
+                HttpRequestMessage localRequest = request;
+                sslOptions.RemoteCertificateValidationCallback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
+                    localFromHttpClientHandler(localRequest, certificate as X509Certificate2, chain, sslPolicyErrors);
+            }
+
+            // Create the SslStream, authenticate, and return it.
+            return EstablishSslConnectionAsyncCore(stream, sslOptions, cancellationToken);
+        }
+
+        private static async ValueTask<SslStream> EstablishSslConnectionAsyncCore(Stream stream, SslClientAuthenticationOptions sslOptions, CancellationToken cancellationToken)
+        {
+            SslStream sslStream = new SslStream(stream);
+
+            // TODO #25206 and #24430: Register/IsCancellationRequested should be removable once SslStream auth and sockets respect cancellation.
+            CancellationTokenRegistration ctr = cancellationToken.Register(s => ((Stream)s).Dispose(), stream);
+            try
+            {
+                await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                sslStream.Dispose();
+
+                if (CancellationHelper.ShouldWrapInOperationCanceledException(e, cancellationToken))
+                {
+                    throw CancellationHelper.CreateOperationCanceledException(e, cancellationToken);
+                }
+
+                throw new HttpRequestException(SR.net_http_ssl_connection_failed, e);
+            }
+            finally
+            {
+                ctr.Dispose();
+            }
+
+            // Handle race condition if cancellation happens after SSL auth completes but before the registration is disposed
+            if (cancellationToken.IsCancellationRequested)
+            {
+                sslStream.Dispose();
+                throw CancellationHelper.CreateOperationCanceledException(null, cancellationToken);
+            }
+
+            return sslStream;
+        }
+    }
+}

--- a/external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http
             {
                 FromHttpClientHandler = fromHttpClientHandler;
                 ForSocketsHttpHandler = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
-                    FromHttpClientHandler(sender as HttpRequestMessage, certificate as X509Certificate2, chain, sslPolicyErrors);
+                    FromHttpClientHandler(new HttpRequestMessage(HttpMethod.Get, (string)sender), certificate as X509Certificate2, chain, sslPolicyErrors);
             }
         }
 

--- a/mcs/class/System.Net.Http/Makefile
+++ b/mcs/class/System.Net.Http/Makefile
@@ -41,6 +41,11 @@ ifeq (wasm,$(PROFILE))
 API_BIN_REFS := System.Net.Http.WebAssemblyHttpHandler
 endif
 
+ifneq (,$(filter unityjit unityaot,$(PROFILE)))
+LIB_MCS_FLAGS += -d:SECURITY_DEP
+LIB_REFS += Mono.Security
+endif
+
 TEST_LIB_REFS = System System.Core
 TEST_MCS_FLAGS =
 

--- a/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
+++ b/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
@@ -373,6 +373,8 @@ namespace System.Net.Http
 			if (timeout != null)
 				wr.Timeout = (int)timeout.Value.TotalMilliseconds;
 
+			wr.ServerCertificateValidationCallback = SslOptions.RemoteCertificateValidationCallback;
+
 			// Add request headers
 			var headers = wr.Headers;
 			foreach (var header in request.Headers) {

--- a/mcs/class/System.Net.Http/legacy.sources
+++ b/mcs/class/System.Net.Http/legacy.sources
@@ -58,4 +58,4 @@ System.Net.Http.Headers/ViaHeaderValue.cs
 System.Net.Http.Headers/WarningHeaderValue.cs
 
 ../../../external/corefx/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CancellationHelper.cs
-../../../external/corefx/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+../../../external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs

--- a/mcs/class/System.Net.Http/legacy.sources
+++ b/mcs/class/System.Net.Http/legacy.sources
@@ -59,3 +59,4 @@ System.Net.Http.Headers/WarningHeaderValue.cs
 
 ../../../external/corefx/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CancellationHelper.cs
 ../../../external/corefx-bugfix/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+../../../external/corefx/src/System.Net.Http/src/System/Net/Http/HttpUtilities.cs

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -34,6 +34,7 @@ using MonoSecurity::Mono.Security.Interface;
 #else
 using Mono.Security.Interface;
 #endif
+using MNS = Mono.Net.Security;
 #endif
 
 using System;
@@ -90,6 +91,13 @@ namespace Mono.Net.Security
 			this.networkStream = networkStream;
 
 			settings = request.TlsSettings;
+
+			if (settings == null && request.ServerCertificateValidationCallback != null)
+			{
+				settings = MonoTlsSettings.CopyDefaultSettings ();
+				settings.RemoteCertificateValidationCallback = MNS.Private.CallbackHelpers.PublicToMono(request.ServerCertificateValidationCallback);
+			}
+
 			provider = request.TlsProvider ?? MonoTlsProviderFactory.GetProviderInternal ();
 			status = WebExceptionStatus.SecureChannelFailure;
 

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -92,11 +92,11 @@ namespace Mono.Net.Security
 
 			settings = request.TlsSettings;
 
-			if (settings == null && request.ServerCertificateValidationCallback != null)
-			{
+			if (settings == null)
 				settings = MonoTlsSettings.CopyDefaultSettings ();
+				
+			if (settings.RemoteCertificateValidationCallback == null)
 				settings.RemoteCertificateValidationCallback = MNS.Private.CallbackHelpers.PublicToMono(request.ServerCertificateValidationCallback);
-			}
 
 			provider = request.TlsProvider ?? MonoTlsProviderFactory.GetProviderInternal ();
 			status = WebExceptionStatus.SecureChannelFailure;

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -824,7 +824,7 @@ ReferenceSources/Win32Exception.cs
 
 ../../../external/corefx/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
 
-../../../external/corefx/src/Common/src/System/Net/Security/CertificateHelper.cs
+../../../external/corefx-bugfix/src/Common/src/System/Net/Security/CertificateHelper.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/CertificateHelper.Unix.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/SecurityBufferType.cs
 ../../../external/corefx/src/Common/src/System/Net/Security/SecurityBuffer.cs


### PR DESCRIPTION
Backport of:
- https://github.com/Unity-Technologies/mono/pull/1978
- https://github.com/Unity-Technologies/mono/pull/1940
- https://github.com/Unity-Technologies/mono/pull/1926

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-57031 @UnityAlex:
Mono: Fixed issue where custom client and server certificates were not correctly being validated by HttpClient.
