### PR TITLE
Do not pass mrgctx for default interface instance methods

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2196,7 +2196,8 @@ check_method_sharing (MonoCompile *cfg, MonoMethod *cmethod, gboolean *out_pass_
 		else
 			g_assert (!pass_vtable);
 
-		if (mono_method_is_generic_sharable_full (cmethod, TRUE, TRUE, TRUE) || mini_method_is_default_method(cmethod)) {
+		if (mono_method_is_generic_sharable_full (cmethod, TRUE, TRUE, TRUE) ||
+			(mini_method_is_default_method(cmethod) && cmethod->flags & METHOD_ATTRIBUTE_STATIC)) {
 			pass_mrgctx = TRUE;
 		} else {
 			if (cfg->gsharedvt && mini_is_gsharedvt_signature (mono_method_signature_internal (cmethod)))


### PR DESCRIPTION
This is a followup fix from a previous PR
https://github.com/Unity-Technologies/mono/pull/2152

The repo in the original case was dealing with static methods not having mrgctx set at the call site.

This commit address a new bug introduced by #2152 where the mrgctx is being set for an instance method and that register has data in it that is being clobbered.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Fixed UUM-115835 @bholmes :
Mono:Fix Ref parameter address mismatch when invoking a default interface method with multiple ref arguments.


**Backports**

 - 6000.4
 - 6000.3
 - 6000.2