### PR TITLE
Fix issue where collisions in the function pointer to delegate map would result in stale function pointers being used (UUM-87193)

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -407,13 +407,11 @@ delegate_hash_table_add (MonoDelegateHandle d)
 			g_hash_table_insert (delegate_hash_table, delegate_trampoline, gchandle);
 		}
 	} else {
-		if (g_hash_table_lookup (delegate_hash_table, delegate_trampoline) == NULL) {
-			MonoGCHandle gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, d), FALSE);
-			// This delegate will always be associated with its delegate_trampoline in the table.
-			// We don't free this delegate object because it is too expensive to keep track of these
-			// pairs and avoid races with the delegate finalization.
-			g_hash_table_insert (delegate_hash_table, delegate_trampoline, gchandle);
-		}
+		MonoGCHandle gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, d), FALSE);
+		// If a delegate already exists with a matching function pointer we assume it's old as
+		// we've just jitted a new one and replace it. This is preferred to continuing to run
+		// with stale data in the map that could be used later.
+		g_hash_table_insert (delegate_hash_table, delegate_trampoline, gchandle);
 	}
 	mono_marshal_unlock ();
 }


### PR DESCRIPTION
This fixes an underlying issue with the map that preserves the connection between function pointers and their managed delegate equivalents. The map itself is not domain reload aware and is not cleared on domain reload. Additionally the mechanism to remove an entry from the map via finalizer ignores delegates that are static. The problem that arises over time is as the map grows it is more likely for there to be a collision in the map since the key value is the address of the jitted function pointer. The default behavior when there is a collision with an older value is to do nothing and continue executing which leads to unwanted behavior.

The fix is to change the default behavior to always add the entry regardless if there is a collision with an older function pointer as it's invalid anyway.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-87193 @UnityAlex:
Mono: Fixed InvalidCastExceptions occasionally being thrown by entity workers after a domain reload.

**Backports**
2022.3, 6000.0, 6000.1
