### PR TITLE
6000.4 -- Update yamato image to vm/prtools-windows-vs2019:v1.1.0

### DIFF
--- a/.yamato/Run IL2CPP Tests.yml
+++ b/.yamato/Run IL2CPP Tests.yml
@@ -7,7 +7,7 @@ name: Run IL2CPP Tests Against This Mono Branch
 
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-prtools-bokken:latest
+  image: vm/prtools-windows-vs2019:v1.1.0
   flavor: b1.xlarge 
 
 variables:

--- a/.yamato/Update Il2cpp-deps.yml
+++ b/.yamato/Update Il2cpp-deps.yml
@@ -1,7 +1,7 @@
 name: 'Update Il2cpp-deps'
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-prtools-bokken:latest
+  image: vm/prtools-windows-vs2019:v1.1.0
   flavor: b1.xlarge 
 variables:
   MONO_REV: "latest"


### PR DESCRIPTION

## Update Yamato Agent Images in 6000.4

### Summary

Updated Yamato configuration files to use the new standardized VM image.

---

### Changes

- Updated `image` field in `.yamato/Run IL2CPP Tests.yml`  
  from:  
  `platform-foundation/windows-vs2019-prtools-bokken:latest`  
  to:  
  `vm/prtools-windows-vs2019:v1.1.0`

- Updated `image` field in `.yamato/Update Il2cpp-deps.yml`  
  from:  
  `platform-foundation/windows-vs2019-prtools-bokken:latest`  
  to:  
  `vm/prtools-windows-vs2019:v1.1.0`

---

### Purpose

Migrating to the new VM image naming convention and specific version tagging for better consistency and reliability in CI/CD pipelines.


<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [x] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:


<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->