### PR TITLE
2022.3 backport 83824

### DIFF
--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
@@ -347,6 +347,9 @@ struct DIRWrapper
     void* result;
     size_t curIndex;
     size_t numEntries;
+    char* entryNameStorage;
+    uint64_t entryNameStorageUsed;
+    uint64_t entryNameStorageCapacity;
 #if !HAVE_REWINDDIR
     char* dirPath;
 #endif

--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
@@ -338,21 +338,14 @@ enum NotifyEvents
     PAL_IN_ISDIR = 0x40000000,
 };
 
-#define READDIR_SORT 1
-
 struct DIRWrapper
 {
     DIR* dir;
-#if READDIR_SORT
     struct DirectoryEntry* result;
     size_t curIndex;
     size_t numEntries;
-    char* entryNameStorage;
-    uint64_t entryNameStorageUsed;
-    uint64_t entryNameStorageCapacity;
 #if !HAVE_REWINDDIR
     char* dirPath;
-#endif
 #endif
 };
 

--- a/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
+++ b/external/corefx-bugfix/src/Native/Unix/System.Native/pal_io.h
@@ -344,7 +344,7 @@ struct DIRWrapper
 {
     DIR* dir;
 #if READDIR_SORT
-    void* result;
+    struct DirectoryEntry* result;
     size_t curIndex;
     size_t numEntries;
     char* entryNameStorage;


### PR DESCRIPTION
backport of: https://github.com/Unity-Technologies/mono/pull/2066 -- cherrypick was clean

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-83824 @john-bell-unity :
Mono: Fix for a potential read beyond the end of a buffer on MacOS when iterating directories.