### PR TITLE
improve error message on mac unsigned bundles

### DIFF
--- a/mono/metadata/unity-utils.h
+++ b/mono/metadata/unity-utils.h
@@ -73,7 +73,7 @@ MONO_API extern void burst_mono_update_tracking_pointers(MonoDomain* domain,Mono
 MONO_API gboolean
 unity_mono_method_is_generic (MonoMethod* method);
 
-typedef const char*(*UnityFindPluginCallback)(const char*);
+typedef const char*(*UnityFindPluginCallback)(const char*, gboolean*);
 
 MONO_API void
 mono_set_find_plugin_callback(UnityFindPluginCallback find);


### PR DESCRIPTION
Backport of: https://github.com/Unity-Technologies/mono/pull/2120

Cherrypick was clean

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-99839 @marina-joffrineau
Mono: Set a more explicit error message when a bundle is not signed on MacOS
