### PR TITLE
Fix memory overwrite when performing nested inlines with code coverag…

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4602,6 +4602,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	MonoMethod *prev_current_method;
 	MonoGenericContext *prev_generic_context;
 	gboolean ret_var_set, prev_ret_var_set, prev_disable_inline, virtual_ = FALSE;
+	MonoProfilerCoverageInfo *prev_coverage_info;
 
 	g_assert (cfg->exception_type == MONO_EXCEPTION_NONE);
 
@@ -4675,6 +4676,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	prev_current_method = cfg->current_method;
 	prev_generic_context = cfg->generic_context;
 	prev_disable_inline = cfg->disable_inline;
+	prev_coverage_info = cfg->coverage_info;
 
 	cfg->ret_var_set = FALSE;
 	cfg->inline_depth ++;
@@ -4699,6 +4701,7 @@ inline_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig,
 	cfg->generic_context = prev_generic_context;
 	cfg->ret_var_set = prev_ret_var_set;
 	cfg->disable_inline = prev_disable_inline;
+	cfg->coverage_info = prev_coverage_info;
 	cfg->inline_depth --;
 
 	if ((costs >= 0 && costs < 60) || inline_always || (costs >= 0 && (cmethod->iflags & METHOD_IMPL_ATTRIBUTE_AGGRESSIVE_INLINING))) {


### PR DESCRIPTION
…e enabled

The initial symptom was regular editor crashes on Mac for a customer I'm working with when entering & exiting play mode repeatedly. Crashes had very varied callstacks, but seemed to be pointing to memory stomping somewhere in the mono runtime.

Digging into it, I think the issue is that when we inline code (during [inline_method](https://github.com/Unity-Technologies/mono/blob/unity-main/mono/mini/method-to-ir.c#L4585)), we can [recursively call](https://github.com/Unity-Technologies/mono/blob/unity-main/mono/mini/method-to-ir.c#L4685) [mono_method_to_ir](https://github.com/Unity-Technologies/mono/blob/unity-main/mono/mini/method-to-ir.c#L6127). This function will [allocate a MonoProfilerCoverageInfo record](https://github.com/Unity-Technologies/mono/blob/unity-main/mono/mini/method-to-ir.c#L6214) for the method we're generating IR for, and assign it to the cfg struct, which is shared with the calling scope. If we inline a method with a smaller code size than the method in the outer scope, the smaller coverage buffer will remain assigned when we get back to the outer scope, and we'll [keep writing to it](https://github.com/Unity-Technologies/mono/blob/unity-main/mono/mini/method-to-ir.c#L6741) (beyond the end of the allocation). FWIW I've verified locally that this is happening by stepping through a failing case in the debugger.

It turned out that the project being investigated had Unity's Code Coverage package (com.unity.testtools.codecoverage) installed (1.2.5, although I think this should affect all/most versions), and `Window->Analysis->Code Coverage->Settings->Enable Code Coverage` was set to true (so code coverage information was always being tracked). If `Enable Code Coverage` is set to `false`, the crashes no longer reproduce.

The fix in the PR is just to keep hold of the outer scope's coverage buffer during inlining, and re-instate it in cfg when inlining is complete. It looks like we already follow this pattern for some other variables. We don't need to change anything re: lifetimes, as both records will still be deallocated by [mono_profiler_coverage_domain_free](https://github.com/Unity-Technologies/mono/blob/unity-main/mono/metadata/profiler.c#L340).

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-83778 @john-bell-unity :
Mono: Prevent a possible out-of-bounds memory write when inlining code with code coverage enabled.

**Backports**

2022.3