### PR TITLE
Add support for TLS 1.3

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/TlsProtocolCode.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/TlsProtocolCode.cs
@@ -32,7 +32,8 @@ namespace Mono.Security.Interface
 	{
 		Tls10 = 0x301,
 		Tls11 = 0x302,
-		Tls12 = 0x303
+		Tls12 = 0x303,
+		Tls13 = 0x304
 	}
 }
 

--- a/mcs/class/Mono.Security/Mono.Security.Interface/TlsProtocols.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/TlsProtocols.cs
@@ -42,8 +42,11 @@ namespace Mono.Security.Interface
 		Tls12Client         = 0x00000800,
 		Tls12Server         = 0x00000400,
 		Tls12               = (Tls12Client | Tls12Server),
-		ClientMask          = (Tls10Client | Tls11Client | Tls12Client),
-		ServerMask          = (Tls10Server | Tls11Server | Tls12Server)
+		Tls13Client         = 0x00002000,
+		Tls13Server         = 0x00001000,
+		Tls13               = (Tls13Client | Tls13Server),
+		ClientMask          = (Tls10Client | Tls11Client | Tls12Client | Tls13Client),
+		ServerMask          = (Tls10Server | Tls11Server | Tls12Server | Tls13Server)
 	};
 }
 

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -341,6 +341,8 @@ namespace Mono.Btls
 				return TlsProtocols.Tls11;
 			case TlsProtocolCode.Tls12:
 				return TlsProtocols.Tls12;
+			case TlsProtocolCode.Tls13:
+				return TlsProtocols.Tls13;
 			default:
 				throw new NotSupportedException ();
 			}

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -121,10 +121,14 @@ namespace Mono.Net.Security
 				min = TlsProtocolCode.Tls11;
 			else if ((EnabledProtocols & SslProtocols.Tls12) != 0)
 				min = TlsProtocolCode.Tls12;
+			else if ((EnabledProtocols & SslProtocols.Tls13) != 0)
+				min = TlsProtocolCode.Tls13;
 			else
 				min = null;
 
-			if ((EnabledProtocols & SslProtocols.Tls12) != 0)
+			if ((EnabledProtocols & SslProtocols.Tls13) != 0)
+				max = TlsProtocolCode.Tls13;
+			else if ((EnabledProtocols & SslProtocols.Tls12) != 0)
 				max = TlsProtocolCode.Tls12;
 			else if ((EnabledProtocols & SslProtocols.Tls11) != 0)
 				max = TlsProtocolCode.Tls11;

--- a/mcs/class/System/Mono.UnityTls/UnityTls.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTls.cs
@@ -158,6 +158,7 @@ namespace Mono.Unity
             UNITYTLS_PROTOCOL_TLS_1_0,
             UNITYTLS_PROTOCOL_TLS_1_1,
             UNITYTLS_PROTOCOL_TLS_1_2,
+            UNITYTLS_PROTOCOL_TLS_1_3,
 
             UNITYTLS_PROTOCOL_INVALID,
         }

--- a/mcs/class/System/Mono.UnityTls/UnityTlsConversions.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsConversions.cs
@@ -15,26 +15,34 @@ namespace Mono.Unity
 {
 	internal static class UnityTlsConversions
 	{
+		// Note that for these conversion routines, we pretty much always end up just returning TLS
+		// 1.2 as the minimum and 1.3 as the maximum, as that's the range supported by UnityTLS. We
+		// do so even if the specified protocols are outside this range. This is not ideal since it
+		// might go against user wishes (if say they specify TLS 1.1 only), but it's better than
+		// failing since there might be old configurations out there that just specify old protocols
+		// out of habit and we don't want to break them. Plus, worst case we just connect with a
+		// protocol more secure than the user asked for which would be weird to complain about.
+
 		public static UnityTls.unitytls_protocol GetMinProtocol (SslProtocols protocols)
 		{
-			if (protocols.HasFlag (SslProtocols.Tls))
-				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_0;
-			if (protocols.HasFlag (SslProtocols.Tls11))
-				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_1;
 			if (protocols.HasFlag (SslProtocols.Tls12))
 				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;
-			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_0;	// Use mbed tls min default
+			if (protocols.HasFlag (SslProtocols.Tls13))
+				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_3;
+
+			// Default to TLS 1.2 as that's the minimum we support in UnityTLS.
+			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;
 		}
 
 		public static UnityTls.unitytls_protocol GetMaxProtocol (SslProtocols protocols)
 		{
+			if (protocols.HasFlag (SslProtocols.Tls13))
+				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_3;
 			if (protocols.HasFlag (SslProtocols.Tls12))
 				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;
-			if (protocols.HasFlag (SslProtocols.Tls11))
-				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_1;
-			if (protocols.HasFlag (SslProtocols.Tls))
-				return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_0;
-			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2;	// Use mbed tls max default
+
+			// Default to TLS 1.3 as that's the maximum we support in UnityTLS.
+			return UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_3;
 		}
 
 		public static TlsProtocols ConvertProtocolVersion(UnityTls.unitytls_protocol protocol)
@@ -47,6 +55,8 @@ namespace Mono.Unity
 				return TlsProtocols.Tls11;
 			case UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_2:
 				return TlsProtocols.Tls12;
+			case UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_TLS_1_3:
+				return TlsProtocols.Tls13;
 			case UnityTls.unitytls_protocol.UNITYTLS_PROTOCOL_INVALID:
 				return TlsProtocols.Zero;
 			}

--- a/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
+++ b/mcs/class/System/Mono.UnityTls/UnityTlsProvider.cs
@@ -33,7 +33,7 @@ namespace Mono.Unity
 		public override bool SupportsMonoExtensions => true;
 		public override bool SupportsConnectionInfo => true;
 		internal override bool SupportsCleanShutdown => true;
-		public override SslProtocols SupportedProtocols => SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
+		public override SslProtocols SupportedProtocols => SslProtocols.Tls12 | SslProtocols.Tls13;
 
 		internal override MNS.MobileAuthenticatedStream CreateSslStream (
 			SslStream sslStream, Stream innerStream, bool leaveInnerStreamOpen,

--- a/mcs/class/System/System.Net/ServicePointManager.platformnotsupported.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.platformnotsupported.cs
@@ -85,7 +85,7 @@ namespace System.Net
 		public static SecurityProtocolType SecurityProtocol {
 			get;
 			set;
-		} = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+		} = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
 
 		public static RemoteCertificateValidationCallback ServerCertificateValidationCallback {
 			get;

--- a/mcs/class/System/System.Security.Authentication/SslProtocols.cs
+++ b/mcs/class/System/System.Security.Authentication/SslProtocols.cs
@@ -34,15 +34,17 @@ namespace System.Security.Authentication {
 	[Flags]
 	public enum SslProtocols {
 		None,
+		[MonoTODO ("unsupported")]
 		Ssl2 = 12,
+		[MonoTODO ("unsupported")]
 		Ssl3 = 48,
+		[MonoTODO ("unsupported")]
 		Tls = 192,
 		[MonoTODO ("unsupported")]
 		Tls11 = 768,
-		[MonoTODO ("unsupported")]
 		Tls12 = 3072,
 		Tls13 = 12288,
-		Default = Ssl3 | Tls
+		Default = Tls12 | Tls13
 	}
 }
 

--- a/mcs/class/referencesource/System/net/System/Net/SecureProtocols/_SslState.cs
+++ b/mcs/class/referencesource/System/net/System/Net/SecureProtocols/_SslState.cs
@@ -387,6 +387,11 @@ namespace System.Net.Security {
                 {
                     proto |= SslProtocols.Tls12;
                 }
+                if ((proto & SslProtocols.Tls13) != 0)
+                {
+                    proto |= SslProtocols.Tls13;
+                }
+
                 return proto;
             }
         }

--- a/mcs/class/referencesource/System/net/System/Net/ServicePointManager.cs
+++ b/mcs/class/referencesource/System/net/System/Net/ServicePointManager.cs
@@ -261,13 +261,14 @@ namespace System.Net {
         {
             // Do not allow Ssl2 (and others) as explicit SSL version request.
             SecurityProtocolType allowed = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls
-                | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+                | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
 
             Debug.Assert((int)SecurityProtocolType.SystemDefault == (int)SslProtocols.None);
             Debug.Assert((int)SecurityProtocolType.Ssl3 == (int)SslProtocols.Ssl3);
             Debug.Assert((int)SecurityProtocolType.Tls == (int)SslProtocols.Tls);
             Debug.Assert((int)SecurityProtocolType.Tls11 == (int)SslProtocols.Tls11);
             Debug.Assert((int)SecurityProtocolType.Tls12 == (int)SslProtocols.Tls12);
+            Debug.Assert((int)SecurityProtocolType.Tls13 == (int)SslProtocols.Tls13);
 
             if ((value & ~allowed) != 0)
             {


### PR DESCRIPTION
This PR adds support for TLS 1.3 (which [is coming to UnityTLS](https://github.cds.internal.unity3d.com/unity/UnityTLS/pull/118)). `HttpClient` and other .NET APIs that use TLS will now offer support for both TLS 1.2 and 1.3 by default unless manually overridden by the user.

The core of the changes are in the UnityTLS wrapper where we're changing the default minimum/maximum supported protocol versions. It might look like we're dropping support for TLS 1.0 and 1.1, but that support has been gone from UnityTLS for a while now (it just accepts old versions in protocol ranges for compatibility reasons). I'm not entirely sure the rest of the changes are strictly required here to get TLS 1.3 working, but I thought I might as well add the required definitions in case these enums can be used in the public API somewhere.

- Should this pull request have release notes?
  - [X] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No (For now at least.)
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Improved MTT-14427 @simon-lemay-unity:
Mono: Add support for TLS 1.3 in the networking APIs.

**Unity repository changes**

This requires [changes](https://github.cds.internal.unity3d.com/unity/UnityTLS/pull/118) to UnityTLS. I'm planning to land both Mono and UnityTLS in the same trunk PR.