### PR TITLE
Fix ETW Profiler Attach Issue UUM-112001

### DIFF
--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -110,6 +110,9 @@ MONO_API void
 mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 
 MONO_API void
+mono_unity_domain_foreach_locked (MonoDomainFunc func, void* user_data);
+
+MONO_API void
 mono_domain_assembly_foreach (MonoDomain* domain, MonoDomainAssemblyFunc func, void* user_data);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *

--- a/mono/metadata/etw-profiler.c
+++ b/mono/metadata/etw-profiler.c
@@ -290,7 +290,7 @@ on_attach ()
 	memset (&enumerationData, 0, sizeof (enumerationData));
 
 	// Iterate through each domain
-	mono_domain_foreach (on_enumerate_domain, &enumerationData);
+	mono_unity_domain_foreach_locked (on_enumerate_domain, &enumerationData);
 
 	ETW_PROFILER_LOG_ARGS ("Finished enumerating JIT data. Found %d domains, %d assemblies, %d methods", enumerationData.mNumDomains, enumerationData.mNumAssemblies, enumerationData.mNumMethods);
 }


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/mono/pull/2178

This code fixes the issue where an ETW profiler attach attempt had the ability to crash Unity due to an issue with accessing a domain from mono that was in the process of being unloaded.

The fix here is to add in a lock around domain enumeration to ensure that the domain is properly locked before taking action on it from the profiler's perspective.

https://jira.unity3d.com/browse/UUM-112001

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-112001@kkukshtel-unity:
Mono: Fix bug where attaching a profiler could cause Unity to crash to desktop.

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->