### PR TITLE
Debugger: Prevent Abort on Invalid Virtual Method

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6545,6 +6545,10 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 			PRINT_DEBUG_MSG (1, "[%p] Error: Interface method invoked without this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 			return ERR_INVALID_ARGUMENT;
 		}
+		if (!mono_object_isinst_checked(this_arg, m->klass, error)) {
+			PRINT_DEBUG_MSG (1, "[%p] Error: Interface method invoked on object that doesn't implement the interface.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+			return ERR_INVALID_ARGUMENT;
+		}
 		m = mono_object_get_virtual_method_internal (this_arg, m);
 		/* Transform this to the format the rest of the code expects it to be */
 		if (m_class_is_valuetype (m->klass)) {
@@ -6554,6 +6558,10 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 	} else if ((m->flags & METHOD_ATTRIBUTE_VIRTUAL) && !m_class_is_valuetype (m->klass) && invoke->flags & INVOKE_FLAG_VIRTUAL) {
 		if (!this_arg) {
 			PRINT_DEBUG_MSG (1, "[%p] Error: invoke with INVOKE_FLAG_VIRTUAL flag set without this argument.\n", (gpointer) (gsize) mono_native_thread_id_get ());
+			return ERR_INVALID_ARGUMENT;
+		}
+		if (!mono_object_isinst_checked(this_arg, m->klass, error)) {
+			PRINT_DEBUG_MSG (1, "[%p] Error: invoke with INVOKE_FLAG_VIRTUAL flag on object that object that doesn't implement the method.\n", (gpointer) (gsize) mono_native_thread_id_get ());
 			return ERR_INVALID_ARGUMENT;
 		}
 		m = mono_object_get_virtual_method_internal (this_arg, m);


### PR DESCRIPTION
If the debugger is asked to invoke an interface or virtual method on a class the mono_object_get_virtual_method_internal will assert & abort (or crash).

mono_object_get_virtual_method_internal assumes that it is being asked to invoke a virtual method on an instance that implements it.  If that's not true it will assert & abort or access invalid memory if assertions are disabled.

To protect against this we check if the this_arg can be cast to the interface or base class type.  If it can then we should be safe to call mono_object_get_virtual_method_internal.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-97917 @scott-ferguson-unity
Mono: Prevent debugger crash when watching or evaluating an interface property or method without an instance (i.e. nameof(IInterface.Property).

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->