### PR TITLE
6000.0 -- Update yamato image to vm/prtools-windows-vs2019:v1.1.0

### DIFF
--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -7,7 +7,7 @@ name: Run IL2CPP Tests Against This Mono Branch
 
 agent:
   type: Unity::VM
-  image: vm/prtools-windows-vs2019:v1.1.0
+  image: vm/il2cpp-gamecore:v1.1.0
   flavor: b1.xlarge 
 
 variables:

--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -35,10 +35,12 @@ commands:
 
         git clone git@github.cds.internal.unity3d.com:unity/prtools.git
 
-    # Step 1.5 - Set PRTOOLS_BUILD_DIR environment variable
+    # Step 1.5 - Set required environment variables
     - command: |
         setx PRTOOLS_BUILD_DIR "C:\buildslave\unity"
+        setx UNITY_SOURCE_PRTOOLS_DIR "C:\buildslave\unity\build"
         $env:PRTOOLS_BUILD_DIR = "C:\buildslave\unity"
+        $env:UNITY_SOURCE_PRTOOLS_DIR = "C:\buildslave\unity\build"
 
     # Step 2 - clone unity/il2cpp into $env:PRTOOLS_BUILD_DIR\il2cpp (C:\buildslave\unity\il2cpp)
     - command: |

--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -35,26 +35,29 @@ commands:
 
         git clone git@github.cds.internal.unity3d.com:unity/prtools.git
 
-    # Step 2 - clone unity/il2cpp into C:\buildslave\unity\il2cpp
+    # Step 2 - clone unity/il2cpp into $env:YAMATO_WORK_DIR\il2cpp (C:\build\output\il2cpp)
     - command: |
         git config --global core.longpaths true
-        cd "C:\buildslave\unity"
+        cd $env:YAMATO_WORK_DIR
 
         git clone --recurse-submodules https://github.cds.internal.unity3d.com/unity/il2cpp.git il2cpp
 
-    # Step 3 - With working dir C:\buildslave\unity\build run PRTools from $env:YAMATO_WORK_DIR\prtools (C:\build\output\prtools) (--test-mono-il2cpp-deps)
-    # pointing PRTools to the IL2CPP checkout we did above (in C:\buildslave\unity\il2cpp)
+    # Step 3 - With working dir $env:YAMATO_WORK_DIR\build (C:\build\output\build) run PRTools from $env:YAMATO_WORK_DIR\prtools (C:\build\output\prtools) (--test-mono-il2cpp-deps)
+    # pointing PRTools to the IL2CPP checkout we did above (in $env:YAMATO_WORK_DIR\il2cpp (C:\build\output\il2cpp))
     # We don't push the IL2CPP test-mono-il2cpp-deps-***** branch this creates, since we're just going to run tests on it 'locally' (see the --bee-update-verification step below)
     - command: |
 
-        cd "C:\buildslave\unity\build"
-        cmd /v /c dotnet run --project $env:YAMATO_WORK_DIR\prtools\PRTools\PRTools.csproj --test-mono-il2cpp-deps=$env:YAMATO_SOURCE_DIR/stevedore/artifactid.txt --backport=$env:BACKPORT_BRANCH --custom-il2cpp-repo-path=C:\buildslave\unity/il2cpp --github-api-token=$env:IL2CPP_GITHUB_TOKEN --yamato-api-token=$env:YAMATO_TOKEN --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=$env:YAMATO_OWNER_EMAIL --no-slack --no-push
+        if (-not (Test-Path -Path "$env:YAMATO_WORK_DIR\build")) {
+            New-Item -Path "$env:YAMATO_WORK_DIR\build" -ItemType Directory -Force
+        }
+        cd "$env:YAMATO_WORK_DIR\build"
+        cmd /v /c dotnet run --project $env:YAMATO_WORK_DIR\prtools\PRTools\PRTools.csproj --test-mono-il2cpp-deps=$env:YAMATO_SOURCE_DIR/stevedore/artifactid.txt --backport=$env:BACKPORT_BRANCH --custom-il2cpp-repo-path=$env:YAMATO_WORK_DIR/il2cpp --github-api-token=$env:IL2CPP_GITHUB_TOKEN --yamato-api-token=$env:YAMATO_TOKEN --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=$env:YAMATO_OWNER_EMAIL --no-slack --no-push
         if ($LASTEXITCODE -ne 0) { echo "PRTools failed"; exit $LASTEXITCODE }
 
     # Step 4 - Copy stevedore.conf:
     - command: |
 
-        cd "C:\buildslave\unity\il2cpp"
+        cd "$env:YAMATO_WORK_DIR\il2cpp"
         echo "Current Git state:"
         git log -1
         git submodule update --init --recursive
@@ -63,7 +66,7 @@ commands:
     # Step 5 - Run bootstrap:
     - command: |
 
-        cd "C:\buildslave\unity\il2cpp"
+        cd "$env:YAMATO_WORK_DIR\il2cpp"
         .\bootstrap.cmd
 
       timeout: 0
@@ -72,7 +75,7 @@ commands:
     # Step 6 - Run bee-update-verification
     - command: |
 
-        cd "C:\buildslave\unity\il2cpp"
+        cd "$env:YAMATO_WORK_DIR\il2cpp"
 
         perl test.pl --build-machine --bee-update-verification; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -86,7 +89,7 @@ after:
             New-Item -Path "$env:YAMATO_SOURCE_DIR\build\ReportedArtifacts" -ItemType Directory
         }
 
-        Copy-Item -Path "C:\buildslave\unity\il2cpp\build\ReportedArtifacts\*" -Destination "$env:YAMATO_SOURCE_DIR\build\ReportedArtifacts" -Recurse -ErrorAction SilentlyContinue
+        Copy-Item -Path "$env:YAMATO_WORK_DIR\il2cpp\build\ReportedArtifacts\*" -Destination "$env:YAMATO_SOURCE_DIR\build\ReportedArtifacts" -Recurse -ErrorAction SilentlyContinue
 
         $licenseLogPath = Join-Path -Path $Env:HOMEDRIVE$Env:HOMEPATH -ChildPath "AppData\Local\Unity\Unity.Licensing.Client.log"
         if (Test-Path -Path $licenseLogPath) {
@@ -95,7 +98,7 @@ after:
 
         if (-not (Test-Path -Path "$env:YAMATO_SOURCE_DIR\build\CrashDumps")) { New-Item -Path "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -ItemType Directory }
         Copy-Item -Path "C:\CrashDump\*" -Destination "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -Recurse -ErrorAction SilentlyContinue
-        Copy-Item -Path "C:\buildslave\unity\il2cpp\CrashDumps\*" -Destination "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -Recurse -ErrorAction SilentlyContinue
+        Copy-Item -Path "$env:YAMATO_WORK_DIR\il2cpp\CrashDumps\*" -Destination "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -Recurse -ErrorAction SilentlyContinue
 
 artifacts:
     crash_dumps:

--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -35,33 +35,26 @@ commands:
 
         git clone git@github.cds.internal.unity3d.com:unity/prtools.git
 
-    # Step 1.5 - Set required environment variables
-    - command: |
-        setx PRTOOLS_BUILD_DIR "C:\buildslave\unity"
-        setx UNITY_SOURCE_PRTOOLS_DIR "C:\buildslave\unity\build"
-        $env:PRTOOLS_BUILD_DIR = "C:\buildslave\unity"
-        $env:UNITY_SOURCE_PRTOOLS_DIR = "C:\buildslave\unity\build"
-
-    # Step 2 - clone unity/il2cpp into $env:PRTOOLS_BUILD_DIR\il2cpp (C:\buildslave\unity\il2cpp)
+    # Step 2 - clone unity/il2cpp into C:\buildslave\unity\il2cpp
     - command: |
         git config --global core.longpaths true
-        cd $env:PRTOOLS_BUILD_DIR
+        cd "C:\buildslave\unity"
 
         git clone --recurse-submodules https://github.cds.internal.unity3d.com/unity/il2cpp.git il2cpp
 
-    # Step 3 - With working dir $env:UNITY_SOURCE_PRTOOLS_DIR (C:\buildslave\unity\build) run PRTools from $env:YAMATO_WORK_DIR\prtools (C:\build\output\prtools) (--test-mono-il2cpp-deps)
-    # pointing PRTools to the IL2CPP checkout we did above (in $env:PRTOOLS_BUILD_DIR\il2cpp (C:\buildslave\unity\il2cpp))
+    # Step 3 - With working dir C:\buildslave\unity\build run PRTools from $env:YAMATO_WORK_DIR\prtools (C:\build\output\prtools) (--test-mono-il2cpp-deps)
+    # pointing PRTools to the IL2CPP checkout we did above (in C:\buildslave\unity\il2cpp)
     # We don't push the IL2CPP test-mono-il2cpp-deps-***** branch this creates, since we're just going to run tests on it 'locally' (see the --bee-update-verification step below)
     - command: |
 
-        cd $env:UNITY_SOURCE_PRTOOLS_DIR
-        cmd /v /c dotnet run --project $env:YAMATO_WORK_DIR\prtools\PRTools\PRTools.csproj --test-mono-il2cpp-deps=$env:YAMATO_SOURCE_DIR/stevedore/artifactid.txt --backport=$env:BACKPORT_BRANCH --custom-il2cpp-repo-path=$env:PRTOOLS_BUILD_DIR/il2cpp --github-api-token=$env:IL2CPP_GITHUB_TOKEN --yamato-api-token=$env:YAMATO_TOKEN --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=$env:YAMATO_OWNER_EMAIL --no-slack --no-push
+        cd "C:\buildslave\unity\build"
+        cmd /v /c dotnet run --project $env:YAMATO_WORK_DIR\prtools\PRTools\PRTools.csproj --test-mono-il2cpp-deps=$env:YAMATO_SOURCE_DIR/stevedore/artifactid.txt --backport=$env:BACKPORT_BRANCH --custom-il2cpp-repo-path=C:\buildslave\unity/il2cpp --github-api-token=$env:IL2CPP_GITHUB_TOKEN --yamato-api-token=$env:YAMATO_TOKEN --yamato-long-lived-token --il2cpp-deps-manifest-file=il2cpp-deps.stevedore --yamato-owner-email=$env:YAMATO_OWNER_EMAIL --no-slack --no-push
         if ($LASTEXITCODE -ne 0) { echo "PRTools failed"; exit $LASTEXITCODE }
 
     # Step 4 - Copy stevedore.conf:
     - command: |
 
-        cd $env:PRTOOLS_BUILD_DIR/il2cpp
+        cd "C:\buildslave\unity\il2cpp"
         echo "Current Git state:"
         git log -1
         git submodule update --init --recursive
@@ -70,7 +63,7 @@ commands:
     # Step 5 - Run bootstrap:
     - command: |
 
-        cd $env:PRTOOLS_BUILD_DIR/il2cpp
+        cd "C:\buildslave\unity\il2cpp"
         .\bootstrap.cmd
 
       timeout: 0
@@ -79,7 +72,7 @@ commands:
     # Step 6 - Run bee-update-verification
     - command: |
 
-        cd $env:PRTOOLS_BUILD_DIR/il2cpp
+        cd "C:\buildslave\unity\il2cpp"
 
         perl test.pl --build-machine --bee-update-verification; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
@@ -93,7 +86,7 @@ after:
             New-Item -Path "$env:YAMATO_SOURCE_DIR\build\ReportedArtifacts" -ItemType Directory
         }
 
-        Copy-Item -Path "$env:PRTOOLS_BUILD_DIR\il2cpp\build\ReportedArtifacts\*" -Destination "$env:YAMATO_SOURCE_DIR\build\ReportedArtifacts" -Recurse -ErrorAction SilentlyContinue
+        Copy-Item -Path "C:\buildslave\unity\il2cpp\build\ReportedArtifacts\*" -Destination "$env:YAMATO_SOURCE_DIR\build\ReportedArtifacts" -Recurse -ErrorAction SilentlyContinue
 
         $licenseLogPath = Join-Path -Path $Env:HOMEDRIVE$Env:HOMEPATH -ChildPath "AppData\Local\Unity\Unity.Licensing.Client.log"
         if (Test-Path -Path $licenseLogPath) {
@@ -102,7 +95,7 @@ after:
 
         if (-not (Test-Path -Path "$env:YAMATO_SOURCE_DIR\build\CrashDumps")) { New-Item -Path "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -ItemType Directory }
         Copy-Item -Path "C:\CrashDump\*" -Destination "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -Recurse -ErrorAction SilentlyContinue
-        Copy-Item -Path "$env:PRTOOLS_BUILD_DIR\il2cpp\CrashDumps\*" -Destination "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -Recurse -ErrorAction SilentlyContinue
+        Copy-Item -Path "C:\buildslave\unity\il2cpp\CrashDumps\*" -Destination "$env:YAMATO_SOURCE_DIR\build\CrashDumps" -Recurse -ErrorAction SilentlyContinue
 
 artifacts:
     crash_dumps:

--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -7,7 +7,7 @@ name: Run IL2CPP Tests Against This Mono Branch
 
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-prtools-bokken:latest
+  image: vm/prtools-windows-vs2019:v1.1.0
   flavor: b1.xlarge 
 
 variables:

--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -35,6 +35,11 @@ commands:
 
         git clone git@github.cds.internal.unity3d.com:unity/prtools.git
 
+    # Step 1.5 - Set PRTOOLS_BUILD_DIR environment variable
+    - command: |
+        setx PRTOOLS_BUILD_DIR "C:\buildslave\unity"
+        $env:PRTOOLS_BUILD_DIR = "C:\buildslave\unity"
+
     # Step 2 - clone unity/il2cpp into $env:PRTOOLS_BUILD_DIR\il2cpp (C:\buildslave\unity\il2cpp)
     - command: |
         git config --global core.longpaths true

--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -1,7 +1,7 @@
 name: 'Update Il2cpp-deps'
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-prtools-bokken:latest
+  image: vm/prtools-windows-vs2019:v1.1.0
   flavor: b1.xlarge 
 variables:
   MONO_REV: "latest"


### PR DESCRIPTION
## Update Yamato Agent Images in 6000.0

### Summary

Updated Yamato configuration files to use the new standardized VM image.

---

### Changes

- Updated `image` field in `.yamato/Run IL2CPP Tests.yml`  
  from:  
  `platform-foundation/windows-vs2019-prtools-bokken:latest`  
  to:  
  `vm/prtools-windows-vs2019:v1.1.0`

- Updated `image` field in `.yamato/Update Il2cpp-deps.yml`  
  from:  
  `platform-foundation/windows-vs2019-prtools-bokken:latest`  
  to:  
  `vm/prtools-windows-vs2019:v1.1.0`

---

### Purpose

Migrating to the new VM image naming convention and specific version tagging for better consistency and reliability in CI/CD pipelines.


<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:


<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->