### PR TITLE
[2023.3] Fix Windows ARM64 crash on Thread.Abort

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4992,6 +4992,17 @@ emit_load_regarray (guint8 *code, guint64 regs, int basereg, int offset)
 
 	for (i = 0; i < 32; ++i) {
 		if (regs & (1 << i)) {
+
+#ifdef TARGET_WIN32
+			// R18 is the TEB pointer on Windows, there is no reason to ever touch it
+			// GetThreadContext will not return it by default
+			if (i + 1 == ARMREG_R18)
+			{
+				i++;
+				continue;
+			}
+#endif
+
 			if ((regs & (1 << (i + 1))) && (i + 1 != ARMREG_SP)) {
 				if (offset + (i * 8) < 500)
 					arm_ldpx (code, i, i + 1, basereg, offset + (i * 8));


### PR DESCRIPTION
The R18 register is used for the Thread Environment Block, which is OS managed and should never change.

In addition calls to GetThreadContext will not return it as part of the CONTEXT_INTEGER (documented in the windows headers).  You can specifically ask for it by passing CONTEXT_ARM64_X18, but that would need to be done consistently.  Since that could be forgotten and there's no reason to save/restore it anyway it's better to just never touch it.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-64814 @scott-ferguson-unity 
Mono: Fixed crash on Windows ARM64 when calling Thread.Abort.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
* 2023.3
* 2023.2

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->