### PR TITLE
Avoiding a memory leak in the Timer class SchedulerLoop

### DIFF
--- a/mcs/class/corlib/System.Threading/Timer.cs
+++ b/mcs/class/corlib/System.Threading/Timer.cs
@@ -427,7 +427,7 @@ namespace System.Threading
 				}
 
 				if (needReSort) {
-					list.Sort(comparer);
+					list.Sort(comparer.Compare);
 					needReSort = false;
 				}
 


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/mono/pull/2062

Update to my previous commit.  The same change needed to be made here.

Followup to previous PR https://github.com/Unity-Technologies/mono/pull/2055


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No



**Release notes**

Fixed UUM-76306 @bholmes :
Mono:Fixed JIT trampoline memory leak with Timers and Sockets.


**Backports**

 - 2023.3
 - 2022.3
 - 2021.1