### PR TITLE
[6000.2] Remove Assert in Method.MakeGeneric on Invalid Args

### DIFF
--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2655,13 +2655,12 @@ reflection_bind_generic_method_parameters (MonoMethod *method, MonoArrayHandle t
 	tmp_context.method_inst = ginst;
 
 	inflated = mono_class_inflate_generic_method_checked (method, &tmp_context, error);
-	mono_error_assert_ok (error);
 
-	if (!mono_verifier_is_method_valid_generic_instantiation (inflated)) {
+	if (!is_ok(error) || !inflated || !mono_verifier_is_method_valid_generic_instantiation (inflated)) {
 #if ENABLE_NETCORE
 		mono_error_set_argument (error, NULL, "Invalid generic arguments");
 #else
-		mono_error_set_argument (error, "typeArguments", "Invalid generic arguments");
+		mono_error_set_argument (error, NULL, "Invalid generic arguments");
 #endif
 		return NULL;
 	}


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/mono/pull/2161
---
The call to `mono_class_inflate_generic_method_checked` will set error when there are invalid types (e.g. `typeof(void)/typeof(int*))` passed in.  This should not be an assert, we should all to the "Invalid generic arguments" message below.   This does loose the error returned by `mono_class_inflate_generic_method_checked` but that error isn't user
friendly.  It would report be something like:

>     "MVAR 1 cannot be expanded with type 0x1"

We can just report the more readable error to the user.

Note I also had to remove the `"typeArguments"` message from the error. When this error is freed Mono will attempt to deallocate that value, but since it's not a allocated value our allocator will crash (In Unity we replace Mono's allocators with our own).

Upstream issue: https://github.com/dotnet/runtime/issues/71339
Upstream PR: https://github.com/dotnet/runtime/pull/116788

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-109251 @scott-ferguson-unity:
Mono: Prevent crash when Method.MakeGenericMethod is called with invalid generic argument types

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->