### PR TITLE
Follow the desktop path for XMLReaderSettings on IL2CPP

### DIFF
--- a/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlReaderSettings.cs
+++ b/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlReaderSettings.cs
@@ -501,7 +501,7 @@ namespace System.Xml {
 
         void Initialize(XmlResolver resolver) {
             nameTable = null;
-#if !SILVERLIGHT && !MOBILE
+#if (!SILVERLIGHT && !MOBILE) || UNITY_AOT
             if (!EnableLegacyXmlSettings())
             {
                 xmlResolver = resolver;


### PR DESCRIPTION
Having this path disabled and always loading creating an resolver changed the XmlReader's behavior in two ways:

1. Causued un-needed xmlns attriubtes to be emitted in the parsed XML
2. Caused DTD valuation to try and download the DTD schema making XML parsing much slower than it otherwise would be.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-66880 @scott-ferguson-unity 
IL2CPP: Fixed slow performance when loading an XML document with DTD.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
* 6.0
* 2022.3
* 2021.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->