### PR TITLE
[UUM-78961] Fixed initialization of a class which has last fields in a table with 65535 field entries and the next class having no fields

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -634,8 +634,9 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 
 	if (tt->rows > tidx){		
 		mono_metadata_decode_row (tt, tidx, cols_next, MONO_TYPEDEF_SIZE);
-		field_last  = cols_next [MONO_TYPEDEF_FIELD_LIST] - 1;
-		method_last = cols_next [MONO_TYPEDEF_METHOD_LIST] - 1;
+		// check if the next row has fields at all, if not, then continue run till the end of the table
+		field_last  = cols_next [MONO_TYPEDEF_FIELD_LIST] ? cols_next [MONO_TYPEDEF_FIELD_LIST] - 1 : image->tables [MONO_TABLE_FIELD].rows;
+		method_last = cols_next [MONO_TYPEDEF_METHOD_LIST] ? cols_next [MONO_TYPEDEF_METHOD_LIST] - 1 : image->tables [MONO_TABLE_METHOD].rows;
 	} else {
 		field_last  = image->tables [MONO_TABLE_FIELD].rows;
 		method_last = image->tables [MONO_TABLE_METHOD].rows;

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -634,7 +634,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 
 	if (tt->rows > tidx){		
 		mono_metadata_decode_row (tt, tidx, cols_next, MONO_TYPEDEF_SIZE);
-		// check if the next row has fields at all, if not, then continue run till the end of the table
+		/* check if the next row has fields at all, if not, then continue run till the end of the table */
 		field_last  = cols_next [MONO_TYPEDEF_FIELD_LIST] ? cols_next [MONO_TYPEDEF_FIELD_LIST] - 1 : image->tables [MONO_TABLE_FIELD].rows;
 		method_last = cols_next [MONO_TYPEDEF_METHOD_LIST] ? cols_next [MONO_TYPEDEF_METHOD_LIST] - 1 : image->tables [MONO_TABLE_METHOD].rows;
 	} else {
@@ -642,10 +642,12 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		method_last = image->tables [MONO_TABLE_METHOD].rows;
 	}
 
+	/* validate for both fields and methods that class has non-null list entries */
 	if (cols [MONO_TYPEDEF_FIELD_LIST] && 
 	    cols [MONO_TYPEDEF_FIELD_LIST] <= image->tables [MONO_TABLE_FIELD].rows)
 		mono_class_set_field_count (klass, field_last - first_field_idx);
-	if (cols [MONO_TYPEDEF_METHOD_LIST] <= image->tables [MONO_TABLE_METHOD].rows)
+	if (cols [MONO_TYPEDEF_METHOD_LIST] && 
+	    cols [MONO_TYPEDEF_METHOD_LIST] <= image->tables [MONO_TABLE_METHOD].rows)
 		mono_class_set_method_count (klass, method_last - first_method_idx);
 
 	/* reserve space to store vector pointer in arrays */


### PR DESCRIPTION
[UUM-78961](https://jira.unity3d.com/browse/UUM-78961) Fixed initialization of a class which has last fields in a table with 65535 field entries and the next class having no fields.

Mono crashes on allocation when initializing a class which has fields or methods that run till the end of the metadata table and the last TypeDef has no fields. This happens die to the last TypeDef without any fields having FieldList index 0 (null field).

The assembly was generated by Mono.Cecil in IL postrpocessor and thus several fix options were considered:

- (Current PR) Fix mono 
- Fix Mono.Cecil
- Fix in IL postprocessor

There are several related sections in the ECMA-335 standard interpreting which lead to the current fix.

- `II.22.37 TypeDef : 0x02` section

> FieldList (an index into the Field table; it marks the first of a contiguous run of
> Fields owned by this Type). The run continues to the smaller of:
> - the last row of the Field table
> - the next run of Fields, found by inspecting the FieldList of the next row in this TypeDef table

-  `II.22.37 TypeDef : 0x02` "This contains informative text only" section

> 14. FieldList can be null or non-null
> 17. If FieldList is non-null, it shall index a valid row in the Field table, where valid
> means 1 <= row <= rowcount+1 [ERROR]

 
- `II.24.2.6 #~ stream` section

> If e is a simple index into a table with index i, it is stored using 2 bytes if table i has
> less than 216 rows, otherwise it is stored using 4 bytes

Fixing Mono.Cecil to use large indices for the FieldList doesn't play well with `II.24.2.6 #~ stream` section as every existing reader won't be able to read the generated assembly.

Fixing IL postprocessor to generate a dummy field fixes that specific postprocessor usage case and won't fix loading any other assembly compiled externally.

I think fixing mono is the best option as it would ensure we can load assembly with this edge case metadata table generated by other sources too (cecil, netcore compiler, etc).
The current fix addressed FieldList and MethodList cases.

**Related discussions:**

- .NET runtime failing to load methods if there are 65535 methods - https://github.com/dotnet/runtime/issues/94892
- Mono.Cecil issue with loading 65535 params in metadata table - https://github.com/jbevain/cecil/issues/913

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-78961 @alexeyzakharov:
Mono: Fixed crash when loading a class which contains fields at the end of the metadata table with a table size 65535.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
6, 2022.3

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->

