### PR TITLE
Remove assertions from ToFileDescriptor

### DIFF
--- a/external/corefx-bugfix/src/Native/Unix/Common/pal_utilities.h
+++ b/external/corefx-bugfix/src/Native/Unix/Common/pal_utilities.h
@@ -156,9 +156,6 @@ inline static int ToFileDescriptorUnchecked(intptr_t fd)
 */
 inline static int ToFileDescriptor(intptr_t fd)
 {
-    assert(0 <= fd);
-    assert(fd < sysconf(_SC_OPEN_MAX) && "Requested file descriptor exceeds maximum number of files allowed to be open at a time.");
-
     return ToFileDescriptorUnchecked(fd);
 }
 


### PR DESCRIPTION
The `fd < sysconf(_SC_OPEN_MAX)` assertion is wrong (`_SC_OPEN_MAX` can be changed at runtime, stranding valid fds above the limit) and the `0 <= fd` is correct but not especially useful - we would pass the negative fd through to the kernel and get back a meaningful errno anyway, which would generate a managed exception that can be handled instead of asserting and unconditionally tearing down the process.

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [x] Yes
  - [ ] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [x] Yes
  - [ ] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Changed UUM-145761 @kg-unity3d:
Mono: Remove assertions from ToFileDescriptor

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->