### PR TITLE
[2022.3] Handle a missing libc library (UUM-60201)

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/UnixIPGlobalProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/UnixIPGlobalProperties.cs
@@ -67,6 +67,9 @@ namespace System.Net.NetworkInformation {
 				} catch (EntryPointNotFoundException) {
 					return String.Empty;
 				}
+				catch (DllNotFoundException) {
+					return String.Empty;
+				}
 #endif
 				int len = Array.IndexOf<byte> (bytes, 0);
 				return Encoding.ASCII.GetString (bytes, 0, len < 0 ? 256 : len);


### PR DESCRIPTION
On the iOS simulator we can get errors in this implementation because libc does not exist. So, handle a DllNotFoundException and return an empty string, like we do for a EntryNotFoundException.

This is a back port of https://github.com/Unity-Technologies/mono/pull/1993.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Internal UUM-60201 @joshuap:
Mono: Workaround a missing libc library on the iOS Simulator.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->