### PR TITLE
Add UNITY_WIN_PLATFORM and use for platform check (case UUM-73753).

### DIFF
--- a/mcs/build/profiles/unityjit.make
+++ b/mcs/build/profiles/unityjit.make
@@ -11,7 +11,16 @@ profile-check:
 	@:
 
 DEFAULT_REFERENCES = mscorlib
-PROFILE_MCS_FLAGS = -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:UNITY_JIT -d:UNITY -d:WIN_PLATFORM -nowarn:1699 -nostdlib $(PLATFORM_DEBUG_FLAGS)
+
+
+ifeq ($(HOST_PLATFORM),win32)
+# The unityjit profiles for all platforms have had WIN_PLATFORM enabled
+# for a number of years/releases. Rather than introduce risk of changing this
+# add a unity specific version to selectively control changes to platform specific code.
+	PLATFORM_FLAGS = -d:UNITY_WIN_PLATFORM
+endif
+
+PROFILE_MCS_FLAGS = -d:NET_4_0 -d:NET_4_5 -d:NET_4_6 -d:MONO -d:UNITY_JIT -d:UNITY -d:WIN_PLATFORM $(PLATFORM_FLAGS) -nowarn:1699 -nostdlib $(PLATFORM_DEBUG_FLAGS)
 API_BIN_PROFILE = v4.7.1
 
 FRAMEWORK_VERSION = 4.5

--- a/mcs/class/System.IO.Compression/corefx/Interop.Libraries.cs
+++ b/mcs/class/System.IO.Compression/corefx/Interop.Libraries.cs
@@ -6,7 +6,7 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-#if WIN_PLATFORM
+#if (WIN_PLATFORM && !UNITY_JIT) || UNITY_WIN_PLATFORM
         internal const string CompressionNative = "__Internal";
 #else
         internal const string CompressionNative = "System.Native";


### PR DESCRIPTION
Similar change was done for unity-aot profile here https://github.com/Unity-Technologies/mono/commit/05281d87e1e22e55131f746d4a487224806d7334

Minimal version of initial proposed fix here https://github.com/Unity-Technologies/mono/pull/2033

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-73753 @joncham :
Mono: Fix exception when using System.IO.Compression.BrotliStream on Android.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
2023.3, 2022.3, 2021.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->