### PR TITLE
[6000.0] Fix the System.String.Replace throwing NotImplementedException (#20960)

### DIFF
--- a/mcs/class/corlib/Test/System/StringTest.cs
+++ b/mcs/class/corlib/Test/System/StringTest.cs
@@ -3221,6 +3221,10 @@ public class StringTest
 
 		// Test replacing null characters (bug #67395)
 		Assert.AreEqual ("is this ok ?", "is \0 ok ?".Replace ("\0", "this"), "should not strip content after nullchar");
+
+		// System.String.Replace fails with NotImplementedException https://github.com/mono/mono/issues/20948
+		Assert.AreEqual ("Original", s1.Replace("o", "O", StringComparison.CurrentCulture), "Replace(string, string, StringComparison)");
+		Assert.AreEqual ("Original", s1.Replace("o", "O", false, CultureInfo.CurrentCulture), "Replace(string, string, bool, CultureInfo)");
 	}
 
 	[Test]

--- a/mcs/class/corlib/corefx/CompareInfo.cs
+++ b/mcs/class/corlib/corefx/CompareInfo.cs
@@ -86,7 +86,7 @@ namespace System.Globalization
 		unsafe int IndexOfCore (string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
 		{
 			if (matchLengthPtr != null)
-				throw new NotImplementedException ();
+				*matchLengthPtr = target.Length;
 
 			return internal_index_switch (source, startIndex, count, target, options, true);
 		}


### PR DESCRIPTION
Cherrypicked uptream fix: https://github.com/mono/mono/issues/20948

Cherrypick was clean and verified that the reported issue is fixed.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-117367 @UnityAlex :
Mono: Fix the System.String.Replace throwing NotImplementedException.
