### PR TITLE
Fix md5 line in builds.tar.zst.list generation in collect_allbuilds.pl

### DIFF
--- a/external/buildscripts/collect_allbuilds.pl
+++ b/external/buildscripts/collect_allbuilds.pl
@@ -66,8 +66,8 @@ my $cmd = "bsdtar --options zstd:compression-level=22 -cavf ../builds.tar.zst *"
 system($cmd) eq 0 or die("Command failed: \"$cmd\"");
 system("mv -f ../builds.tar.zst .") eq 0 or die("Failed to move builds.tar.zst into place");
 
-my $md5 = `md5sum builds.tar.zst | cut -d' ' -f1"`;
-open(FH, '>', builds.tar.zst.list) or die $!;
+my $md5 = `md5sum builds.tar.zst | cut -d' ' -f1`;
+open(FH, '>', "builds.tar.zst.list") or die $!;
 print FH "md5:$md5\n";
 close(FH);
 


### PR DESCRIPTION
Let's see if this creates a valid builds.tar.zst.list - we can check this by downloading it from the artifacts and checking that it looks something like:
```
md5:2d9145909fd7a035d500a6a198035a18
--
Path = foo/bar/builds.tar.zst
...
```