### PR TITLE
[6000.2] Fix debugger agent not restarting

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10530,8 +10530,8 @@ debugger_thread (void *arg)
 
 	PRINT_DEBUG_MSG (1, "[dbg] Debugger thread exited.\n");
 	
-	if (!attach_failed && command_set == CMD_SET_VM && command == CMD_VM_DISPOSE && !(vm_death_event_sent || mono_runtime_is_shutting_down ())) {
-		PRINT_DEBUG_MSG (2, "[dbg] Detached - restarting clean debugger thread.\n");
+	if (!attach_failed && !(vm_death_event_sent || mono_runtime_is_shutting_down ())) {
+		PRINT_DEBUG_MSG (1, "[dbg] Detached - restarting clean debugger thread.\n");
 		ERROR_DECL (error);
 		start_debugger_thread (error);
 		mono_error_cleanup (error);


### PR DESCRIPTION
backport of: https://github.com/Unity-Technologies/mono/pull/2137

Cherrypick was clean

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-107431 @UnityAlex:
Mono: Fix issue where mono's debugger agent thread would not restart when a connection issue was encountered.