### PR TITLE
Protect calls to fork with a gc_lock on all MacOS variations

### DIFF
--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1858,7 +1858,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: new process startup not synchronized. We may not notice if the newly created process exits immediately.", __func__);
 	}
 
-#if defined(HOST_DARWIN) && defined(TARGET_AMD64)
+#if defined(HOST_DARWIN)
 	mono_gc_invoke_with_gc_lock(fork_helper, &pid);
 #else
 	pid = fork();


### PR DESCRIPTION
Followup to https://github.com/Unity-Technologies/mono/pull/2124

We have reports of older version of MacOS showing the crash on fork even on M1 systems. Adding this thread protection appears to help those systems as well.


- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [X] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No


**Release notes**

Fixed UUM-101541 @bholmes :
Mono: Protect calls to fork with a gc_lock on all MacOS variations.


**Backports**

 - 6000.4
 - 6000.3
 - 6000.2
 - 6000.0
