### PR TITLE
[6000.2] Fix Crash from Missing MRGCTX on Default Interface Method

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2196,7 +2196,7 @@ check_method_sharing (MonoCompile *cfg, MonoMethod *cmethod, gboolean *out_pass_
 		else
 			g_assert (!pass_vtable);
 
-		if (mono_method_is_generic_sharable_full (cmethod, TRUE, TRUE, TRUE)) {
+		if (mono_method_is_generic_sharable_full (cmethod, TRUE, TRUE, TRUE) || mini_method_is_default_method(cmethod)) {
 			pass_mrgctx = TRUE;
 		} else {
 			if (cfg->gsharedvt && mini_is_gsharedvt_signature (mono_method_signature_internal (cmethod)))


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/mono/pull/2152
--

Mono assumes that all generic default interface methods should pass there generic context in the method generic context register.  However it does not correct mark this at the call site when the method isn't sharable.

This leads to a crash in the [trampoline ](https://github.com/Unity-Technologies/mono/blob/71738fd2d373c2afece6c89bfd743ac4ce838034/mono/mini/mini-trampolines.c#L568) where it looks for the generic context on any default interface method.

This crash does not occur in upstream - it was fixed by https://github.com/dotnet/runtime/pull/64129 which [replaced the code that this PR patches](https://github.com/dotnet/runtime/pull/64129/files#diff-7b30038b10c5aa1f90ae73ccfa79f19ea86ec1f3101cb3bab7cf80e4d7513a44L2151).  It looks like the cleanup in that PR fixed this issues, even if it wasn't explicitly called out.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-109706 @scott-ferguson-unity 
Mono: Fix Crash when invoking a default interface method that is generic with value type generic argument

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

**Backports**
This does affect all supported versions - but we will want to make sure we understand the risk of this change before backporting.


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->