### PR TITLE
Fix issue where macOS machines set to Morocco/Casablanca Timezone were one hour behind (UUM-87263)

### DIFF
--- a/external/corefx-bugfix/src/Common/src/CoreLib/System/TimeZoneInfo.Unix.cs
+++ b/external/corefx-bugfix/src/Common/src/CoreLib/System/TimeZoneInfo.Unix.cs
@@ -1009,21 +1009,12 @@ namespace System
                 // NOTE: index == dts.Length
                 DateTime startTransitionDate = dts[index - 1];
 
-                if (!string.IsNullOrEmpty(futureTransitionsPosixFormat))
-                {
-                    AdjustmentRule r = TZif_CreateAdjustmentRuleForPosixFormat(futureTransitionsPosixFormat, startTransitionDate, timeZoneBaseUtcOffset);
-
-                    if (r != null)
-                    {
-                        if (!IsValidAdjustmentRuleOffest(timeZoneBaseUtcOffset, r))
-                        {
-                            NormalizeAdjustmentRuleOffset(timeZoneBaseUtcOffset, ref r);
-                        }
-
-                        rulesList.Add(r);
-                    }
-                }
-                else
+                // pulled in from this fix
+                // https://github.com/dotnet/runtime/pull/458/
+                AdjustmentRule r = !string.IsNullOrEmpty(futureTransitionsPosixFormat) ?
+                    TZif_CreateAdjustmentRuleForPosixFormat(futureTransitionsPosixFormat, startTransitionDate, timeZoneBaseUtcOffset) :
+                    null;
+                if (r == null)
                 {
                     // just use the last transition as the rule which will be used until the end of time
 
@@ -1032,22 +1023,22 @@ namespace System
                     TimeSpan daylightDelta = transitionType.IsDst ? transitionOffset : TimeSpan.Zero;
                     TimeSpan baseUtcDelta = transitionType.IsDst ? TimeSpan.Zero : transitionOffset;
 
-                    AdjustmentRule r = AdjustmentRule.CreateAdjustmentRule(
+                    r = AdjustmentRule.CreateAdjustmentRule(
                         startTransitionDate,
                         DateTime.MaxValue,
                         daylightDelta,
-                        default(TransitionTime),
-                        default(TransitionTime),
+                        default,
+                        default,
                         baseUtcDelta,
                         noDaylightTransitions: true);
-
-                    if (!IsValidAdjustmentRuleOffest(timeZoneBaseUtcOffset, r))
-                    {
-                        NormalizeAdjustmentRuleOffset(timeZoneBaseUtcOffset, ref r);
-                    }
-
-                    rulesList.Add(r);
                 }
+
+                if (!IsValidAdjustmentRuleOffest(timeZoneBaseUtcOffset, r))
+                {
+                    NormalizeAdjustmentRuleOffset(timeZoneBaseUtcOffset, ref r);
+                }
+
+                rulesList.Add(r);
             }
 
             index++;
@@ -1141,15 +1132,20 @@ namespace System
                             daylightSavingsTimeSpan = TZif_CalculateTransitionOffsetFromBase(daylightSavingsTimeSpan, baseOffset);
                         }
 
-                        TransitionTime dstStart = TZif_CreateTransitionTimeFromPosixRule(start, startTime);
-                        TransitionTime dstEnd = TZif_CreateTransitionTimeFromPosixRule(end, endTime);
+                        TransitionTime? dstStart = TZif_CreateTransitionTimeFromPosixRule(start, startTime);
+                        TransitionTime? dstEnd = TZif_CreateTransitionTimeFromPosixRule(end, endTime);
+
+                        if (dstStart == null || dstEnd == null)
+                        {
+                            return null;
+                        }
 
                         return AdjustmentRule.CreateAdjustmentRule(
                             startTransitionDate,
                             DateTime.MaxValue,
                             daylightSavingsTimeSpan,
-                            dstStart,
-                            dstEnd,
+                            dstStart.GetValueOrDefault(),
+                            dstEnd.GetValueOrDefault(),
                             baseOffset,
                             noDaylightTransitions: false);
                     }
@@ -1240,11 +1236,11 @@ namespace System
             return timeOfDay;
         }
 
-        private static TransitionTime TZif_CreateTransitionTimeFromPosixRule(string date, string time)
+        private static TransitionTime? TZif_CreateTransitionTimeFromPosixRule(string date, string time)
         {
             if (string.IsNullOrEmpty(date))
             {
-                return default(TransitionTime);
+                return null;
             }
 
             if (date[0] == 'M')
@@ -1290,7 +1286,8 @@ namespace System
                     //
                     // If we need to support n format, we'll have to have a floating adjustment rule support this case.
 
-                    throw new InvalidTimeZoneException(SR.InvalidTimeZone_NJulianDayNotSupported);
+                    // Since we can't support this rule, return null to indicate to skip the POSIX rule.
+                    return null;
                 }
 
                 // Julian day


### PR DESCRIPTION
Backport of #2103
cherrypick was clean

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

Fixed UUM-87263 @kkukshtel:
Mono: Fixed issue where macOS machines set to Morocco/Casablanca Timezone were one hour behind

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->