### PR TITLE
platform/windows/dynamic-crt

### DIFF
--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -20,7 +20,7 @@ my $clean = 0;
 my $targetArch = "";
 my $debug = 0;
 my $gc = "bdwgc";
-my @vsVersions = (2019, 2022, 2017);
+my @vsVersions = (2019, 2022, 2017, 18); # Starting with VS 2026 ("VS 18"), installation folder follows version number rathan than year.
 my @vsEditions = ("Professional", "Enterprise", "Community");
 my @vsBaseFolder = ("ProgramFiles(x86)", "ProgramFiles");
 

--- a/external/buildscripts/build_runtime_vs.pl
+++ b/external/buildscripts/build_runtime_vs.pl
@@ -64,7 +64,7 @@ sub CompileVCProj
 	my $arch = $targetArch;
 
 	my $target = $clean ? "/t:Clean,Build" :"/t:Build";
-	my $properties = "/p:Configuration=$config;Platform=$arch;MONO_TARGET_GC=$gc;MONO_USE_STATIC_C_RUNTIME=true";
+	my $properties = "/p:Configuration=$config;Platform=$arch;MONO_TARGET_GC=$gc;MONO_USE_STATIC_C_RUNTIME=false";
 
 	print (">>> $msbuild $properties $target $sln\n\n");
 	system($msbuild, $properties, $target, $sln) eq 0


### PR DESCRIPTION
This PR switches Mono native binaries for Windows to link CRT dynamically. In Unity 6.7, we are switching all binaries that go into the Windows player build to link CRT dynamically. While we will copy CRT redist files into build output directory, this isn't the case for the editor, however, it is okay to do there too because Unity editor already depends on system wide VC++ redist installation.

- Should this pull request have release notes?
  - [x] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No

**Release notes**

Internal PLAT-20591 @zilys:
Mono: Switch Mono native binaries for Windows to link CRT dynamically.