### PR TITLE
[6000.0] Remove assertions from ToFileDescriptor

### DIFF
--- a/external/corefx-bugfix/src/Native/Unix/Common/pal_utilities.h
+++ b/external/corefx-bugfix/src/Native/Unix/Common/pal_utilities.h
@@ -156,9 +156,6 @@ inline static int ToFileDescriptorUnchecked(intptr_t fd)
 */
 inline static int ToFileDescriptor(intptr_t fd)
 {
-    assert(0 <= fd);
-    assert(fd < sysconf(_SC_OPEN_MAX) && "Requested file descriptor exceeds maximum number of files allowed to be open at a time.");
-
     return ToFileDescriptorUnchecked(fd);
 }
 


### PR DESCRIPTION
Backport of #2226 

<!--
Thank you for your Pull Request!

Here are a few things to think about (see below for more details). Please check each option after the PR is created.
-->

- Should this pull request have release notes?
  - [x] Yes
  - [ ] No
- Do these changes need to be back ported?
  - [ ] Yes
  - [x] No
- Do these changes need to be upstreamed to [mono/mono](https://github.com/mono/mono) or [dotnet/runtime](https://github.com/dotnet/runtime) repositories?
  - [ ] Yes
  - [x] No

Reviewers: please consider these questions as well! :heart:

**Release notes**

Changed UUM-145761 @kg-unity3d:
Mono: Remove assertions from ToFileDescriptor

<!-- Most pull requests should have release notes.

Use Internal for release notes that should not be public.

Other options: Changed, Improved, Feature.
-->

<!-- Use this section is the pull request should be back ported.
**Backports**

List the versions of Unity where this change should be back ported here.
-->

<!-- Use this section if the pull request requires other changes in the Unity repository.
**Unity repository changes**

List any Unity repository PRs.
-->