### PR TITLE
Fixed time zone retrieval due to an exception being thrown

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.Unity.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.Unity.cs
@@ -58,10 +58,12 @@ namespace System {
 			if(data[(int)TimeZoneData.DaylightDeltaIdx] == 0)
 				return rulesForYear;
 
-			// If the first and second transition DateTime objects are the same, ValidateAdjustmentRule will throw
-			// an exception. I'm unsure why these would be the same, but we do see that occur for some locales.
+			// If the first and second transition DateTime objects have the same time, day and month, ValidateAdjustmentRule will throw
+			// an exception. This appears to be due to the GetTimeZoneData icall occasionally returning garbage data on some platforms.
 			// In that case, just exit early.
-			if (firstTransition.Equals(secondTransition))
+			if (firstTransition.TimeOfDay.Equals(secondTransition.TimeOfDay)
+				&& firstTransition.Month.Equals(secondTransition.Month)
+				&& firstTransition.Day.Equals(secondTransition.Day))
 				return rulesForYear;
 
 			var beginningOfYear = new DateTime (year, 1, 1, 0, 0, 0, 0);


### PR DESCRIPTION
Backport of: https://github.com/Unity-Technologies/mono/pull/2007

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-67254 @UnityAlex :
Mono: Fixed issue where incorrect TimeZones would be returned on some devices due to an exception being thrown.
