### PR TITLE
Use mobile PopulatePrefixList style when running Unity on Android

### DIFF
--- a/mcs/class/referencesource/System/net/System/Net/WebRequest.cs
+++ b/mcs/class/referencesource/System/net/System/Net/WebRequest.cs
@@ -556,6 +556,24 @@ namespace System.Net {
             res.Add(new WebRequestPrefixElement("https", http));
             res.Add(new WebRequestPrefixElement("file", new FileWebRequestCreator ()));
             res.Add(new WebRequestPrefixElement("ftp", new FtpWebRequestCreator ()));
+#elif UNITY
+			if (Console.IsRunningOnAndroid)
+			{
+				IWebRequestCreate http = new HttpRequestCreator ();
+	            res.Add(new WebRequestPrefixElement("http", http));
+	            res.Add(new WebRequestPrefixElement("https", http));
+	            res.Add(new WebRequestPrefixElement("file", new FileWebRequestCreator ()));
+	            res.Add(new WebRequestPrefixElement("ftp", new FtpWebRequestCreator ()));
+			}
+			else
+			{
+				object cfg = ConfigurationManager.GetSection ("system.net/webRequestModules");
+	            WebRequestModulesSection s = cfg as WebRequestModulesSection;
+	            if (s != null) {
+	                foreach (WebRequestModuleElement el in s.WebRequestModules)
+	                    res.Add (new WebRequestPrefixElement(el.Prefix, el.Type));
+	            }
+			}
 #else
             object cfg = ConfigurationManager.GetSection ("system.net/webRequestModules");
             WebRequestModulesSection s = cfg as WebRequestModulesSection;


### PR DESCRIPTION
forward-port of: https://github.com/Unity-Technologies/mono/pull/2059

Upstream mono does not rely on the machine config to populate the prefix list. After debugging it appears that while the machine config is read correctly the icall that fetches the type returns null for the FTP element. Populating the list in the same way as upstream fixes the issue. Populate is only called once as the result is cached so we won't be making frequent IO calls so this will not impact performance.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-75503 @UnityAlex:
Mono: Fixed issue with exception being thrown on WebRequest.Create on Android when the scripting backend is Mono.

**Backports**
2022.3