### PR TITLE
Fix update il2cpp deps

### DIFF
--- a/.yamato/Publish To Stevedore.yml
+++ b/.yamato/Publish To Stevedore.yml
@@ -9,11 +9,14 @@ dependencies:
   - .yamato/Collate Builds.yml
   
 commands:
-  - curl -sSo StevedoreUpload.exe "$STEVEDORE_UPLOAD_TOOL_URL"
-  - mono StevedoreUpload.exe --repo=unity-internal --version-len=8 --version="$GIT_REVISION" stevedore/MonoBleedingEdge.7z
+  - curl -sSo StevedoreUpload "$STEVEDORE_UPLOAD_TOOL_LINUX_X64_URL"
+  - chmod +x StevedoreUpload
+  - mv collectedbuilds/builds.tar.zst collectedbuilds/MonoBleedingEdge.tar.zst
+  - .yamato/scripts/generate_artifactid.sh collectedbuilds/MonoBleedingEdge.tar.zst
+  - ./StevedoreUpload --repo=unity-internal --version-len=8 --version="$GIT_REVISION" collectedbuilds/MonoBleedingEdge.tar.zst
 
 artifacts: 
   stevedore:
     paths:
-      - stevedore/artifactid.txt
+      - collectedbuilds/artifactid.txt
 

--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -13,7 +13,7 @@ commands:
     git checkout main
     cd %UNITY_SOURCE_PRTOOLS_DIR%
     git config --global core.longpaths true
-    cmd /v /c dotnet run --project C:\build\output\prtools\PRTools\PRTools.csproj --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/stevedore/artifactid.txt --github-api-token=%GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%
+    cmd /v /c dotnet run --project C:\build\output\prtools\PRTools\PRTools.csproj --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/collectedbuilds/artifactid.txt --github-api-token=%IL2CPP_GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%
     if NOT %errorlevel% == 0 (
       echo "PRTools failed"
       EXIT /B %errorlevel%

--- a/.yamato/scripts/generate_artifactid.sh
+++ b/.yamato/scripts/generate_artifactid.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+revision=$(git rev-parse --short HEAD)
+artifactsha=$(sha256sum $1 | cut -d " " -f1)
+
+mkdir -p collectedbuilds
+
+printf "MonoBleedingEdge/%s_%s.tar.zst\n" $revision $artifactsha > collectedbuilds/artifactid.txt
+


### PR DESCRIPTION
Updates buildscripts to have the ability to push the collated mono builds.tar.zsh to stevedore.

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

