### PR TITLE
Move encodings usage within the lock to make access thread safe.

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/text/encoding.cs
+++ b/mcs/class/referencesource/mscorlib/system/text/encoding.cs
@@ -438,14 +438,14 @@ namespace System.Text
 
             // Our Encoding
 
-            // See if we have a hash table with our encoding in it already.
-            if (encodings != null)
-                encodings.TryGetValue (codepage, out result);
-
-            if (result == null)
+            // Don't conflict with ourselves
+            lock (InternalSyncObject)
             {
-                // Don't conflict with ourselves
-                lock (InternalSyncObject)
+                // See if we have a hash table with our encoding in it already.
+                if (encodings != null)
+                    encodings.TryGetValue (codepage, out result);
+
+                if (result == null)
                 {
                     // Need a new hash table
                     // in case another thread beat us to creating the Dictionary


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-82959 @UnityAlex :
Mono: Fix exception being thrown due to a race condition within Encoding.GetEncoding.

**Backports**
6000, 2022.3