### PR TITLE
Change builds.tar.zst.list to v2 format

### DIFF
--- a/.yamato/scripts/collate_builds.sh
+++ b/.yamato/scripts/collate_builds.sh
@@ -17,12 +17,6 @@ case $osarch in
 			unzip 3.8.1_28985563_1365df71ca0a504c6949b1cf2e257caa6b0cacbac4b2b15f49ce75da6699bc87.zip bsdtar
 		fi
 
-		if [ ! -e unity-unpacker ]
-		then
-			wget -q https://public-stevedore.unity3d.com/r/public/unity-unpacker-linux-x64/3.8.1_28985563_715449296d1e57e2625bb882eee684e27f46553a6782ddf4a3ec9a42e4210e58.zip
-			unzip 3.8.1_28985563_715449296d1e57e2625bb882eee684e27f46553a6782ddf4a3ec9a42e4210e58.zip unity-unpacker
-		fi
-
 		PATH=`pwd`:$PATH
 		popd
 		;;

--- a/external/buildscripts/collect_allbuilds.pl
+++ b/external/buildscripts/collect_allbuilds.pl
@@ -66,10 +66,10 @@ my $cmd = "bsdtar --options zstd:compression-level=22 -cavf ../builds.tar.zst *"
 system($cmd) eq 0 or die("Command failed: \"$cmd\"");
 system("mv -f ../builds.tar.zst .") eq 0 or die("Failed to move builds.tar.zst into place");
 
-my $md5 = `md5sum builds.tar.zst | cut -d' ' -f1`;
+chomp(my $md5 = `md5sum builds.tar.zst | cut -d' ' -f1`);
 open(FH, '>', "builds.tar.zst.list") or die $!;
-print FH "md5:$md5\n";
+print FH "v2:md5:$md5\n";
 close(FH);
 
-$cmd = "unity-unpacker l -slt builds.tar.zst >> builds.tar.zst.list";
+$cmd = "bsdtar -tf builds.tar.zst | grep -v '/\$' | LC_ALL=C sort >> builds.tar.zst.list";
 system($cmd) eq 0 or die("Command failed: \"$cmd\"");


### PR DESCRIPTION
Emit a `v2:md5:<hash>` header and a plain, LC_ALL=C-sorted list of file paths instead of the verbose `unity-unpacker l -slt` output. The archive is now listed with `bsdtar -tf` (dropping the unity-unpacker dependency), directory entries are filtered out, and the md5 is chomped so the header is a single line.





- Should this pull request have release notes?
  - [ ] Yes
  - [X] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [X] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [X] No
