### PR TITLE
UUM-79025 - Crash on RaiseException

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3676,6 +3676,10 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 	case MONO_TYPE_PTR:
 		is_ptr = TRUE;
 		break;
+	case MONO_TYPE_FNPTR:
+		mono_error_set_error(error, MONO_ERROR_ARGUMENT, "Cannot get value of a function pointer field");
+		goto return_null;
+
 	default:
 		g_error ("type 0x%x not handled in "
 			 "mono_field_get_value_object", type->type);


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->
Added a MONO_TYPE_FNPTR case to mono_field_get_value_object_checked to set error instead of crash

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-79025 @PatrickSycz:
Mono: Change to prevent crash for MONO_TYPE_FNPTR cases in mono_field_get_value_object_checked

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
2021.3.X, 2022.3.X

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->