### PR TITLE
Add Checked API to load assembly refs.

### DIFF
--- a/mono/metadata/unity-utils.c
+++ b/mono/metadata/unity-utils.c
@@ -18,6 +18,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/tabledefs.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/class-init.h>
 #include <mono/metadata/object-internals.h>
@@ -1118,6 +1119,11 @@ void* mono_unity_get_field_address(MonoObject *obj, MonoVTable *vt, MonoClassFie
 	}
 
 	return src;
+}
+
+MONO_API gboolean mono_unity_assembly_get_assemblyref_checked(MonoImage* image, int index, MonoAssemblyName* aname, MonoError* error)
+{
+	return mono_assembly_get_assemblyref_checked(image, index, aname, error);
 }
 
 MONO_API MonoClass* mono_unity_class_get_checked(MonoImage *image, guint32 token, MonoError *error)

--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -221,6 +221,7 @@ MonoObject* mono_unity_delegate_get_target(MonoDelegate *delegate);
 gchar* mono_unity_get_runtime_build_info(const char *date, const char *time);
 void* mono_unity_get_field_address(MonoObject *obj, MonoVTable *vt, MonoClassField *field);
 
+MONO_API gboolean mono_unity_assembly_get_assemblyref_checked(MonoImage* image, int index, MonoAssemblyName* aname, MonoError* error);
 MONO_API MonoClass* mono_unity_class_get_checked(MonoImage* image, guint32 token, MonoError* error);
 MONO_API MonoMethod* mono_unity_get_method_checked(MonoImage* image, guint32 token, MonoClass* klass, MonoGenericContext* context, MonoError* error);
 MONO_API MonoClassField* mono_unity_field_from_token_checked(MonoImage *image, guint32 token, MonoClass **retklass, MonoGenericContext *context, MonoError *error);


### PR DESCRIPTION
Getting assembly refs could assert and kill the Unity editor if an invalid assembly was processed.

This adds support to address UUM-66498, but the fix won't be complete until this API usage is updated in Unity

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Improved @scott-ferguson-unity 
Mono: Added Unity Embedding API to load assembly refs with error checking.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->