### PR TITLE
Fix ETW Profiler Attach Issue UUM-112001

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -110,6 +110,9 @@ MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 
 MONO_API void
+mono_domain_foreach_locked (MonoDomainFunc func, void* user_data);
+
+MONO_API void
 mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, void* user_data);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -110,7 +110,7 @@ MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 
 MONO_API void
-mono_domain_foreach_locked (MonoDomainFunc func, void* user_data);
+mono_unity_domain_foreach_locked (MonoDomainFunc func, void* user_data);
 
 MONO_API void
 mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, void* user_data);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -86,6 +86,10 @@ gboolean mono_dont_free_domains;
 #define mono_appdomains_unlock() mono_coop_mutex_unlock (&appdomains_mutex)
 static MonoCoopMutex appdomains_mutex;
 
+#define mono_domain_unload_lock() mono_coop_mutex_lock (&mono_domain_unload_mutex)
+#define mono_domain_unload_unlock() mono_coop_mutex_unlock (&mono_domain_unload_mutex)
+MonoCoopMutex mono_domain_unload_mutex;
+
 static MonoDomain *mono_root_domain = NULL;
 
 /* some statistics */
@@ -559,6 +563,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_thread_info_attach ();
 
 	mono_coop_mutex_init_recursive (&appdomains_mutex);
+	mono_coop_mutex_init_recursive(&mono_domain_unload_mutex);
 
 	mono_metadata_init ();
 	mono_images_init ();
@@ -925,6 +930,7 @@ mono_cleanup (void)
 	mono_metadata_cleanup ();
 
 	mono_coop_mutex_destroy (&appdomains_mutex);
+	mono_coop_mutex_destroy (&mono_domain_unload_mutex);
 
 	mono_w32process_cleanup ();
 	mono_w32file_cleanup ();
@@ -1039,6 +1045,14 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 
 	gc_free_fixed_non_heap_list (copy);
 	MONO_EXIT_GC_UNSAFE;
+}
+
+void
+mono_domain_foreach_locked(MonoDomainFunc func, gpointer user_data)
+{
+	mono_domain_unload_lock();
+	mono_domain_foreach(func, user_data);
+	mono_domain_unload_unlock();
 }
 
 void

--- a/mono/metadata/etw-profiler.c
+++ b/mono/metadata/etw-profiler.c
@@ -290,7 +290,7 @@ on_attach ()
 	memset (&enumerationData, 0, sizeof (enumerationData));
 
 	// Iterate through each domain
-	mono_domain_foreach (on_enumerate_domain, &enumerationData);
+	mono_domain_foreach_locked (on_enumerate_domain, &enumerationData);
 
 	ETW_PROFILER_LOG_ARGS ("Finished enumerating JIT data. Found %d domains, %d assemblies, %d methods", enumerationData.mNumDomains, enumerationData.mNumAssemblies, enumerationData.mNumMethods);
 }

--- a/mono/metadata/etw-profiler.c
+++ b/mono/metadata/etw-profiler.c
@@ -290,7 +290,7 @@ on_attach ()
 	memset (&enumerationData, 0, sizeof (enumerationData));
 
 	// Iterate through each domain
-	mono_domain_foreach_locked (on_enumerate_domain, &enumerationData);
+	mono_unity_domain_foreach_locked (on_enumerate_domain, &enumerationData);
 
 	ETW_PROFILER_LOG_ARGS ("Finished enumerating JIT data. Found %d domains, %d assemblies, %d methods", enumerationData.mNumDomains, enumerationData.mNumAssemblies, enumerationData.mNumMethods);
 }


### PR DESCRIPTION
This code fixes the issue where an ETW profiler attach attempt had the ability to crash Unity due to an issue with accessing a domain from mono that was in the process of being unloaded.

Original work done and approved on this PR (retargeting the PR to main to then backport):
https://github.com/Unity-Technologies/mono/pull/2173

Original bug:
https://jira.unity3d.com/browse/UUM-112001

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-112001@kkukshtel-unity:
Mono: Fix bug where attaching a profiler could cause Unity to crash to desktop.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->


**Backports**

[unity-6000.3-mbe](https://github.com/Unity-Technologies/mono/pull/2173)
[unity-6000.2-mbe](https://github.com/Unity-Technologies/mono/pull/2179)
[unity-6000.1-mbe](https://github.com/Unity-Technologies/mono/pull/2181)
[unity-6000.0-mbe](https://github.com/Unity-Technologies/mono/pull/2180)


<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->