### PR TITLE
Expand the GC bitmap size on 64 bit platforms

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -874,7 +874,8 @@ void*
 mono_gc_make_descr_from_bitmap (gsize *bitmap, int numbits)
 {
 	/* It seems there are issues when the bitmap doesn't fit: play it safe */
-	if (numbits >= 30)
+	#define MAX_GC_DESCR_BITS (sizeof(void*) * 8 - GC_DS_TAG_BITS)
+	if (numbits >= MAX_GC_DESCR_BITS)
 		return GC_NO_DESCRIPTOR;
 	else
 		return (gpointer)GC_make_descriptor ((GC_bitmap)bitmap, numbits);


### PR DESCRIPTION
The supported bitmap size in passed on the platform word/pointer size, so 64 bit platforms can use up to 62 bits, not 30.  This expands the size of objects we can use for precise scanning.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed Improved @scott-ferguson-unity 
Mono: Updated the GC bitmap size on 64 bit platforms

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->