### PR TITLE
2023.3/platform/windows/uum-62035 to unity-2023.3-mbe

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -2156,7 +2156,12 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		mono_mb_emit_calli (mb, csig);
 	} else if (MONO_CLASS_IS_IMPORT (mb->method->klass)) {
 #ifndef DISABLE_COM
-		mono_mb_emit_ldloc (mb, gc_safe_transition_builder.coop_cominterop_fnptr);
+		if (need_gc_safe) {
+			mono_mb_emit_ldloc (mb, gc_safe_transition_builder.coop_cominterop_fnptr);
+		} else {
+			mono_mb_emit_cominterop_get_function_pointer (mb, &piinfo->method);
+		}
+
 		if (piinfo->piflags & PINVOKE_ATTRIBUTE_SUPPORTS_LAST_ERROR) {
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_byte (mb, CEE_MONO_SAVE_LAST_ERROR);


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/mono/pull/2003

Fix marshaling/interop code emitting ldloc 65535 instruction when calling method on a COM interface. This happened due to unitialized local variable (gc_safe_transition_builder.coop_cominterop_fnptr) getting loaded when "need_gc_safe" is false. This caused the JIT to throw an InvalidOperationException. This fixes case UUM-62035. This bug was indirectly introduced by a previous pull request, which optimized interop call performance and made us take another code path which turned out not to work with COM interop: https://github.com/Unity-Technologies/mono/pull/1753.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-62035 @zilys
Mono: Fixed InvalidProgramException (Invalid IL code in (wrapper managed-to-native) <METHOD>: IL_0004: ldloc     65535)
 getting thrown when calling COM interop methods, 

**Unity repository changes**

I added a test for this change on this branch: https://github.cds.internal.unity3d.com/unity/unity/commits/platform/windows/uum-62035. Preferably this test gets merged to trunk together with this bugfix.