### PR TITLE
[2022.3][PLAT-11775][Android] Add support for 16kb page sizes

### DIFF
--- a/external/buildscripts/build.pl
+++ b/external/buildscripts/build.pl
@@ -823,7 +823,7 @@ if ($build)
 			$ENV{LDFLAGS} = "-Wl,--wrap,sigaction -L$kraitPatchPath/obj/local/armeabi-v7a -lkrait-signal-handler $ENV{LDFLAGS}";
 		}
 
-		$ENV{LDFLAGS} = "-Wl,--no-undefined -Wl,--gc-sections -ldl -lm -llog -lc $ENV{LDFLAGS}";
+		$ENV{LDFLAGS} = "-Wl,--no-undefined -Wl,--gc-sections -ldl -lm -llog -lc -Wl,-z,max-page-size=16384 $ENV{LDFLAGS}";
 
 		print "\n";
 		print ">>> Environment:\n";


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

All `.so` libraries included in an Android `.apk` need to be updated from 4kb aligment (default) to 16kb. This is a requirement from Google to accommodate for new (unreleased) devices that will have 16kb page sizes.

- More information here: [16KB Page Size What / So What / Now What
](https://docs.google.com/document/d/1HZvw40JWGAlVLD2-qqRUf8wZ4ccX8MiMJsSAKrL3JRk/edit?tab=t.0#heading=h.mr9pd0mqty70)

The changes have been already tested downstream in these branches:
- [il2cpp#2022.3/platform/android/test-16kb-libs](https://github.cds.internal.unity3d.com/unity/il2cpp/commits/2022.3/platform/android/test-16kb-libs/)
- [unity#2022.3/platform/android/test-16kb-libs](https://github.cds.internal.unity3d.com/unity/unity/commits/2022.3/platform/android/test-16kb-libs)

### Why is this landing first on 22.3 and 21.3?
We are landing this first in `2022.3` and `2021.3`, since due to contractual obligations with Google we want to make sure 16kb devices are supported as soon as possible. LTS release cadence is a month, and the sooner we can make it available to users the sooner they can test on their side. Google will make it a requirement mid-2025, not allowing to publish apps on the play store if `.so` libs are not aligned to 16kb.  Read more from Google [here](https://developer.android.com/guide/practices/page-sizes).

Once 22.3 and 21.3 have landed, our focus will be to land NDK27 update in Unity-6 and include these 16kb changes.

----
- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported? 
  - [x] Yes - This will eventually be backported to 2021.3
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed [PLAT-9673](https://jira.unity3d.com/browse/PLAT-11775) @manuel-gil:
Mono: [Android] Add support for 16kb page sizes 

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->