### PR TITLE
[2023.3] Correct the selection of alloc/free functions for zlib

### DIFF
--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -76,6 +76,8 @@ CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle)
 		return NULL;
 
 	z = z_new0 (z_stream);
+	z->zalloc = z_alloc;
+	z->zfree = z_free;
 	if (compress) {
 		retval = deflateInit2 (z, Z_DEFAULT_COMPRESSION, Z_DEFLATED, gzip ? 31 : -15, 8, Z_DEFAULT_STRATEGY);
 	} else {
@@ -86,8 +88,6 @@ CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle)
 		free (z);
 		return NULL;
 	}
-	z->zalloc = z_alloc;
-	z->zfree = z_free;
 	result = z_new0 (ZStream);
 	result->stream = z;
 	result->func = func;


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/mono/pull/2032

This is a port of: https://github.com/mono/mono/pull/21759

Avoids segfault when working with zlib-ng.
See: 
https://github.com/zlib-ng/zlib-ng/issues/1708

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-72446 @scott-ferguson-unity:
Mono: Fix crash on access zip files on Linux distributions using zlib-ng (Fedora 40)

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->