### PR TITLE
Enable intrinsification of System.Numerics types in corlib

### DIFF
--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -2058,12 +2058,14 @@ mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	const char *class_name;
 	MonoInst *simd_inst = NULL;
 
-	if (is_sys_numerics_assembly (m_class_get_image (cmethod->klass)->assembly)) {
+	if (mono_is_corlib_image (m_class_get_image (cmethod->klass)) ||
+	    is_sys_numerics_assembly (m_class_get_image (cmethod->klass)->assembly)) {
 		simd_inst = emit_sys_numerics_intrinsics (cfg, cmethod, fsig, args);
 		goto on_exit;
 	}
 
-	if (is_sys_numerics_vectors_assembly (m_class_get_image (cmethod->klass)->assembly)) {
+	if (mono_is_corlib_image (m_class_get_image (cmethod->klass)) ||
+	    is_sys_numerics_vectors_assembly (m_class_get_image (cmethod->klass)->assembly)) {
 		simd_inst = emit_sys_numerics_vectors_intrinsics (cfg, cmethod, fsig, args);
 		goto on_exit;
 	}


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-77339 @UnityAlex:
Mono: Fix issue where Vector and Vector do not receive hardware acceleration.
