### PR TITLE
Add a more explicit error message on MacOS when dlOpen fails on Editor side

### DIFF
--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -73,7 +73,7 @@ MONO_API extern void burst_mono_update_tracking_pointers(MonoDomain* domain,Mono
 MONO_API gboolean
 unity_mono_method_is_generic (MonoMethod* method);
 
-typedef const char*(*UnityFindPluginCallback)(const char*);
+typedef const char*(*UnityFindPluginCallback)(const char*, gboolean*);
 
 MONO_API void
 mono_set_find_plugin_callback(UnityFindPluginCallback find);


### PR DESCRIPTION
On MacOS, trying to load an unsigned .bundle results in "DllNotFound" error.
Added a load_error that can be used to get a more explicit message from dlopen/dlerror in Plugins.cpp.
With the changes, the error code is now:

`System.DllNotFoundException: dlopen(Assets/External Assets/Photon/Encryptor/MacOSX/Release/PhotonEncryptorPlugin.bundle, 0x0002): tried: 'Assets/External Assets/Photon/Encryptor/MacOSX/Release/PhotonEncryptorPlugin.bundle' (code signature in <03345CA3-AC56-3594-A9BC-77AFADDA1496> '....../Assets/External Assets/Photon/Encryptor/MacOSX/Release/PhotonEncryptorPlugin.bundle' not valid for use in process: Trying to load an unsigned library), '/System/Volumes/Preboot/Cryptexes/OSAssets/External Assets/Photon/Encryptor/MacOSX/Release/PhotonEncryptorPlugin.bundle' (no such file),`

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**


Fixed UUM-99839 @marina-joffrineau 
Mono: Set a more explicit error message when a bundle is not signed on MacOS 

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->