### PR TITLE
Avoiding a memory leak in the Timer class SchedulerLoop

### DIFF
--- a/mcs/class/corlib/System.Threading/Timer.cs
+++ b/mcs/class/corlib/System.Threading/Timer.cs
@@ -390,7 +390,7 @@ namespace System.Threading
 				var comparer = new TimerComparer();
 
 				if (needReSort) {
-					list.Sort(comparer);
+					list.Sort(comparer.Compare);
 					needReSort = false;
 				}
 


### PR DESCRIPTION
Rather than calling the Sort overload that accepts the IComparer interface, we will call the overload that accepts the Comparison delegate.  Both overloads end up in the same place eventually.

There is a memory leak in the Mono runtime with the ldvirtftn opcode in a generic method. The opcode targets a generic interface's method on a struct instance. Each time ldvirtftn is called an unbox trampoline is created. The ldvirtftn leak will be filed separately upstream but this simple change avoids the bug for this scenario.


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Fixed UUM-76306 @bholmes :
Mono:Fixed JIT trampoline memory leak with Timers and Sockets.


**Backports**

 - 2023.3
 - 2022.3
 - 2021.1

