### PR TITLE
[2022.3] Fix class initialization during class enumeration

### DIFF
--- a/mono/metadata/unity-memory-info.h
+++ b/mono/metadata/unity-memory-info.h
@@ -6,8 +6,4 @@ typedef void(*ClassReportFunc) (MonoClass* klass, void *user_data);
 
 MONO_API void mono_unity_class_for_each(ClassReportFunc callback, void* user_data);
 
-typedef struct MonoManagedMemorySnapshot MonoManagedMemorySnapshot;
-MONO_API MonoManagedMemorySnapshot* mono_unity_capture_memory_snapshot();
-MONO_API void mono_unity_free_captured_memory_snapshot(MonoManagedMemorySnapshot* snapshot);
-
 #endif


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-90945 @alexeyzakharov:
Mono: Fixed Editor freeze when taking a Snapshot with a Memory Profiler

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**

- [6000.1](https://github.com/Unity-Technologies/mono/pull/2095)
- [6000.0](https://github.com/Unity-Technologies/mono/pull/2098)
- [2022.3](https://github.com/Unity-Technologies/mono/pull/2097)

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->

**Changes:**

Fixed a deadlock when enumerating image types which was causes by creating a type from a token.

For Memory Profiler needs we actually want to avoid a situation when we create a type as it causes types inflation and memory grow. Types enumeration could be done with the help of `class_cache` where every created type is added upon initialization.

- Moved to enumerating `image->class_cache` instead of image tokens to get image classes
- Removed not used anymore `mono_unity_capture_memory_snapshot` methods from API surface

**Testing:**

- Validated repro project with mono fixes - no deadlock
- Validated MemorySnapshot tests locally on Windows - Editor + WindowsStandalone pass
- Validated TestProject of Memory Profiler package locally on Windows - Editor passes
- Validated MemorySnapshot and memoryprofiler package tests [with a build.7z from 6000.1 branch](https://unity-ci.cds.internal.unity3d.com/project/3/branch/profiler%2Fbugfixes%2Fuum-90945?nav=jobDefinitions&root=true)
  - https://unity-ci.cds.internal.unity3d.com/job/44722241
  - https://unity-ci.cds.internal.unity3d.com/job/44722242
  - https://unity-ci.cds.internal.unity3d.com/job/44722226/dependency-graph