### PR TITLE
Add IL offset and method token to stack frame details.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -493,6 +493,11 @@ typedef void     (*GDestroyNotify) (gpointer data);
 typedef guint    (*GHashFunc)      (gconstpointer key);
 typedef gboolean (*GEqualFunc)     (gconstpointer a, gconstpointer b);
 typedef void     (*GFreeFunc)      (gpointer       data);
+#ifdef G_OS_WIN32
+/* oop support*/
+typedef gpointer (*GReadPointerFunc)(gconstpointer address);
+typedef guint32  (*GReadUInt32Func) (gconstpointer address);
+#endif
 
 /*
  * Lists
@@ -630,6 +635,9 @@ gboolean        g_hash_table_contains (GHashTable *hash, gconstpointer key);
 G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gpointer        g_hash_table_lookup          (GHashTable *hash, gconstpointer key);
 gboolean        g_hash_table_lookup_extended (GHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);
+#ifdef G_OS_WIN32
+gpointer        g_hash_table_lookup_oop      (GHashTable* hash, gconstpointer key, GReadPointerFunc read_pointer, GReadUInt32Func read_uint32);
+#endif
 G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void            g_hash_table_foreach         (GHashTable *hash, GHFunc func, gpointer user_data);
 gpointer        g_hash_table_find            (GHashTable *hash, GHRFunc predicate, gpointer user_data);


### PR DESCRIPTION
Add support to read IL offset and method token out-of-process (oop). This will enable the symbolication of managed frames to file/line level rather than just the method level.

Notes:

- Remove `int _GHashTable::threshold` field. This was never updated, always had value `0`, and thus always caused a rehash when checked.
- Add `gboolean _GHashTable::uses_default_hash_and_equality` field. The out-of-process read logic needs to inspect a hash table, and thus can only be done when direct hash/equality is used; custom hash/equality functions are not supported.
- Add `g_hash_table_lookup_oop` to perform the actual hash lookup. This was done in `mono/eglib/ghashtable.c` directly to avoid having to expose hashtable implementation internals.
- In `mono/metadata/oop.c` replicate enough data/logic for a simple oop version of `mono_debug_read_method` that can retrieve the offset/token info.

These changes have some risk, but they are only invoked when processing a crash. Thus, we may lose some crash info in the case of errors, but we should not cause any additional crashes.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:


<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->