### PR TITLE
Fix Issue With Windows ARM64 Unwind Codes

### DIFF
--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -827,7 +827,7 @@ mono_arch_unwind_add_alloc_x (guint8* unwind_codes, guint32* unwind_code_size, g
 }
 
 static int
-mono_arch_unwind_add_reg_offset (MonoUnwindOp* unwind_op_data, GSList* next, gint stack_offset, guint8 *unwind_codes, guint32 *unwind_code_size, MonoUnwindOp** last_saved_regp, gboolean reverse) {
+mono_arch_unwind_add_reg_offset (MonoUnwindOp* unwind_op_data, GSList* next, gint stack_offset, guint8 *unwind_codes, guint32 *unwind_code_size, MonoUnwindOp** last_saved_regp, gboolean processing_prolog_codes) {
 
 	if (unwind_op_data->reg == ARMREG_SP) {
 		g_assert("I don't believe there is a way to encode this in the unwind info");
@@ -853,14 +853,15 @@ mono_arch_unwind_add_reg_offset (MonoUnwindOp* unwind_op_data, GSList* next, gin
 	if (next && next->data)
 		next_unwind_op_data = (MonoUnwindOp*)next->data;
 
-	if (next_unwind_op_data && unwind_op_data->reg % 2 && next_unwind_op_data->op == DW_CFA_offset && next_unwind_op_data->reg == unwind_op_data->reg + 1 && next_unwind_op_data->val == unwind_op_data->val + sizeof(host_mgreg_t)) {
+	gint next_reg_dir = processing_prolog_codes ? 1 : -1;
+	guint8 op = processing_prolog_codes ? DW_CFA_offset : DW_CFA_mono_restore_offset_win64_arm64;
 
-		if (*last_saved_regp && (*last_saved_regp)->reg == unwind_op_data->reg - 2 && unwind_op_data->val == (*last_saved_regp)->val + 2*sizeof(host_mgreg_t))
-			mono_arch_unwind_add_save_next(unwind_codes, unwind_code_size);
-		else if (offset)
-			mono_arch_unwind_add_save_regp_x(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
-		else
-			mono_arch_unwind_add_save_regp(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
+	if (next_unwind_op_data && next_unwind_op_data->op == op && next_unwind_op_data->reg == unwind_op_data->reg + next_reg_dir && next_unwind_op_data->val == unwind_op_data->val + next_reg_dir * sizeof(host_mgreg_t)) {
+
+		if (*last_saved_regp && (*last_saved_regp)->reg == unwind_op_data->reg - 2*next_reg_dir && unwind_op_data->val == (*last_saved_regp)->val + 2*next_reg_dir*sizeof(host_mgreg_t))
+			mono_arch_unwind_add_save_next (unwind_codes, unwind_code_size);
+		else 
+			mono_arch_unwind_add_save_regp (unwind_codes, unwind_code_size, unwind_op_data->reg, offset, processing_prolog_codes);
 
 		*last_saved_regp = unwind_op_data;
 		return 2;
@@ -868,10 +869,15 @@ mono_arch_unwind_add_reg_offset (MonoUnwindOp* unwind_op_data, GSList* next, gin
 
 	*last_saved_regp = NULL;
 
-	if (offset)
-		mono_arch_unwind_add_save_reg_x(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
-	else
-		mono_arch_unwind_add_save_reg(unwind_codes, unwind_code_size, unwind_op_data->reg, offset, reverse);
+	if (arm_is_strx_imm(offset)) {
+		mono_arch_unwind_add_save_reg (unwind_codes, unwind_code_size, unwind_op_data->reg, offset, processing_prolog_codes);
+	}
+	else {
+		// Mono emits this add a mov xip0, #offset; str rn,[sp+xip0]
+		// There doesn't appear to be any way to encode this in the unwind codes, so just emit nops
+		mono_arch_unwind_add_nop (unwind_codes, unwind_code_size);
+		mono_arch_unwind_add_nop (unwind_codes, unwind_code_size);
+	}
 
 	return 1;
 }

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5193,7 +5193,7 @@ emit_load_regset_cfa (MonoCompile* cfg, guint8* code, guint64 stored_regs, guint
 			{
 				for (j = 0; j < nregs; ++j) {
 					if (cfa_regset & (1 << (i - j)))
-						mono_emit_unwind_op_restore_offset(cfg, code, i + j, (-cfa_offset) + offset + ((pos + j) * 8));
+						mono_emit_unwind_op_restore_offset(cfg, code, i - j, (-cfa_offset) + offset + ((pos - j) * 8));
 				}
 			}
 


### PR DESCRIPTION
Fixes a couple of issues with ARM64 Unwind Codes on Windows:

1. For methods that restored a different set of registers in the epilog than where saved in the prolog, and saved the registers in pairs we were emitting mono unwind info the wrong pair.  (we were saving i & i+1, not i and i-1)
2. For those same methods, we were not correctly emitting Windows ARM64 unwind codes for paired saves, because we were not handling that saves & restores happen in reverse order.
3. We were emitting the wrong save codes for reg save/restores.  The `_x` postfixed versions were for saves with the pre-index instruction format, which Mono doesn't use in the prolog/epilog.  The non `_x` postfixed versions are what we should use.
4. When mono emits a single reg save and the offset from the base pointer can't be expressed in an immediate value,  it will emit 2 instructions.  We were not handling that.  There is no way to encode that, and it will likely never be hit, but is a possibility.   
    - I would go as far to say that it will never happen.  The save reg pair case doesn't handle this and the the save single reg only does because its calling a shared helper function to emit the opcode.  For this to trigger the registers would have to be saved > 512 bytes into the stack frame.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-66457 @scott-ferguson-unity 
Mono: Fixed crash while emitting Windows ARM64 stack unwind codes

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->


**Backports**
2023.3/6000
2023.2

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->