### PR TITLE
Use 2nd lowest bit for weak handle tagging.

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs
@@ -90,7 +90,7 @@ namespace System.Runtime.InteropServices
 		internal static bool CanDereferenceHandle(IntPtr handle)
 		{
 			// weak handles have lowest bit set
-			return ((nint)handle & 1) == 0;
+			return ((nint)handle & 2) == 0;
 		}
 
 		public object Target

--- a/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/GCHandle.cs
@@ -74,23 +74,16 @@ namespace System.Runtime.InteropServices
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal static unsafe object GetRef(IntPtr handle)
+		internal static unsafe ref object GetRef(IntPtr handle)
 		{
-			return Unsafe.As<IntPtr, object>(ref *(IntPtr*)handle);
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal static unsafe void SetRef(IntPtr handle, object value)
-		{
-			// this returns a ref object that we can store safely into
-			Unsafe.As<IntPtr, object>(ref *(IntPtr*)handle) = value;
+			return ref Unsafe.As<IntPtr, object>(ref *(IntPtr*)((nuint)handle & ~(nuint)3));
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool CanDereferenceHandle(IntPtr handle)
 		{
-			// weak handles have lowest bit set
-			return ((nint)handle & 2) == 0;
+			// weak handles have lowest two bits set
+			return ((nuint)handle & 3) == 0;
 		}
 
 		public object Target
@@ -115,7 +108,7 @@ namespace System.Runtime.InteropServices
 			{
 
 				if (CanDereferenceHandle(handle))
-					SetRef(handle, value);
+					GetRef(handle) = value;
 				else
 					handle = GetTargetHandle (value, handle, (GCHandleType)(-1));
 			} 

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1708,15 +1708,27 @@ handle_data_find_slot(HandleData* handles)
 }
 
 static MonoGCHandle
-handle_tag_weak (MonoGCHandle handle)
+handle_tag_normal (MonoGCHandle handle)
 {
 	return (MonoGCHandle)((uintptr_t)handle | (uintptr_t)2);
 }
 
 static MonoGCHandle
-handle_untag_weak (MonoGCHandle handle)
+handle_tag_pinned (MonoGCHandle handle)
 {
-	return (MonoGCHandle)((uintptr_t)handle & ~(uintptr_t)2);
+	return (MonoGCHandle)((uintptr_t)handle | (uintptr_t)1);
+}
+
+static MonoGCHandle
+handle_tag_weak (MonoGCHandle handle)
+{
+	return (MonoGCHandle)((uintptr_t)handle | (uintptr_t)3);
+}
+
+static MonoGCHandle
+handle_untag (MonoGCHandle handle)
+{
+	return (MonoGCHandle)((uintptr_t)handle & ~(uintptr_t)3);
 }
 
 static HandleData*
@@ -1731,7 +1743,7 @@ handle_lookup (MonoGCHandle handle, guint* slot)
 {
 	HandleData* handles = get_handle_data_from_handle (handle);
 	if (slot)
-		*slot = (int)(ptrdiff_t)((gpointer*)handle_untag_weak (handle) - &handles->entries[0]);
+		*slot = (int)(ptrdiff_t)((gpointer*)handle_untag (handle) - &handles->entries[0]);
 	return handles;
 }
 
@@ -1776,6 +1788,11 @@ alloc_handle (int type, MonoObject *obj, gboolean track)
 		 * when the bit is not set.
 		*/
 		res = handle_tag_weak (res);
+	} else {
+		if (handles->type == HANDLE_PINNED)
+			res = handle_tag_pinned (res);
+		else
+			res = handle_tag_normal (res);
 	}
 	/*
 	 * TODO: We now require the full pointer sized representation of GCHandle on 64-bit,

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1710,13 +1710,13 @@ handle_data_find_slot(HandleData* handles)
 static MonoGCHandle
 handle_tag_weak (MonoGCHandle handle)
 {
-	return (MonoGCHandle)((uintptr_t)handle | (uintptr_t)1);
+	return (MonoGCHandle)((uintptr_t)handle | (uintptr_t)2);
 }
 
 static MonoGCHandle
 handle_untag_weak (MonoGCHandle handle)
 {
-	return (MonoGCHandle)((uintptr_t)handle & ~(uintptr_t)1);
+	return (MonoGCHandle)((uintptr_t)handle & ~(uintptr_t)2);
 }
 
 static HandleData*


### PR DESCRIPTION
This avoids conflicting with .NET which uses the lowest bit for tagging pinned handles.



<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

Reviewers: please consider these questions as well! :heart:

