### PR TITLE
2022.3 [UUM-105139] Backport fix for gc handle leak

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1898,6 +1898,43 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gch, MonoDomain *domain)
 }
 
 /**
+ * mono_gchandle_is_in_domain_internal_lock_free:
+ * \param gchandle a GCHandle's handle.
+ * \param domain An application domain.
+ * 
+ * Lock free version of \c mono_gchandle_is_in_domain_internal. To be used only if the caller
+ * already has the handle lock.
+ * 
+ * \returns TRUE if the object wrapped by the \p gchandle belongs to the specific \p domain.
+ */
+gboolean
+mono_gchandle_is_in_domain_internal_lock_free(MonoGCHandle gchandle, MonoDomain* domain)
+{
+	guint slot = 0;
+	HandleData* handles = handle_lookup(gchandle, &slot);
+	gboolean result = FALSE;
+
+	if (handles->type >= HANDLE_TYPE_MAX)
+		return FALSE;
+
+	if (slot < handles->size && slot_occupied(handles, slot)) {
+		if (MONO_GC_HANDLE_TYPE_IS_WEAK(handles->type)) {
+			result = domain->domain_id == handles->domain_ids[slot];
+		}
+		else {
+			MonoObject* obj;
+			obj = (MonoObject*)handles->entries[slot];
+			if (obj == NULL)
+				result = TRUE;
+			else
+				result = domain == mono_object_domain(obj);
+		}
+	}
+
+	return result;
+}
+
+/**
  * mono_gchandle_free_internal:
  * \param gchandle a GCHandle's handle.
  *

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1898,7 +1898,7 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gch, MonoDomain *domain)
 }
 
 /**
- * mono_gchandle_is_in_domain_internal_lock_free:
+ * mono_gchandle_is_in_domain_internal_unsafe:
  * \param gchandle a GCHandle's handle.
  * \param domain An application domain.
  * 
@@ -1908,7 +1908,7 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gch, MonoDomain *domain)
  * \returns TRUE if the object wrapped by the \p gchandle belongs to the specific \p domain.
  */
 gboolean
-mono_gchandle_is_in_domain_internal_lock_free(MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe(MonoGCHandle gchandle, MonoDomain* domain)
 {
 	guint slot = 0;
 	HandleData* handles = handle_lookup(gchandle, &slot);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1908,26 +1908,27 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gch, MonoDomain *domain)
  * \returns TRUE if the object wrapped by the \p gchandle belongs to the specific \p domain.
  */
 gboolean
-mono_gchandle_is_in_domain_internal_unsafe(MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe(MonoGCHandle gch, MonoDomain* domain)
 {
-	guint slot = 0;
-	HandleData* handles = handle_lookup(gchandle, &slot);
+	guint32 gchandle = MONO_GC_HANDLE_TO_UINT (gch);
+	guint slot = MONO_GC_HANDLE_SLOT (gchandle);
+	guint type = MONO_GC_HANDLE_TYPE (gchandle);
+	HandleData *handles = &gc_handles [type];
 	gboolean result = FALSE;
 
-	if (handles->type >= HANDLE_TYPE_MAX)
+	if (type >= HANDLE_TYPE_MAX)
 		return FALSE;
 
-	if (slot < handles->size && slot_occupied(handles, slot)) {
-		if (MONO_GC_HANDLE_TYPE_IS_WEAK(handles->type)) {
-			result = domain->domain_id == handles->domain_ids[slot];
-		}
-		else {
-			MonoObject* obj;
-			obj = (MonoObject*)handles->entries[slot];
+	if (slot < handles->size && slot_occupied (handles, slot)) {
+		if (MONO_GC_HANDLE_TYPE_IS_WEAK (handles->type)) {
+			result = domain->domain_id == handles->domain_ids [slot];
+		} else {
+			MonoObject *obj;
+			obj = (MonoObject *)handles->entries [slot];
 			if (obj == NULL)
 				result = TRUE;
 			else
-				result = domain == mono_object_domain(obj);
+				result = domain == mono_object_domain (obj);
 		}
 	}
 

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -951,6 +951,8 @@ finalize_domain_objects (void)
 	mono_gc_invoke_finalizers ();
 #endif
 
+	delegate_hash_table_clear_domain (domain);
+
 	/* cleanup the reference queue */
 	reference_queue_clear_for_domain (domain);
 	

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -380,12 +380,16 @@ delegate_hash_table_clear_domain (MonoDomain* domain)
 {
 	// This function is called when a domain is unloaded.
 	// We take the handle lock first to ensure we don't deadlock with any gc threads that might access marshalling apis
+#if HAVE_BOEHM_GC
 	mono_gc_handle_lock ();
+#endif
 	mono_marshal_lock ();
 	if (delegate_hash_table)
 		g_hash_table_foreach_remove (delegate_hash_table, domain_free_delegate, domain);
 	mono_marshal_unlock ();
+#if HAVE_BOEHM_GC
 	mono_gc_handle_unlock ();
+#endif
 }
 
 static void 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -368,6 +368,26 @@ delegate_hash_table_new (void) {
 	return g_hash_table_new (NULL, NULL);
 }
 
+static gboolean 
+domain_free_delegate (gpointer key, gpointer value, gpointer data)
+{
+	// We don't need to free the GCHandle here because the domain unload already did that for us
+	return mono_gchandle_is_in_domain_internal_lock_free ((MonoGCHandle)value, (MonoDomain*)data);
+}
+
+void
+delegate_hash_table_clear_domain (MonoDomain* domain)
+{
+	// This function is called when a domain is unloaded.
+	// We take the handle lock first to ensure we don't deadlock with any gc threads that might access marshalling apis
+	mono_gc_handle_lock ();
+	mono_marshal_lock ();
+	if (delegate_hash_table)
+		g_hash_table_foreach_remove (delegate_hash_table, domain_free_delegate, domain);
+	mono_marshal_unlock ();
+	mono_gc_handle_unlock ();
+}
+
 static void 
 delegate_hash_table_remove (MonoDelegate *d)
 {
@@ -406,11 +426,12 @@ delegate_hash_table_add (MonoDelegateHandle d)
 			g_hash_table_insert (delegate_hash_table, delegate_trampoline, gchandle);
 		}
 	} else {
-		MonoGCHandle gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, d), FALSE);
-		// If a delegate already exists with a matching function pointer we assume it's old as
-		// we've just jitted a new one and replace it. This is preferred to continuing to run
-		// with stale data in the map that could be used later.
-		g_hash_table_insert (delegate_hash_table, delegate_trampoline, gchandle);
+		if (g_hash_table_lookup (delegate_hash_table, delegate_trampoline) == NULL) {
+			// We assume that if an entry already exists in the table that it is correct and from the
+			// current domain. The domain entries are removed from the table on domain unload.
+			MonoGCHandle gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST(MonoObject, d), FALSE);
+			g_hash_table_insert (delegate_hash_table, delegate_trampoline, gchandle);
+		}
 	}
 	mono_marshal_unlock ();
 }

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -372,7 +372,7 @@ static gboolean
 domain_free_delegate (gpointer key, gpointer value, gpointer data)
 {
 	// We don't need to free the GCHandle here because the domain unload already did that for us
-	return mono_gchandle_is_in_domain_internal_lock_free ((MonoGCHandle)value, (MonoDomain*)data);
+	return mono_gchandle_is_in_domain_internal_unsafe ((MonoGCHandle)value, (MonoDomain*)data);
 }
 
 void

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -401,6 +401,8 @@ mono_ptr_to_ansibstr (const char *ptr, size_t slen);
 
 void mono_delegate_free_ftnptr (MonoDelegate *delegate);
 
+void delegate_hash_table_clear_domain (MonoDomain *domain);
+
 void
 mono_marshal_ftnptr_eh_callback (guint32 gchandle);
 

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -383,7 +383,7 @@ mono_gchandle_is_in_domain_internal (guint32 gchandle, MonoDomain *domain)
 }
 
 gboolean
-mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe (MonoGCHandle gchandle, MonoDomain* domain)
 {
 	guint slot = MONO_GC_HANDLE_SLOT (gchandle);
 	guint type = MONO_GC_HANDLE_TYPE (gchandle);

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -382,6 +382,33 @@ mono_gchandle_is_in_domain_internal (guint32 gchandle, MonoDomain *domain)
 	return result;
 }
 
+gboolean
+mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+{
+	guint slot = MONO_GC_HANDLE_SLOT (gchandle);
+	guint type = MONO_GC_HANDLE_TYPE (gchandle);
+	HandleData *handles = &gc_handles [type];
+	gboolean result = FALSE;
+
+	if (type >= HANDLE_TYPE_MAX)
+		return FALSE;
+
+	if (slot < handles->size && slot_occupied (handles, slot)) {
+		if (MONO_GC_HANDLE_TYPE_IS_WEAK (handles->type)) {
+			result = domain->domain_id == handles->domain_ids [slot];
+		} else {
+			MonoObject *obj;
+			obj = (MonoObject *)handles->entries [slot];
+			if (obj == NULL)
+				result = TRUE;
+			else
+				result = domain == mono_object_domain (obj);
+		}
+	}
+
+	return result;
+}
+
 /**
  * mono_gchandle_free:
  * \param gchandle a GCHandle's handle.

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2392,7 +2392,7 @@ mono_gc_handle_unlock ();
 /* make sure the gchandle was allocated for an object in domain */
 gboolean mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain* domain);
 
-gboolean mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain);
+gboolean mono_gchandle_is_in_domain_internal_unsafe (MonoGCHandle gchandle, MonoDomain* domain);
 
 /* Reference queue support
  *

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2381,11 +2381,13 @@ mono_gchandle_get_target_internal (MonoGCHandle gchandle);
 
 void mono_gchandle_free_internal (MonoGCHandle gchandle);
 
+#if HAVE_BOEHM_GC
 void
 mono_gc_handle_lock ();
 
 void
 mono_gc_handle_unlock ();
+#endif
 
 /* make sure the gchandle was allocated for an object in domain */
 gboolean mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain* domain);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2381,8 +2381,16 @@ mono_gchandle_get_target_internal (MonoGCHandle gchandle);
 
 void mono_gchandle_free_internal (MonoGCHandle gchandle);
 
+void
+mono_gc_handle_lock ();
+
+void
+mono_gc_handle_unlock ();
+
 /* make sure the gchandle was allocated for an object in domain */
-gboolean mono_gchandle_is_in_domain_internal(MonoGCHandle gchandle, MonoDomain* domain);
+gboolean mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain* domain);
+
+gboolean mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain);
 
 /* Reference queue support
  *

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2804,7 +2804,7 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain *domain)
 }
 
 gboolean
-mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+mono_gchandle_is_in_domain_internal_unsafe (MonoGCHandle gchandle, MonoDomain* domain)
 {
 	return mono_gchandle_is_in_domain_internal(gchandle, domain);
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2803,6 +2803,12 @@ mono_gchandle_is_in_domain_internal (MonoGCHandle gchandle, MonoDomain *domain)
 	return domain->domain_id == gchandle_domain->domain_id;
 }
 
+gboolean
+mono_gchandle_is_in_domain_internal_lock_free (MonoGCHandle gchandle, MonoDomain* domain)
+{
+	return mono_gchandle_is_in_domain_internal(gchandle, domain);
+}
+
 /**
  * mono_gchandle_free_internal:
  * \param gchandle a GCHandle's handle.


### PR DESCRIPTION
Backport of: https://github.com/Unity-Technologies/mono/pull/2131

Cherrypick required minor massaging. GC handle get type doesn't exist in 2022.3.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-105139 @UnityAlex:
Mono: Fixed GC Handle leak that would happen every time a new function pointer was returned for a managed delegate.
