### PR TITLE
[6000.1] Make sure tooltip window handle is being destroyed when parent window/control is destroyed

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -6552,7 +6552,7 @@ namespace System.Windows.Forms {
 		private ToolTip ToolTipWindow {
 			get {
 				if (tooltip_window == null)
-					tooltip_window = new ToolTip ();
+					tooltip_window = new ToolTip (this);
 
 				return tooltip_window;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
@@ -2239,7 +2239,7 @@ namespace System.Windows.Forms
 		
 		private int filterIndex = 1;
 		
-		private ToolTip toolTip;
+		public ToolTip toolTip;
 		private int oldItemIndexForToolTip = -1;
 		
 		private ContextMenu contextMenu;
@@ -2295,10 +2295,6 @@ namespace System.Windows.Forms
 			SuspendLayout ();
 			
 			contextMenu = new ContextMenu ();
-			
-			toolTip = new ToolTip ();
-			toolTip.InitialDelay = 300;
-			toolTip.ReshowDelay = 0; 
 			
 			// contextMenu
 			
@@ -2456,6 +2452,18 @@ namespace System.Windows.Forms
 			
 			get {
 				return selectedFilesString;
+			}
+		}
+
+		private ToolTip ToolTipWindow {
+			get {
+				if (toolTip == null) {
+					toolTip = new ToolTip(this);
+					toolTip.InitialDelay = 300;
+					toolTip.ReshowDelay = 0;
+				}
+
+				return toolTip;
 			}
 		}
 		
@@ -2891,8 +2899,8 @@ namespace System.Windows.Forms
 				if (currentItemIndex != oldItemIndexForToolTip) {
 					oldItemIndexForToolTip = currentItemIndex;
 					
-					if (toolTip != null && toolTip.Active)
-						toolTip.Active = false;
+					if (ToolTipWindow.Active)
+						ToolTipWindow.Active = false;
 					
 					FSEntry fsEntry = item.FSEntry;
 					
@@ -2907,12 +2915,12 @@ namespace System.Windows.Forms
 					else
 						output = Locale.GetText("File: {0}", fsEntry.FullName);
 					
-					toolTip.SetToolTip (this, output);	
+					ToolTipWindow.SetToolTip (this, output);
 					
-					toolTip.Active = true;
+					ToolTipWindow.Active = true;
 				}
 			} else
-				toolTip.Active = false;
+				ToolTipWindow.Active = false;
 			
 			base.OnMouseMove (e);
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/FileDialog.cs
@@ -2239,7 +2239,7 @@ namespace System.Windows.Forms
 		
 		private int filterIndex = 1;
 		
-		public ToolTip toolTip;
+		private ToolTip toolTip;
 		private int oldItemIndexForToolTip = -1;
 		
 		private ContextMenu contextMenu;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/InternalWindowManager.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/InternalWindowManager.cs
@@ -1072,7 +1072,7 @@ namespace System.Windows.Forms {
 			}
 
 			if (tooltip == null)
-				tooltip = new ToolTip.ToolTipWindow ();
+				tooltip = new ToolTip.ToolTipWindow (form);
 			else if (tooltip.Text == text && tooltip.Visible)
 				return;
 			else if (tooltip.Visible)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -271,8 +271,6 @@ namespace System.Windows.Forms
 			items_location = new Point [16];
 			items_matrix_location = new ItemMatrixLocation [16];
 			reordered_items_indices = new int [16];
-			item_tooltip = new ToolTip ();
-			item_tooltip.Active = false;
 			insertion_mark = new ListViewInsertionMark (this);
 
 			InternalBorderStyle = BorderStyle.Fixed3D;
@@ -289,7 +287,6 @@ namespace System.Windows.Forms
 
 			v_scroll = new ImplicitVScrollBar ();
 			Controls.AddImplicit (this.v_scroll);
-
 			h_marker = v_marker = 0;
 			keysearch_tickcnt = 0;
 
@@ -316,7 +313,7 @@ namespace System.Windows.Forms
 		}
 		#endregion	// Public Constructors
 
-		#region Private Internal Properties
+		#region Private & Internal Properties
 		internal Size CheckBoxSize {
 			get {
 				if (this.check_boxes) {
@@ -375,6 +372,16 @@ namespace System.Windows.Forms
 		internal ColumnHeader EnteredColumnHeader {
 			get {
 				return header_control.EnteredColumnHeader;
+			}
+		}
+
+		private ToolTip ToolTipWindow {
+			get {
+				if (item_tooltip == null) {
+					item_tooltip = new ToolTip(this);
+					item_tooltip.Active = false;
+				}
+				return item_tooltip;
 			}
 		}
 		#endregion	// Private Internal Properties
@@ -815,7 +822,7 @@ namespace System.Windows.Forms
 			}
 			set {
 				show_item_tooltips = value;
-				item_tooltip.Active = false;
+				ToolTipWindow.Active = false;
 			}
 		}
 
@@ -2779,11 +2786,11 @@ namespace System.Windows.Forms
 
 				if (owner.ShowItemToolTips) {
 					if (item == null) {
-						owner.item_tooltip.Active = false;
+						owner.ToolTipWindow.Active = false;
 						prev_tooltip_item = null;
 					} else if (item != prev_tooltip_item && item.ToolTipText.Length > 0) {
-						owner.item_tooltip.Active = true;
-						owner.item_tooltip.SetToolTip (owner, item.ToolTipText);
+						owner.ToolTipWindow.Active = true;
+						owner.ToolTipWindow.SetToolTip (owner, item.ToolTipText);
 						prev_tooltip_item = item;
 					}
 				}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -287,6 +287,7 @@ namespace System.Windows.Forms
 
 			v_scroll = new ImplicitVScrollBar ();
 			Controls.AddImplicit (this.v_scroll);
+
 			h_marker = v_marker = 0;
 			keysearch_tickcnt = 0;
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/StatusBar.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/StatusBar.cs
@@ -466,7 +466,7 @@ namespace System.Windows.Forms {
 		private ToolTip ToolTipWindow {
 			get {
 				if (tooltip_window == null)
-					tooltip_window = new ToolTip ();
+					tooltip_window = new ToolTip (this);
 
 				return tooltip_window;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TabControl.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TabControl.cs
@@ -1509,7 +1509,7 @@ namespace System.Windows.Forms {
 			}
 
 			if (tooltip == null) {
-				tooltip = new ToolTip ();
+				tooltip = new ToolTip (this);
 				tooltip_timer = new Timer ();
 				tooltip_timer.Tick += new EventHandler (ToolTipTimerTick);
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolBar.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolBar.cs
@@ -899,7 +899,7 @@ namespace System.Windows.Forms
 				return;
 
 			if (tip_window == null)
-				tip_window = new ToolTip ();
+				tip_window = new ToolTip (this);
 
 			ToolBarItem item = ItemAtPoint (PointToClient (Control.MousePosition));
 			current_item = item;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -1572,7 +1572,7 @@ namespace System.Windows.Forms
 		private ToolTip ToolTipWindow {
 			get {
 				if (tooltip_window == null)
-					tooltip_window = new ToolTip ();
+					tooltip_window = new ToolTip (this);
 					
 				return tooltip_window;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripTextBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripTextBox.cs
@@ -568,7 +568,7 @@ namespace System.Windows.Forms
 			private ToolTip ToolTipWindow {
 				get {
 					if (tooltip_window == null)
-						tooltip_window = new ToolTip ();
+						tooltip_window = new ToolTip (this);
 
 					return tooltip_window;
 				}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolTip.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolTip.cs
@@ -75,7 +75,7 @@ namespace System.Windows.Forms {
 			#endregion	// ToolTipWindow Class Local Variables
 			
 			#region ToolTipWindow Class Constructor
-			internal ToolTipWindow() {
+			internal ToolTipWindow(Control owner = null) {
 				Visible = false;
 				Size = new Size(100, 20);
 				ForeColor = ThemeEngine.Current.ColorInfoText;
@@ -94,8 +94,17 @@ namespace System.Windows.Forms {
 				} else
 					SetStyle (ControlStyles.Opaque, true);
 
-				SetTopLevel (true);
+				if (owner == null)
+				{
+					SetTopLevel (true);
+				}
+				else
+				{
+					SetTopLevel (false);
+					owner.Controls.Add(this);
+				}
 			}
+
 
 			#endregion	// ToolTipWindow Class Constructor
 
@@ -288,7 +297,7 @@ namespace System.Windows.Forms {
 		#endregion	// ToolTipWindow Class
 
 		#region Public Constructors & Destructors
-		public ToolTip() {
+		public ToolTip(Control owner = null) {
 
 			// Defaults from MS
 			is_active = true;
@@ -307,10 +316,11 @@ namespace System.Windows.Forms {
 			tooltip_strings = new Hashtable(5);
 			controls = new ArrayList(5);
 
-			tooltip_window = new ToolTipWindow();
+			tooltip_window = new ToolTipWindow(owner);
 			tooltip_window.MouseLeave += new EventHandler(control_MouseLeave);
 			tooltip_window.Draw += new DrawToolTipEventHandler (tooltip_window_Draw);
 			tooltip_window.Popup += new PopupEventHandler (tooltip_window_Popup);
+
 
 			// UIA Framework: Static event handlers
 			tooltip_window.UnPopup += delegate (object sender, PopupEventArgs args) {
@@ -321,8 +331,8 @@ namespace System.Windows.Forms {
 			timer = new Timer();
 			timer.Enabled = false;
 			timer.Tick +=new EventHandler(timer_Tick);
-
 		}
+
 
 
 		#region UIA Framework: Events, Delegates and Methods

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolTip.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolTip.cs
@@ -94,12 +94,9 @@ namespace System.Windows.Forms {
 				} else
 					SetStyle (ControlStyles.Opaque, true);
 
-				if (owner == null)
-				{
+				if (owner == null) {
 					SetTopLevel (true);
-				}
-				else
-				{
+				} else {
 					SetTopLevel (false);
 					owner.Controls.Add(this);
 				}
@@ -321,7 +318,6 @@ namespace System.Windows.Forms {
 			tooltip_window.Draw += new DrawToolTipEventHandler (tooltip_window_Draw);
 			tooltip_window.Popup += new PopupEventHandler (tooltip_window_Popup);
 
-
 			// UIA Framework: Static event handlers
 			tooltip_window.UnPopup += delegate (object sender, PopupEventArgs args) {
 				OnUnPopup (args);
@@ -331,8 +327,8 @@ namespace System.Windows.Forms {
 			timer = new Timer();
 			timer.Enabled = false;
 			timer.Tick +=new EventHandler(timer_Tick);
-		}
 
+		}
 
 
 		#region UIA Framework: Events, Delegates and Methods

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
@@ -2229,14 +2229,19 @@ namespace System.Windows.Forms {
 			tooltip_currently_showing = null;
 		}
 
-		private ToolTip ToolTipWindow {
-			get {
+		private ToolTip ToolTipWindow
+		{
+			get
+			{
 				if (tooltip_window == null)
-					tooltip_window = new ToolTip ();
+				{
+					tooltip_window = new ToolTip(this);
+				}
 
 				return tooltip_window;
 			}
 		}
+
 		#endregion
 		
 		#endregion	// Internal & Private Methods and Properties

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
@@ -2229,19 +2229,14 @@ namespace System.Windows.Forms {
 			tooltip_currently_showing = null;
 		}
 
-		private ToolTip ToolTipWindow
-		{
-			get
-			{
+		private ToolTip ToolTipWindow {
+			get {
 				if (tooltip_window == null)
-				{
 					tooltip_window = new ToolTip(this);
-				}
-
+				
 				return tooltip_window;
 			}
 		}
-
 		#endregion
 		
 		#endregion	// Internal & Private Methods and Properties

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
@@ -2232,8 +2232,8 @@ namespace System.Windows.Forms {
 		private ToolTip ToolTipWindow {
 			get {
 				if (tooltip_window == null)
-					tooltip_window = new ToolTip(this);
-				
+					tooltip_window = new ToolTip (this);
+
 				return tooltip_window;
 			}
 		}


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

Inside Systems.Windows.Forms various dialogs and views use and create Tooltip window. The tooltip window is special in a way that is never added to the controls of the window which created the tooltip resulting in never being destroyed with the main window. After the tooltip window is used and domain reload happens, focusing on a newly created main window can result in a crash as the tooltip's registered class object no longer exists in memory. 

This PR adds two things: 

1. provides a way to set parent/owner for the tooltip window so it can be added to the controls of its owner to be destroyed when its owner is
2. Make sure that classes using the tooltip don't create it in their constructor as that is too early for registering with controls

The fix is applied to the following classes instantiating the tooltip:
- `datagridview`
- `internalwindowmanager`
- `filedialog `
- `tabcontrol`
- `statusbar `
- `listview	`
- `toolstriptextbox`
- `toolstrip`		
- `toolbar	`
- `treeview`

Fix is not applied to the following classes instantiating tooltip as there is no obvious or guaranteed owner:

- `helpprovider`
- `errorprovider `

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-79065 @zorana.curkovic
Mono: Prevent the crash on domain reload when Windows Form is using a tooltip window.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.

List the versions of Unity where this change should be back ported here.
-->
**6000.0**
**2022.3**
**2021.3**
<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->