### PR TITLE
[6000.1] Fix Crash Due to Incorrect Optimization of EqualityComparer<T>.Default on Generic Record Type

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7471,9 +7471,12 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ERROR_DECL (error);
 
 				MonoMethod *new_cmethod = mono_class_get_virtual_method (sp [0]->klass, cmethod, FALSE, error);
-				mono_error_assert_ok (error);
-				cmethod = new_cmethod;
-				virtual_ = FALSE;
+				if (is_ok (error)) {
+					cmethod = new_cmethod;
+					virtual_ = FALSE;
+				} else {
+					mono_error_cleanup (error);
+				}
 			}
 
 			if (cmethod && method_does_not_return (cmethod)) {


### PR DESCRIPTION
This is a backport of https://github.com/mono/mono/commit/ef848cfa83ea16b8afbd5b933968b1838df19505, which is it self a backport of https://github.com/dotnet/runtime/pull/59861

This addresses fixes https://github.com/dotnet/runtime/issues/72181.

The root issue is that the devitalization of `EqualityComparer<T>.Default` may generate an instance with open generic types still it in.  This causes a virtual method resolution lookup in method-to-ir.c to fail and trigger an assert.  The upstream fix will disable the devitalization and do a normal virtual call in this case.

unity-main PR: https://github.com/Unity-Technologies/mono/pull/2127

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-99151 @scott-ferguson-unity 
Mono: Fixed crash on incorrectly optimized calls to EqualityComparer<T>.Default in Generic Record Type Equals implementations

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->