### PR TITLE
Remove unhelpful warning message in type_from_parsed_name

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1837,9 +1837,6 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoStackCrawlMark *stack_mark, 
 	if (assembly) {
 		type_resolve = TRUE;
 		rootimage = assembly->image;
-	} else {
-		// FIXME: once wasm can use stack marks, consider turning all this into an assert
-		g_warning (G_STRLOC);
 	}
 
 	*caller_assembly = assembly;


### PR DESCRIPTION
The is commonly hit for us when we are attempting to determine the Type for generics from native embedding calls. The `image->assembly.name` is always filled out in this case and therefore the assembly is successfully resolved shortly after. The caller function also references the assembly name to resolve the assembly making this warning message not really that helpful for our usage.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-64646 @UnityAlex:
Mono: Removed unhelpful mono icall warning message that was logged on domain reload.

**Backports**
2023.2, 2023.3