### PR TITLE
Revert "Enable intrinsification of System.Numerics types in corlib"

### DIFF
--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -37,7 +37,7 @@ commands:
 
     # Step 2 - clone unity/il2cpp into $env:PRTOOLS_BUILD_DIR\il2cpp (C:\buildslave\unity\il2cpp)
     - command: |
-
+        git config --global core.longpaths true
         cd $env:PRTOOLS_BUILD_DIR
 
         git clone --recurse-submodules https://github.cds.internal.unity3d.com/unity/il2cpp.git il2cpp
@@ -48,7 +48,6 @@ commands:
     - command: |
 
         cd $env:UNITY_SOURCE_PRTOOLS_DIR
-        git config --global core.longpaths true
         cmd /v /c dotnet run --project $env:YAMATO_WORK_DIR\prtools\PRTools\PRTools.csproj --test-mono-il2cpp-deps=$env:YAMATO_SOURCE_DIR/stevedore/artifactid.txt --backport=$env:BACKPORT_BRANCH --custom-il2cpp-repo-path=$env:PRTOOLS_BUILD_DIR/il2cpp --github-api-token=$env:IL2CPP_GITHUB_TOKEN --yamato-api-token=$env:YAMATO_TOKEN --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=$env:YAMATO_OWNER_EMAIL --no-slack --no-push
         if ($LASTEXITCODE -ne 0) { echo "PRTools failed"; exit $LASTEXITCODE }
 

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -2058,14 +2058,12 @@ mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	const char *class_name;
 	MonoInst *simd_inst = NULL;
 
-	if (mono_is_corlib_image (m_class_get_image (cmethod->klass)) ||
-	    is_sys_numerics_assembly (m_class_get_image (cmethod->klass)->assembly)) {
+	if (is_sys_numerics_assembly (m_class_get_image (cmethod->klass)->assembly)) {
 		simd_inst = emit_sys_numerics_intrinsics (cfg, cmethod, fsig, args);
 		goto on_exit;
 	}
 
-	if (mono_is_corlib_image (m_class_get_image (cmethod->klass)) ||
-	    is_sys_numerics_vectors_assembly (m_class_get_image (cmethod->klass)->assembly)) {
+	if (is_sys_numerics_vectors_assembly (m_class_get_image (cmethod->klass)->assembly)) {
 		simd_inst = emit_sys_numerics_vectors_intrinsics (cfg, cmethod, fsig, args);
 		goto on_exit;
 	}


### PR DESCRIPTION
This reverts commit cf6aea03e5449129653ac159e22886d16ae190ee.

Backport of: https://github.com/Unity-Technologies/mono/pull/2114

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-85288 @UnityAlex:
Mono: Fixed performance regression where hardware intrinsics were not being applied fully.

