### PR TITLE
Fix Native Stack Trace Issue

### DIFF
--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -895,7 +895,7 @@ mono_arch_unwind_add_emit_subx_sp_imm (gint offset, guint8* unwind_codes, guint3
 }
 
 static void 
-mono_arch_uwwind_add_frame_setup(guint cfa_offset, guint8* unwind_codes, guint32* unwind_code_size, gboolean reverse) {
+mono_arch_uwwind_add_frame_setup(gint cfa_offset, guint8* unwind_codes, guint32* unwind_code_size, gboolean reverse) {
 
 	// Frame Setup
 	// This matches the logic in mini-arm64.c::mono_arch_emit_prolog
@@ -929,7 +929,7 @@ initialize_unwind_info_prolog (GSList* unwind_ops, guint8 *unwind_codes, guint32
 
 	gint32 last_saved_in_order_reg = -1;
 	guint32 last_saved_reg_offset = -1;
-	guint cfa_offset = -1;
+	gint cfa_offset = -1;
 	
 	MonoUnwindOp* unwind_op_data;
 	MonoUnwindOp* last_saved_regp = NULL;;


### PR DESCRIPTION
The `cfa_offset` (Canonical Frame Address) value is normally positive, but is emitted instructions as a negative value (because the stack grows down).  This caused an
unsigned integer overflow in [mono_arch_uwwind_add_frame_setup](https://github.com/Unity-Technologies/mono/pull/2011/files#diff-90c089fd795716a5ad3b86b5d0fcb22523e846ffd2d286f8189d7e72e081dedcR902), which caused the wrong unwind codes to be emitted.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-65149 @scott-ferguson-unity 
Mono: Fix issue that caused some stack traces on Windows ARM64 to fail to generate

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**
* 6000

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->