### PR TITLE
[6000.2] Update Il2cpp deps needs to use the new token

### DIFF
--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -16,7 +16,7 @@ commands:
     git checkout main
     cd %UNITY_SOURCE_PRTOOLS_DIR%
     git config --global core.longpaths true
-    cmd /v /c dotnet run --project C:\build\output\prtools\PRTools\PRTools.csproj --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/stevedore/artifactid.txt --backport=%BACKPORT_BRANCH% --github-api-token=%GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%    
+    cmd /v /c dotnet run --project C:\build\output\prtools\PRTools\PRTools.csproj --update-mono-il2cpp-deps=%YAMATO_SOURCE_DIR%/stevedore/artifactid.txt --backport=%BACKPORT_BRANCH% --github-api-token=%IL2CPP_GITHUB_TOKEN% --yamato-api-token=%YAMATO_TOKEN% --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=%YAMATO_OWNER_EMAIL%    
 
     if NOT %errorlevel% == 0 (
       echo "PRTools failed"


### PR DESCRIPTION
Backport of: https://github.com/Unity-Technologies/mono/pull/2163

cherrypick was clean

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

