### PR TITLE
Bugfix/macos oob read

### DIFF
--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
@@ -347,6 +347,9 @@ struct DIRWrapper
     void* result;
     size_t curIndex;
     size_t numEntries;
+    char* entryNameStorage;
+    uint64_t entryNameStorageUsed;
+    uint64_t entryNameStorageCapacity;
 #if !HAVE_REWINDDIR
     char* dirPath;
 #endif

--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
@@ -338,21 +338,14 @@ enum NotifyEvents
     PAL_IN_ISDIR = 0x40000000,
 };
 
-#define READDIR_SORT 1
-
 struct DIRWrapper
 {
     DIR* dir;
-#if READDIR_SORT
     struct DirectoryEntry* result;
     size_t curIndex;
     size_t numEntries;
-    char* entryNameStorage;
-    uint64_t entryNameStorageUsed;
-    uint64_t entryNameStorageCapacity;
 #if !HAVE_REWINDDIR
     char* dirPath;
-#endif
 #endif
 };
 

--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
@@ -344,7 +344,7 @@ struct DIRWrapper
 {
     DIR* dir;
 #if READDIR_SORT
-    void* result;
+    struct DirectoryEntry* result;
     size_t curIndex;
     size_t numEntries;
     char* entryNameStorage;


### PR DESCRIPTION
This change relates to a possible segmentation violation discussed in Slack

When running the Editor on mac with [GuardMalloc](https://www.manpagez.com/man/3/guardmalloc/osx-10.6.php) enabled, a crash occurred inside `SystemNative_ReadDirR`, as we were reading beyond the end of the allocated page when `memcpy`-ing from a `dirent` returned by `readdir`, on [this line](https://github.com/Unity-Technologies/mono/blob/unity-main/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.c#L477):

`memcpy(&((struct dirent*)dirWrapper->result)[index], entry, sizeof(struct dirent));`

This is possibly related to another issue [discussed here](https://unity.slack.com/archives/C0E72RUEA/p1701896068204899).

Although the struct for `dirent` specifies a fixed buffer of 1024 characters, it looks like `readdir` doesn't actually allocate that full amount on macOS if it isn't needed - it'll just have enough of a trailing buffer to store the d_name (subject to alignment). The [readdir source](https://opensource.apple.com/source/Libc/Libc-262/gen/readdir.c.auto.html) seems to confirm this.

The fix in this PR changes the READDIR_SORT logic to store `DirectoryEntry` structs, rather than raw `dirents`. It also manages a separate allocation to contain the directory names.  One alternative would be to use `_DIRENT_HAVE_D_RECLEN` to copy only the valid length from the source dirent record, I'd have no objection to changing things towards that approach if it's preferred, but had initially settled on what's currently shown in the PR in the hope of it being more portable.

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Mono: Fix for a potential read beyond the end of a buffer on MacOS when iterating directories.

2022.3 LTS