### PR TITLE
Fix encoding problem in some machine force wrong encoding

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -808,6 +808,9 @@ namespace System.Diagnostics
 #else
 				var stdinEncoding = startInfo.StandardInputEncoding ?? Console.InputEncoding;
 #endif
+	            if(stdinEncoding?.GetPreamble()?.Length > 0)
+	                stdinEncoding = new UTF8Encoding(false);
+
 				standardInput = new StreamWriter (new FileStream (stdin_write, FileAccess.Write, true, 8192), stdinEncoding) {
 					AutoFlush = true
 				};


### PR DESCRIPTION
https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-61599

https://forum.unity.com/threads/unity-2023-commandinvokationfailure-unable-to-list-keys-in-the-keystore.1519348/#post-9503509



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed IN-61599 @thainayu:
Mono: Fix encoding problem in some machine force wrong encoding

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

**Backports**
2023.1, 2023.2