### PR TITLE
[Forward Port] Handle a missing libc library (UUM-60201)

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/UnixIPGlobalProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/UnixIPGlobalProperties.cs
@@ -67,6 +67,9 @@ namespace System.Net.NetworkInformation {
 				} catch (EntryPointNotFoundException) {
 					return String.Empty;
 				}
+				catch (DllNotFoundException) {
+					return String.Empty;
+				}
 #endif
 				int len = Array.IndexOf<byte> (bytes, 0);
 				return Encoding.ASCII.GetString (bytes, 0, len < 0 ? 256 : len);


### PR DESCRIPTION
On the iOS simulator we can get errors in this implementation because libc does not exist. So, handle a DllNotFoundException and return an empty string, like we do for a EntryNotFoundException.

Forward port of: https://github.com/Unity-Technologies/mono/pull/1993


- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

