### PR TITLE
Fix stack misalignment before calls in get_win32_restore_stack thunk.

### DIFF
--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -125,7 +125,7 @@ get_win32_restore_stack (void)
 	amd64_mov_reg_reg (code, AMD64_RBP, AMD64_RSP, 8);
 
 	/* push 32 bytes of stack space for Win64 calling convention */
-	amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 32);
+	amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 40);
 
 	/* restore guard page */
 	amd64_mov_reg_imm (code, AMD64_R11, _resetstkoflw);

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -124,7 +124,7 @@ get_win32_restore_stack (void)
 	amd64_push_reg (code, AMD64_RBP);
 	amd64_mov_reg_reg (code, AMD64_RBP, AMD64_RSP, 8);
 
-	/* push 32 bytes of stack space for Win64 calling convention */
+	/* Align stack for Win64 calling convention */
 	amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, 40);
 
 	/* restore guard page */


### PR DESCRIPTION
## Why

The stack overflow handler fails to execute properly in some cases, it can happen both in game release builds and inside some user editor code / c# scripts.


## How 
The thunk pushed RBP (−8) and then reserved only 32 bytes of shadow space, leaving RSP misaligned by 8 bytes. This violated the Win64 ABI requirement that RSP be 16-byte aligned at every call instruction. As a result, the calls to _resetstkoflw, mono_tls_get_jit_tls, and mono_restore_context were executed with an unaligned stack.

Increase the reservation to 40 bytes (32 shadow + 8 alignment fixup) to restore correct 16-byte alignment after the initial push and ensure all call sites are ABI-compliant.

----------

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - Yeah? Probably?
- Do these changes need to be back ported?
  - [x] Yes.
  I don't know how far back, probably forever since that line of code is probably decade old at this point, I did test this personally on 2019.4.26 and 2021.3.33 but that's it.
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) repository?
  - [x] Yes.
  In fact, this issue still happens on current mono (see https://github.com/mono/mono/blob/main/mono/mini/exceptions-amd64.c#L94)
  I figured i'd do the pr here because i don't use mono outside of an unity environement and it would be nice to get this fixed.

