### PR TITLE
[6000.3] Fix Incorrect Xml Read Deserializing a Byte Array

### DIFF
--- a/mcs/class/System.XML/System.Xml.Serialization/XmlSerializationReader.cs
+++ b/mcs/class/System.XML/System.Xml.Serialization/XmlSerializationReader.cs
@@ -853,11 +853,11 @@ namespace System.Xml.Serialization
 		{
 			readCount++;
 			if (isNull) {
-				Reader.ReadString ();
+				Reader.ReadElementString ();
 				return null;
 			}
 			else
-				return ToByteArrayBase64 (Reader.ReadString ());
+				return ToByteArrayBase64 (Reader.ReadElementString ());
 		}
 
 		protected static byte[] ToByteArrayBase64 (string value)
@@ -869,11 +869,11 @@ namespace System.Xml.Serialization
 		{
 			readCount++;
 			if (isNull) {
-				Reader.ReadString ();
+				Reader.ReadElementString ();
 				return null;
 			}
 			else
-				return ToByteArrayHex (Reader.ReadString ());
+				return ToByteArrayHex (Reader.ReadElementString ());
 		}
 
 		protected static byte[] ToByteArrayHex (string value)


### PR DESCRIPTION
This is a backport of https://github.com/Unity-Technologies/mono/pull/2201
----

Change from using `ReadString()` to `ReadElementString()` when deserialization a byte array.  The expectation for `ToByteArrayHex()` and `ToByteArrayBase64()` is that the `XmlDocument` will be left at the start of next Xml element.  But with just a `ReadString()` the document is left at the end tag of the current element, not the start of the next element. Changing to `ReadElementString()` changes this behavior.

This only affects the mobile profile - the Mono desktop profile uses a [different implementation](https://github.com/Unity-Technologies/mono/blob/60122c5a5d7a4f3aa52dcb24860b5d80c5d2bf5e/mcs/class/referencesource/System.Xml/System/Xml/Serialization/XmlSerializationReader.cs#L474-L513) that doesn't have this issue.  I also validated the CoreCLR matches the Mono Desktop profile behavior.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Fixed UUM-105294 @scott-ferguson-unity 
IL2CPP: Fix XML Deserialization of a byte array leaving the reader at the wrong element

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->