### PR TITLE
6000.2 [UUM-105139] Backport fix for gc handle leak

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1944,7 +1944,7 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain *domain)
 }
 
 /**
- * mono_gchandle_is_in_domain_internal_lock_free:
+ * mono_gchandle_is_in_domain_internal_unsafe:
  * \param gchandle a GCHandle's handle.
  * \param domain An application domain.
  * 
@@ -1954,7 +1954,7 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain *domain)
  * \returns TRUE if the object wrapped by the \p gchandle belongs to the specific \p domain.
  */
 gboolean
-mono_gchandle_is_in_domain_internal_lock_free(MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe(MonoGCHandle gchandle, MonoDomain* domain)
 {
 	guint slot = 0;
 	HandleData* handles = handle_lookup(gchandle, &slot);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -950,6 +950,8 @@ finalize_domain_objects (void)
 	mono_gc_invoke_finalizers ();
 #endif
 
+	delegate_hash_table_clear_domain (domain);
+
 	/* cleanup the reference queue */
 	reference_queue_clear_for_domain (domain);
 	

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -373,7 +373,7 @@ static gboolean
 domain_free_delegate (gpointer key, gpointer value, gpointer data)
 {
 	// We don't need to free the GCHandle here because the domain unload already did that for us
-	return mono_gchandle_is_in_domain_internal_lock_free ((MonoGCHandle)value, (MonoDomain*)data);
+	return mono_gchandle_is_in_domain_internal_unsafe ((MonoGCHandle)value, (MonoDomain*)data);
 }
 
 void

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -381,12 +381,16 @@ delegate_hash_table_clear_domain (MonoDomain* domain)
 {
 	// This function is called when a domain is unloaded.
 	// We take the handle lock first to ensure we don't deadlock with any gc threads that might access marshalling apis
+#if HAVE_BOEHM_GC
 	mono_gc_handle_lock ();
+#endif
 	mono_marshal_lock ();
 	if (delegate_hash_table)
 		g_hash_table_foreach_remove (delegate_hash_table, domain_free_delegate, domain);
 	mono_marshal_unlock ();
+#if HAVE_BOEHM_GC
 	mono_gc_handle_unlock ();
+#endif
 }
 
 static void 

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -401,6 +401,8 @@ mono_ptr_to_ansibstr (const char *ptr, size_t slen);
 
 void mono_delegate_free_ftnptr (MonoDelegate *delegate);
 
+void delegate_hash_table_clear_domain (MonoDomain *domain);
+
 void
 mono_marshal_ftnptr_eh_callback (guint32 gchandle);
 

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -383,7 +383,7 @@ mono_gchandle_is_in_domain_internal (guint32 gchandle, MonoDomain *domain)
 }
 
 gboolean
-mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe (MonoGCHandle gchandle, MonoDomain* domain)
 {
 	guint slot = MONO_GC_HANDLE_SLOT (gchandle);
 	guint type = MONO_GC_HANDLE_TYPE (gchandle);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2383,11 +2383,13 @@ void mono_gchandle_free_internal (MonoGCHandle gchandle);
 
 GCHandleType mono_gchandle_get_type_internal (MonoGCHandle gchandle);
 
+#if HAVE_BOEHM_GC
 void
 mono_gc_handle_lock ();
 
 void
 mono_gc_handle_unlock ();
+#endif
 
 /* make sure the gchandle was allocated for an object in domain */
 gboolean mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain* domain);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2394,7 +2394,7 @@ mono_gc_handle_unlock ();
 /* make sure the gchandle was allocated for an object in domain */
 gboolean mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain* domain);
 
-gboolean mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain);
+gboolean mono_gchandle_is_in_domain_internal_unsafe (MonoGCHandle gchandle, MonoDomain* domain);
 
 /* Reference queue support
  *

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2383,8 +2383,16 @@ void mono_gchandle_free_internal (MonoGCHandle gchandle);
 
 GCHandleType mono_gchandle_get_type_internal (MonoGCHandle gchandle);
 
+void
+mono_gc_handle_lock ();
+
+void
+mono_gc_handle_unlock ();
+
 /* make sure the gchandle was allocated for an object in domain */
-gboolean mono_gchandle_is_in_domain_internal(MonoGCHandle gchandle, MonoDomain* domain);
+gboolean mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain* domain);
+
+gboolean mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain);
 
 /* Reference queue support
  *

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2821,6 +2821,12 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain *domain)
 	return domain->domain_id == gchandle_domain->domain_id;
 }
 
+gboolean
+mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+{
+	return mono_gchandle_is_in_domain_internal(gchandle, domain);
+}
+
 GCHandleType
 mono_gchandle_get_type_internal (MonoGCHandle gchandle)
 {

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2822,7 +2822,7 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain *domain)
 }
 
 gboolean
-mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe (MonoGCHandle gchandle, MonoDomain* domain)
 {
 	return mono_gchandle_is_in_domain_internal(gchandle, domain);
 }


### PR DESCRIPTION
Backport of: https://github.com/Unity-Technologies/mono/pull/2131

Cherrypick was clean

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-105139 @UnityAlex:
Mono: Fixed GC Handle leak that would happen every time a new function pointer was returned for a managed delegate.
